### PR TITLE
Fail fast if user doesn't select board

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -1,17 +1,23 @@
 #include <heltec-eink-modules.h>
 
-// ── Board selection: uncomment the line that matches your hardware ────────────
-//#define BOARD_V1_1
-// #define BOARD_V1_2
-// ─────────────────────────────────────────────────────────────────────────────
-
 #include "pala_app.h"
 #include "pala_api.h"
 #include <stdarg.h>
+
+// ── Board selection: uncomment the line that matches your hardware ────────────
+// #define BOARD_V1_1
+// #define BOARD_V1_2
+// ─────────────────────────────────────────────────────────────────────────────
 #ifdef BOARD_V1_1
   using DisplayType = EInkDisplay_WirelessPaperV1_1;
-#else
-  using DisplayType = EInkDisplay_WirelessPaperV1_2;
+  #define BOARD_CHOSEN 
+#endif
+#if defined BOARD_V1_2
+  using DisplayType = EInkDisplay_WirelessPaperV1_1;
+  #define BOARD_CHOSEN 
+#endif
+#ifndef BOARD_CHOSEN
+  #error "Uncomment a board version"
 #endif
 
 DisplayType display;


### PR DESCRIPTION
If a user 1.1 forgets to select their board, the firmware will compile
and upload, but the button will not work. (Tested with V1.1 code on V1.2
board).

To make this more friendly, we should output a helpful error at compile
time until the user takes an action: uncommenting a board version.

Tested:
- [x] Both commented results in nice error: `Compilation error: #error "Uncomment a board version"`
- [x] Either board uncommented compiles