### PR TITLE
Hide Apps menu option when no apps are installed

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -1333,7 +1333,7 @@ static void buildLibraryEntries() {
     g_library.entryDepths[g_library.entryCount] = 0;
     g_library.entryCount++;
   }
-  if (g_library.entryCount < MAX_LIBRARY_ENTRIES) {
+  if (hasAnyApp() && g_library.entryCount < MAX_LIBRARY_ENTRIES) {
     g_library.entryTypes[g_library.entryCount] = LIB_ENTRY_APPS;
     g_library.entryRefs[g_library.entryCount] = -1;
     g_library.entryDepths[g_library.entryCount] = 0;
@@ -2470,6 +2470,23 @@ static void drawAbout() {
   }
 
   display.update();
+}
+
+static bool hasAnyApp() {
+  if (!FS.exists("/apps")) return false;
+  File dir = FS.open("/apps");
+  if (!dir || !dir.isDirectory()) { if (dir) dir.close(); return false; }
+
+  bool found = false;
+  File f = dir.openNextFile();
+  while (f) {
+    String n = String(f.name());
+    f.close();
+    if (n.endsWith(".bin")) { found = true; break; }
+    f = dir.openNextFile();
+  }
+  dir.close();
+  return found;
 }
 
 static void scanApps() {


### PR DESCRIPTION
## Summary

The Apps menu entry is currently rendered unconditionally in the library, even on a fresh device with no apps installed. Selecting it lands on an empty screen with no affordance to go back without context. This PR hides the Apps entry from `buildLibraryEntries()` when `/apps/` contains no `.bin` files.

## Behavior

- No `/apps/` directory, or `/apps/` exists but contains no `.bin`: Apps entry hidden.
- One or more `.bin` files in `/apps/`: Apps entry shown (unchanged from current behavior).
- Detection runs once per library rebuild, not on every render, so e-ink refresh cost is unchanged.

## Implementation

- New static `hasAnyApp()` helper: opens `/apps/`, returns true on the first file with a `.bin` extension. Closes the directory in all paths.
- Caller-site guard: `buildLibraryEntries()` only emits the Apps entry when `hasAnyApp()` is true.

`.ino` files get auto-generated forward declarations from the Arduino preprocessor, so the helper's definition below its call site is fine — both board variants compile clean.