### PR TITLE
Firmware hook to allow Sleep Timer and Streak Counter to work automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs
+
+# Built app artifacts (per-example .bin/.elf produced by examples/build.ps1).
+examples/**/*.bin
+examples/**/*.elf

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -4442,6 +4442,139 @@ static void drawSleepScreen() {
   display.update();
 }
 
+// ============================================================================
+//  App integration: reading-streak auto-log + sleep-timer notification
+//  Both features touch /apps/<key>.dat files that the corresponding example
+//  apps (examples/reading_streak, examples/sleep_timer) own. The structs
+//  below MUST match the SavedState/SleepTimerFile layouts in those apps —
+//  field order and types are the wire format.
+// ============================================================================
+
+struct ReadingStreakFile {
+  uint32_t version;        // == STREAK_SCHEMA
+  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
+  uint32_t lastLoggedDay;  // day index, 0xFFFFFFFFu = never
+  uint32_t currentStreak;
+  uint32_t longestStreak;
+  uint32_t totalSessions;
+  uint32_t bitmapHead;     // day index of bit 0
+  uint32_t bitmap;         // bit i = "logged on day (head - i)"
+};
+
+struct SleepTimerFile {
+  uint32_t version;        // == SLEEP_TIMER_SCHEMA
+  uint32_t status;         // SLEEP_TIMER_IDLE / RUNNING / NEEDS_NOTIFY
+  uint32_t endRtcSec;
+  uint32_t durationMin;
+  uint32_t startedRtcSec;
+};
+
+static const uint32_t STREAK_SCHEMA          = 1;
+static const uint32_t STREAK_DAY_SECS        = 86400u;
+static const int      STREAK_PAGES_THRESHOLD = 5;     // pages today before we log
+
+static const uint32_t SLEEP_TIMER_SCHEMA        = 1;
+static const uint32_t SLEEP_TIMER_IDLE          = 0;
+static const uint32_t SLEEP_TIMER_RUNNING       = 1;
+static const uint32_t SLEEP_TIMER_NEEDS_NOTIFY  = 2;
+
+static struct {
+  int      pagesToday        = 0;
+  uint32_t cachedFirstRtcSec = 0;
+  uint32_t cachedLastDay     = 0xFFFFFFFFu;
+  bool     bootstrapped      = false;
+} g_streakAuto;
+
+static bool readAppDat(const char* key, void* buf, size_t expected) {
+  String path = String("/apps/") + key + ".dat";
+  File f = LittleFS.open(path, "r");
+  if (!f) return false;
+  size_t n = f.read((uint8_t*)buf, expected);
+  f.close();
+  return n == expected;
+}
+
+static void writeAppDat(const char* key, const void* buf, size_t len) {
+  String path = String("/apps/") + key + ".dat";
+  File f = LittleFS.open(path, "w");
+  if (!f) return;
+  f.write((const uint8_t*)buf, len);
+  f.close();
+}
+
+// Increment the streak after enough page turns on a new day. Mirrors the
+// log logic in examples/reading_streak/app.c so manual taps and auto-log
+// produce the same numbers.
+static void streakAutoLogOnPageTurn() {
+  if (!g_streakAuto.bootstrapped) {
+    ReadingStreakFile s;
+    if (!readAppDat("streak", &s, sizeof(s)) || s.version != STREAK_SCHEMA) {
+      s.version       = STREAK_SCHEMA;
+      s.firstRtcSec   = api_rtcSeconds();
+      s.lastLoggedDay = 0xFFFFFFFFu;
+      s.currentStreak = 0;
+      s.longestStreak = 0;
+      s.totalSessions = 0;
+      s.bitmapHead    = 0;
+      s.bitmap        = 0;
+      writeAppDat("streak", &s, sizeof(s));
+    }
+    g_streakAuto.cachedFirstRtcSec = s.firstRtcSec;
+    g_streakAuto.cachedLastDay     = s.lastLoggedDay;
+    g_streakAuto.bootstrapped      = true;
+  }
+
+  uint32_t now = api_rtcSeconds();
+  if (now < g_streakAuto.cachedFirstRtcSec) return;           // RTC ran backwards
+  uint32_t today = (now - g_streakAuto.cachedFirstRtcSec) / STREAK_DAY_SECS;
+
+  if (g_streakAuto.cachedLastDay == today) return;            // already logged today
+  if (++g_streakAuto.pagesToday < STREAK_PAGES_THRESHOLD) return;
+
+  ReadingStreakFile s;
+  if (!readAppDat("streak", &s, sizeof(s)) || s.version != STREAK_SCHEMA) return;
+
+  bool cont = (s.lastLoggedDay != 0xFFFFFFFFu) && (today == s.lastLoggedDay + 1);
+  if (today > s.bitmapHead) {
+    uint32_t d = today - s.bitmapHead;
+    s.bitmap     = (d >= 32) ? 0 : (s.bitmap << d);
+    s.bitmapHead = today;
+  }
+  s.bitmap        |= 1u;
+  s.currentStreak  = cont ? (s.currentStreak + 1) : 1;
+  if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
+  s.lastLoggedDay  = today;
+  s.totalSessions += 1;
+  writeAppDat("streak", &s, sizeof(s));
+
+  g_streakAuto.cachedLastDay = today;
+  g_streakAuto.pagesToday    = 0;
+
+  showToast(String("Reading streak: day ") + String(s.currentStreak));
+}
+
+// Flip RUNNING -> NEEDS_NOTIFY exactly once when the timer first expires,
+// and toast at that moment. Subsequent page turns are quiet — the
+// sleep_timer app's own UI is the persistent indicator (and it clears
+// the file back to IDLE on acknowledge).
+static void sleepTimerCheckExpired() {
+  SleepTimerFile s;
+  if (!readAppDat("sleep_timer", &s, sizeof(s)) || s.version != SLEEP_TIMER_SCHEMA) return;
+  if (s.status != SLEEP_TIMER_RUNNING) return;
+  if (api_rtcSeconds() < s.endRtcSec)  return;
+
+  s.status = SLEEP_TIMER_NEEDS_NOTIFY;
+  writeAppDat("sleep_timer", &s, sizeof(s));
+  showToast(String("Sleep timer up (") + String(s.durationMin) + " min)");
+}
+
+// Called from the four reader next/prev-page sites (not from bookmark
+// adds — those re-render but aren't a real page turn).
+static inline void onReaderPageTurn() {
+  streakAutoLogOnPageTurn();
+  sleepTimerCheckExpired();
+}
+
 static void goToSleep() {
   if (!ENABLE_DEEP_SLEEP) return;
 
@@ -4475,6 +4608,22 @@ static void goToSleep() {
   Platform::prepareToSleep();
   esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
   esp_sleep_enable_ext0_wakeup((gpio_num_t)BTN, 0);
+
+  // If a sleep timer is running, also wake at its end-time so the user
+  // gets the toast even if they put the device down.
+  {
+    SleepTimerFile st;
+    if (readAppDat("sleep_timer", &st, sizeof(st)) &&
+        st.version == SLEEP_TIMER_SCHEMA &&
+        st.status  == SLEEP_TIMER_RUNNING) {
+      uint32_t now = api_rtcSeconds();
+      if (st.endRtcSec > now) {
+        uint64_t deltaUs = (uint64_t)(st.endRtcSec - now) * 1000000ULL;
+        esp_sleep_enable_timer_wakeup(deltaUs);
+      }
+    }
+  }
+
   delay(50);
   esp_deep_sleep_start();
 }
@@ -4522,6 +4671,10 @@ void setup() {
   loadBooks();
   registerWebRoutes();
   markUserActivity();
+
+  // If a sleep timer expired (possibly woke us via RTC alarm), queue the
+  // toast so it appears on whatever screen we render next.
+  sleepTimerCheckExpired();
 
   bool restored = false;
   if (prefs.getInt("wake_mode", 0) == 1) {
@@ -4701,6 +4854,7 @@ static void handleModeBookmarkPreview() {
     if (g_reader.pageIndex > 0) {
       g_reader.pageIndex--;
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4713,6 +4867,7 @@ static void handleModeBookmarkPreview() {
     if (g_reader.eofReached && g_reader.pageIndex >= g_reader.knownPages) g_reader.pageIndex = g_reader.knownPages - 1;
     if (g_reader.pageIndex != oldPage) {
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4836,6 +4991,7 @@ static void handleModeReader() {
       g_reader.pageIndex--;
       saveProgressThrottled(false);
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4850,6 +5006,7 @@ static void handleModeReader() {
     if (g_reader.pageIndex != oldPage) {
       saveProgressThrottled(false);
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;

--- a/examples/build.ps1
+++ b/examples/build.ps1
@@ -1,0 +1,122 @@
+# Pala One app builder for Windows.
+#
+# Builds a single example app without requiring `make` or Git Bash. Uses the
+# xtensa-esp32s3 toolchain installed by Arduino IDE plus the system Python.
+#
+# Usage (from the repo root or anywhere):
+#   .\examples\build.ps1 examples\reading_streak
+#   .\examples\build.ps1 examples\wordle
+#   .\examples\build.ps1 examples\click_counter
+#   .\examples\build.ps1 examples\palagotchi -Clean
+#
+# Equivalent to running `make` against the Makefile, but pure PowerShell.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [string]$AppDir,
+
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Locate toolchain --------------------------------------------------------
+$tcBase = Join-Path $env:LOCALAPPDATA 'Arduino15\packages\esp32\tools\esp-x32'
+if (-not (Test-Path $tcBase)) {
+    throw "ESP32 toolchain not found at $tcBase. Install the ESP32 board package via Arduino IDE first."
+}
+$tcVer = (Get-ChildItem $tcBase -Directory | Sort-Object Name -Descending | Select-Object -First 1).Name
+$bin = Join-Path $tcBase "$tcVer\bin"
+
+$cc      = Join-Path $bin 'xtensa-esp32s3-elf-gcc.exe'
+$objcopy = Join-Path $bin 'xtensa-esp32s3-elf-objcopy.exe'
+$nm      = Join-Path $bin 'xtensa-esp32s3-elf-nm.exe'
+$readelf = Join-Path $bin 'xtensa-esp32s3-elf-readelf.exe'
+
+foreach ($t in @($cc, $objcopy, $nm, $readelf)) {
+    if (-not (Test-Path $t)) { throw "Missing toolchain binary: $t" }
+}
+
+# --- Locate Python -----------------------------------------------------------
+$python = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $python) { $python = Get-Command python3 -ErrorAction SilentlyContinue }
+if (-not $python) { throw "Python 3 not found. Install from python.org and ensure `python` is on PATH." }
+$python = $python.Source
+
+# --- Resolve app paths -------------------------------------------------------
+$AppDir = (Resolve-Path $AppDir).Path
+$appName = Split-Path $AppDir -Leaf
+$src    = Join-Path $AppDir 'app.c'
+$ld     = Join-Path $AppDir 'pala_app.ld'
+$elf    = Join-Path $AppDir "$appName.elf"
+$binOut = Join-Path $AppDir "$appName.bin"
+
+if (-not (Test-Path $src)) { throw "No app.c in $AppDir" }
+if (-not (Test-Path $ld))  { throw "No pala_app.ld in $AppDir" }
+
+if ($Clean) {
+    if (Test-Path $elf)    { Remove-Item $elf -Force }
+    if (Test-Path $binOut) { Remove-Item $binOut -Force }
+    Write-Host "Cleaned $appName."
+    return
+}
+
+# --- Resolve firmware header include path ------------------------------------
+# Script lives in examples/; headers are at <repo>/Pala_One_2_1.
+$headers = (Resolve-Path (Join-Path $PSScriptRoot '..\Pala_One_2_1')).Path
+if (-not (Test-Path (Join-Path $headers 'pala_api.h'))) {
+    throw "Cannot find pala_api.h under $headers"
+}
+
+# --- Compile -----------------------------------------------------------------
+$cflags = @(
+    '-fPIC', '-mlongcalls', '-Os', '-fno-jump-tables',
+    '-nostdlib', '-nodefaultlibs',
+    "-I$headers"
+)
+
+Write-Host "[1/3] Compiling $appName ..."
+& $cc @cflags "-Wl,-T,$ld" '-Wl,-shared' '-o' $elf $src
+if ($LASTEXITCODE -ne 0) { throw "gcc failed (exit $LASTEXITCODE)" }
+
+# --- Strip to raw binary -----------------------------------------------------
+Write-Host "[2/3] Stripping ELF to raw binary ..."
+& $objcopy '-O' binary $elf $binOut
+if ($LASTEXITCODE -ne 0) { throw "objcopy failed (exit $LASTEXITCODE)" }
+
+# --- Find app_main entry offset via nm ---------------------------------------
+$nmLines = & $nm $elf
+if ($LASTEXITCODE -ne 0) { throw "nm failed (exit $LASTEXITCODE)" }
+$entryMatch = $nmLines | Where-Object { $_ -match '^([0-9a-fA-F]+)\s+[Tt]\s+app_main$' } | Select-Object -First 1
+if (-not $entryMatch) { throw "app_main symbol not found in $elf" }
+$entryOff = [Convert]::ToUInt32(($entryMatch -split '\s+')[0], 16)
+
+# --- Patch header (entry offset + relocation table) via Python ---------------
+# Mirrors the Python snippet in the Makefile: read readelf -r, collect
+# R_XTENSA_RELATIVE offsets, append them as a table, and write the three
+# patched header fields (entry_offset @40, reloc_offset @44, reloc_count @48).
+Write-Host "[3/3] Patching header (entry + relocation table) ..."
+$pyScript = @'
+import struct, subprocess, sys
+readelf, elf_in, bin_path, entry_off = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+out = subprocess.check_output([readelf, '-r', elf_in], text=True)
+relocs = [int(ln.split()[0], 16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]
+d = bytearray(open(bin_path, 'rb').read())
+struct.pack_into('<I', d, 40, entry_off)
+reloc_off = len(d) if relocs else 0
+d.extend(struct.pack('<' + 'I' * len(relocs), *relocs))
+struct.pack_into('<I', d, 44, reloc_off)
+struct.pack_into('<I', d, 48, len(relocs))
+open(bin_path, 'wb').write(d)
+print(f'relocations: {len(relocs)} ({relocs})')
+'@
+
+& $python -c $pyScript $readelf $elf $binOut $entryOff
+if ($LASTEXITCODE -ne 0) { throw "Python patch step failed (exit $LASTEXITCODE)" }
+
+$size = (Get-Item $binOut).Length
+Write-Host ""
+Write-Host "Built $binOut" -ForegroundColor Green
+Write-Host ("  size:  {0} bytes" -f $size)
+Write-Host ("  entry: 0x{0:x}" -f $entryOff)

--- a/examples/reading_streak/Makefile
+++ b/examples/reading_streak/Makefile
@@ -1,0 +1,39 @@
+TOOLCHAIN_BASE ?= $(HOME)/.arduino15/packages/esp32/tools/esp-x32
+TOOLCHAIN_VER  ?= $(shell ls $(TOOLCHAIN_BASE) 2>/dev/null | sort -V | tail -1)
+TOOLCHAIN      ?= $(TOOLCHAIN_BASE)/$(TOOLCHAIN_VER)/bin
+
+CC      = $(TOOLCHAIN)/xtensa-esp32s3-elf-gcc
+OBJCOPY = $(TOOLCHAIN)/xtensa-esp32s3-elf-objcopy
+NM      = $(TOOLCHAIN)/xtensa-esp32s3-elf-nm
+READELF = $(TOOLCHAIN)/xtensa-esp32s3-elf-readelf
+
+CFLAGS = -fPIC -mlongcalls -Os -fno-jump-tables -nostdlib -nodefaultlibs \
+         -I../../Pala_One_2_1
+
+all: reading_streak.bin
+
+reading_streak.elf: app.c pala_app.ld
+	$(CC) $(CFLAGS) -Wl,-T,pala_app.ld -Wl,-shared -o $@ app.c
+
+reading_streak.bin: reading_streak.elf
+	$(OBJCOPY) -O binary $< $@
+	$(eval ENTRY_OFF := $(shell $(NM) $< | awk '/^[0-9a-f]+ [Tt] app_main$$/{print $$1}'))
+	@[ -n "$(ENTRY_OFF)" ] || (echo "ERROR: app_main symbol not found"; exit 1)
+	python3 -c " \
+import struct, subprocess; \
+out=subprocess.check_output(['$(READELF)','-r','$<'],text=True); \
+relocs=[int(ln.split()[0],16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]; \
+d=bytearray(open('$@','rb').read()); \
+struct.pack_into('<I',d,40,int('$(ENTRY_OFF)',16)); \
+reloc_off=len(d) if relocs else 0; \
+d.extend(struct.pack('<'+'I'*len(relocs),*relocs)); \
+struct.pack_into('<I',d,44,reloc_off); \
+struct.pack_into('<I',d,48,len(relocs)); \
+open('$@','wb').write(d); \
+print(f'relocations: {relocs}')"
+	@echo "Built $@: $$(wc -c < $@) bytes, entry=0x$(ENTRY_OFF)"
+
+clean:
+	rm -f reading_streak.elf reading_streak.bin
+
+.PHONY: all clean

--- a/examples/reading_streak/app.c
+++ b/examples/reading_streak/app.c
@@ -1,0 +1,183 @@
+#include "../../Pala_One_2_1/pala_app.h"
+#include "../../Pala_One_2_1/pala_api.h"
+
+__attribute__((section(".header")))
+const PalaAppHeader pala_header = {
+    .magic        = PALA_APP_MAGIC,
+    .api_version  = PALA_API_VERSION,
+    .name         = "Reading Streak",
+    .entry_offset = 0,
+    .reloc_offset = 0,
+    .reloc_count  = 0,
+};
+
+#define LONG_PRESS_MS    850u
+#define CONFIRM_SHOW_MS  1500u
+#define DAY_SECS         86400u
+#define HISTORY_CELLS    30
+#define BITMAP_BITS      32
+#define UNSET_DAY        0xFFFFFFFFu
+
+/* Persisted state.  All uint32_t to keep alignment portable across rebuilds. */
+typedef struct {
+    uint32_t version;        /* schema version, currently 1 */
+    uint32_t firstRtcSec;    /* rtcSeconds() the very first time app ran */
+    uint32_t lastLoggedDay;  /* day index of most recent log, UNSET_DAY if never */
+    uint32_t currentStreak;
+    uint32_t longestStreak;
+    uint32_t totalSessions;
+    uint32_t bitmapHead;     /* day index that bit 0 of bitmap refers to */
+    uint32_t bitmap;         /* bit i = "logged on day (bitmapHead - i)" */
+} SavedState;
+
+static void drawStreakBar(const PalaAPI* api, int y, uint32_t bitmap) {
+    /* 30 cells, rightmost = today (bit 0), 8 px per cell, centered. */
+    const int cellW  = 8;
+    const int totalW = HISTORY_CELLS * cellW;
+    const int startX = (250 - totalW) / 2;
+    char buf[2];
+    buf[1] = 0;
+    for (int p = 0; p < HISTORY_CELLS; p++) {
+        int bit  = (HISTORY_CELLS - 1) - p;
+        int bold = (p == HISTORY_CELLS - 1) ? 1 : 0;
+        buf[0] = ((bitmap >> bit) & 1u) ? '#' : '.';
+        api->drawTextAt(startX + p * cellW, y, buf, bold);
+    }
+}
+
+static void drawMain(const PalaAPI* api, const SavedState* s, int loggedToday) {
+    char buf[40];
+
+    api->clearScreen();
+    api->drawHeader("Reading Streak");
+
+    api->snprintf_wrap(buf, sizeof(buf), "Current streak: %u days",
+                       (unsigned)s->currentStreak);
+    api->drawTextAt(6, 34, buf, 1);
+
+    api->snprintf_wrap(buf, sizeof(buf), "Longest: %u",
+                       (unsigned)s->longestStreak);
+    api->drawTextAt(6, 48, buf, 0);
+
+    api->snprintf_wrap(buf, sizeof(buf), "Total: %u sessions",
+                       (unsigned)s->totalSessions);
+    api->drawTextAt(6, 62, buf, 0);
+
+    api->drawTextAt(6, 80, "Last 30 days (today on right):", 0);
+    drawStreakBar(api, 96, s->bitmap);
+
+    if (loggedToday) {
+        api->drawTextAt(6, 118, "Logged today.  Hold = exit", 0);
+    } else {
+        api->drawTextAt(6, 118, "Click = log today   Hold = exit", 1);
+    }
+
+    api->refreshDisplay();
+}
+
+static void drawConfirm(const PalaAPI* api, uint32_t streak) {
+    char buf[16];
+    api->clearScreen();
+    api->drawHeader("Reading Streak");
+    api->drawTextAt(95, 36, "Logged!", 1);
+    api->snprintf_wrap(buf, sizeof(buf), "%u", (unsigned)streak);
+    api->drawCenteredLarge(buf);
+    api->drawTextAt(85, 116, "day streak", 0);
+    api->refreshDisplay();
+}
+
+void app_main(const PalaAPI* api) {
+    SavedState s;
+    int hasSave = (api->storageRead("streak", &s, sizeof(s)) == (int)sizeof(s));
+    uint32_t now = api->rtcSeconds();
+
+    if (!hasSave || s.version != 1) {
+        s.version        = 1;
+        s.firstRtcSec    = now;
+        s.lastLoggedDay  = UNSET_DAY;
+        s.currentStreak  = 0;
+        s.longestStreak  = 0;
+        s.totalSessions  = 0;
+        s.bitmapHead     = 0;
+        s.bitmap         = 0;
+    }
+
+    /* RTC went backwards (battery died, was replaced): reset the day baseline
+       but keep cumulative stats so the user doesn't lose their record. */
+    if (now < s.firstRtcSec) {
+        s.firstRtcSec   = now;
+        s.lastLoggedDay = UNSET_DAY;
+        s.currentStreak = 0;
+        s.bitmapHead    = 0;
+        /* keep bitmap, longestStreak, totalSessions */
+    }
+
+    uint32_t today = (now - s.firstRtcSec) / DAY_SECS;
+
+    /* Slide the bitmap forward so bit 0 represents today. */
+    if (today > s.bitmapHead) {
+        uint32_t delta = today - s.bitmapHead;
+        if (delta >= BITMAP_BITS) s.bitmap = 0;
+        else                      s.bitmap <<= delta;
+        s.bitmapHead = today;
+    }
+
+    /* Streak is broken if there's a gap of more than one day since last log. */
+    if (s.lastLoggedDay != UNSET_DAY && today > s.lastLoggedDay + 1) {
+        s.currentStreak = 0;
+    }
+
+    /* Persist the normalized state so future opens see consistent values. */
+    api->storageWrite("streak", &s, sizeof(s));
+
+    int loggedToday      = (s.lastLoggedDay == today) ? 1 : 0;
+    int needsRedraw      = 1;
+    int showingConfirm   = 0;
+    uint32_t confirmStart = 0;
+    uint32_t pressStart   = 0;
+
+    while (1) {
+        uint32_t mNow = api->millisNow();
+
+        /* Long-press exit, fires while held (same pattern as click_counter). */
+        if (api->buttonPressed()) {
+            if (pressStart == 0) pressStart = mNow;
+            if ((mNow - pressStart) >= LONG_PRESS_MS) {
+                api->storageWrite("streak", &s, sizeof(s));
+                return;
+            }
+        } else {
+            pressStart = 0;
+        }
+
+        /* pendingPresses() bypasses multi-click grouping for a snappy tap. */
+        uint32_t presses = api->pendingPresses();
+        if (presses > 0 && !loggedToday) {
+            int isContinuation = (s.lastLoggedDay != UNSET_DAY) &&
+                                 (today == s.lastLoggedDay + 1);
+            s.bitmap        |= 1u;
+            s.currentStreak  = isContinuation ? (s.currentStreak + 1) : 1;
+            if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
+            s.lastLoggedDay  = today;
+            s.totalSessions += 1;
+            loggedToday      = 1;
+            api->storageWrite("streak", &s, sizeof(s));
+
+            showingConfirm = 1;
+            confirmStart   = mNow;
+            drawConfirm(api, s.currentStreak);
+        }
+
+        if (showingConfirm && (mNow - confirmStart) >= CONFIRM_SHOW_MS) {
+            showingConfirm = 0;
+            needsRedraw    = 1;
+        }
+
+        if (needsRedraw && !showingConfirm) {
+            drawMain(api, &s, loggedToday);
+            needsRedraw = 0;
+        }
+
+        api->delayMs(10);
+    }
+}

--- a/examples/reading_streak/pala_app.ld
+++ b/examples/reading_streak/pala_app.ld
@@ -1,0 +1,8 @@
+ENTRY(app_main)
+SECTIONS {
+    .header   0 : { KEEP(*(.header)) }
+    .literal    : { *(.literal) *(.literal.*) }
+    .text       : { *(.text*) }
+    .rodata     : { *(.rodata*) }
+    .data       : { *(.data*) }
+}

--- a/examples/sleep_timer/Makefile
+++ b/examples/sleep_timer/Makefile
@@ -1,0 +1,39 @@
+TOOLCHAIN_BASE ?= $(HOME)/.arduino15/packages/esp32/tools/esp-x32
+TOOLCHAIN_VER  ?= $(shell ls $(TOOLCHAIN_BASE) 2>/dev/null | sort -V | tail -1)
+TOOLCHAIN      ?= $(TOOLCHAIN_BASE)/$(TOOLCHAIN_VER)/bin
+
+CC      = $(TOOLCHAIN)/xtensa-esp32s3-elf-gcc
+OBJCOPY = $(TOOLCHAIN)/xtensa-esp32s3-elf-objcopy
+NM      = $(TOOLCHAIN)/xtensa-esp32s3-elf-nm
+READELF = $(TOOLCHAIN)/xtensa-esp32s3-elf-readelf
+
+CFLAGS = -fPIC -mlongcalls -Os -fno-jump-tables -nostdlib -nodefaultlibs \
+         -I../../Pala_One_2_1
+
+all: sleep_timer.bin
+
+sleep_timer.elf: app.c pala_app.ld
+	$(CC) $(CFLAGS) -Wl,-T,pala_app.ld -Wl,-shared -o $@ app.c
+
+sleep_timer.bin: sleep_timer.elf
+	$(OBJCOPY) -O binary $< $@
+	$(eval ENTRY_OFF := $(shell $(NM) $< | awk '/^[0-9a-f]+ [Tt] app_main$$/{print $$1}'))
+	@[ -n "$(ENTRY_OFF)" ] || (echo "ERROR: app_main symbol not found"; exit 1)
+	python3 -c " \
+import struct, subprocess; \
+out=subprocess.check_output(['$(READELF)','-r','$<'],text=True); \
+relocs=[int(ln.split()[0],16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]; \
+d=bytearray(open('$@','rb').read()); \
+struct.pack_into('<I',d,40,int('$(ENTRY_OFF)',16)); \
+reloc_off=len(d) if relocs else 0; \
+d.extend(struct.pack('<'+'I'*len(relocs),*relocs)); \
+struct.pack_into('<I',d,44,reloc_off); \
+struct.pack_into('<I',d,48,len(relocs)); \
+open('$@','wb').write(d); \
+print(f'relocations: {relocs}')"
+	@echo "Built $@: $$(wc -c < $@) bytes, entry=0x$(ENTRY_OFF)"
+
+clean:
+	rm -f sleep_timer.elf sleep_timer.bin
+
+.PHONY: all clean

--- a/examples/sleep_timer/app.c
+++ b/examples/sleep_timer/app.c
@@ -1,0 +1,180 @@
+#include "../../Pala_One_2_1/pala_app.h"
+#include "../../Pala_One_2_1/pala_api.h"
+
+__attribute__((section(".header")))
+const PalaAppHeader pala_header = {
+    .magic        = PALA_APP_MAGIC,
+    .api_version  = PALA_API_VERSION,
+    .name         = "Sleep Timer",
+    .entry_offset = 0,
+    .reloc_offset = 0,
+    .reloc_count  = 0,
+};
+
+#define LONG_PRESS_MS  850u
+
+/* Status values are part of the wire format the firmware reads from
+   /apps/sleep_timer.dat. The firmware checks the file after each reader
+   page turn and shows a "time's up" toast when ST_RUNNING has elapsed.
+   Field order in SleepTimerFile is frozen — do not reorder. */
+#define ST_IDLE          0
+#define ST_RUNNING       1
+#define ST_NEEDS_NOTIFY  2
+
+typedef struct {
+    uint32_t version;        /* schema version, currently 1 */
+    uint32_t status;         /* ST_IDLE / ST_RUNNING / ST_NEEDS_NOTIFY */
+    uint32_t endRtcSec;      /* rtcSeconds() value when timer should fire */
+    uint32_t durationMin;    /* original duration; remembered across runs */
+    uint32_t startedRtcSec;  /* rtcSeconds() at start of current run */
+} SleepTimerFile;
+
+static const uint32_t DURATIONS[] = {5, 10, 15, 20, 25, 30, 45, 60};
+#define NUM_DURATIONS         ((int)(sizeof(DURATIONS) / sizeof(DURATIONS[0])))
+#define DEFAULT_DURATION_IDX  4    /* 25 min — common reading session length */
+
+static void drawIdle(const PalaAPI* api, uint32_t durationMin) {
+    char buf[16];
+    api->clearScreen();
+    api->drawHeader("Sleep Timer");
+    api->drawTextAt(78, 34, "Set duration", 0);
+    api->snprintf_wrap(buf, sizeof(buf), "%u min", (unsigned)durationMin);
+    api->drawCenteredLarge(buf);
+    api->drawTextAt(8, 118, "Click=cycle  2x=start  Hold=exit", 0);
+    api->refreshDisplay();
+}
+
+static void drawRunning(const PalaAPI* api, uint32_t remainingSec, uint32_t durationMin) {
+    char buf[24];
+    api->clearScreen();
+    api->drawHeader("Sleep Timer");
+
+    uint32_t mins = remainingSec / 60u;
+    uint32_t secs = remainingSec - (mins * 60u);
+    api->snprintf_wrap(buf, sizeof(buf), "%u:%02u", (unsigned)mins, (unsigned)secs);
+    api->drawCenteredLarge(buf);
+
+    api->snprintf_wrap(buf, sizeof(buf), "%u-min timer", (unsigned)durationMin);
+    api->drawTextAt(82, 108, buf, 0);
+    api->drawTextAt(8, 118, "Click=cancel  Hold=exit (keeps running)", 0);
+    api->refreshDisplay();
+}
+
+static void drawNotify(const PalaAPI* api, uint32_t durationMin) {
+    char buf[24];
+    api->clearScreen();
+    api->drawHeader("Sleep Timer");
+    api->drawCenteredLarge("Time's up!");
+    api->snprintf_wrap(buf, sizeof(buf), "(%u-min timer)", (unsigned)durationMin);
+    api->drawTextAt(82, 108, buf, 0);
+    api->drawTextAt(38, 118, "Click=dismiss   Hold=exit", 0);
+    api->refreshDisplay();
+}
+
+void app_main(const PalaAPI* api) {
+    SleepTimerFile s;
+    int hasSave = (api->storageRead("sleep_timer", &s, sizeof(s)) == (int)sizeof(s));
+    uint32_t now = api->rtcSeconds();
+
+    if (!hasSave || s.version != 1) {
+        s.version       = 1;
+        s.status        = ST_IDLE;
+        s.endRtcSec     = 0;
+        s.durationMin   = DURATIONS[DEFAULT_DURATION_IDX];
+        s.startedRtcSec = 0;
+    }
+
+    /* If a stored timer is running but already past its end, treat as expired. */
+    if (s.status == ST_RUNNING && now >= s.endRtcSec) {
+        s.status = ST_NEEDS_NOTIFY;
+    }
+
+    /* Find current duration index for cycling. Defaults to 25 min if unmatched. */
+    int durIdx = DEFAULT_DURATION_IDX;
+    for (int i = 0; i < NUM_DURATIONS; i++) {
+        if (DURATIONS[i] == s.durationMin) { durIdx = i; break; }
+    }
+
+    api->storageWrite("sleep_timer", &s, sizeof(s));
+
+    int needsRedraw       = 1;
+    uint32_t pressStart   = 0;
+    uint32_t lastDispSec  = 0;
+
+    while (1) {
+        uint32_t mNow = api->millisNow();
+        now = api->rtcSeconds();
+
+        /* Long-press exit. Timer state is preserved on disk; if it's running,
+           the firmware will still show the toast when it expires. */
+        if (api->buttonPressed()) {
+            if (pressStart == 0) pressStart = mNow;
+            if ((mNow - pressStart) >= LONG_PRESS_MS) {
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                return;
+            }
+        } else {
+            pressStart = 0;
+        }
+
+        /* In-app expiration detection (when user is watching the countdown). */
+        if (s.status == ST_RUNNING && now >= s.endRtcSec) {
+            s.status = ST_NEEDS_NOTIFY;
+            api->storageWrite("sleep_timer", &s, sizeof(s));
+            needsRedraw = 1;
+        }
+
+        uint8_t evt = api->pollEvent();
+
+        if (s.status == ST_IDLE) {
+            if (evt == PALA_CLICK) {
+                durIdx += 1;
+                if (durIdx >= NUM_DURATIONS) durIdx = 0;
+                s.durationMin = DURATIONS[durIdx];
+                needsRedraw = 1;
+            } else if (evt == PALA_DOUBLE) {
+                s.status        = ST_RUNNING;
+                s.startedRtcSec = now;
+                s.endRtcSec     = now + (s.durationMin * 60u);
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                needsRedraw = 1;
+            }
+        } else if (s.status == ST_RUNNING) {
+            if (evt == PALA_CLICK) {
+                /* Cancel and return to idle. */
+                s.status        = ST_IDLE;
+                s.endRtcSec     = 0;
+                s.startedRtcSec = 0;
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                needsRedraw = 1;
+            }
+            /* Tick the seconds display once per real second. */
+            if (now != lastDispSec) {
+                lastDispSec = now;
+                needsRedraw = 1;
+            }
+        } else { /* ST_NEEDS_NOTIFY */
+            if (evt != 0) {
+                s.status        = ST_IDLE;
+                s.endRtcSec     = 0;
+                s.startedRtcSec = 0;
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                needsRedraw = 1;
+            }
+        }
+
+        if (needsRedraw) {
+            if (s.status == ST_IDLE) {
+                drawIdle(api, s.durationMin);
+            } else if (s.status == ST_RUNNING) {
+                uint32_t remaining = (now < s.endRtcSec) ? (s.endRtcSec - now) : 0;
+                drawRunning(api, remaining, s.durationMin);
+            } else {
+                drawNotify(api, s.durationMin);
+            }
+            needsRedraw = 0;
+        }
+
+        api->delayMs(50);
+    }
+}

--- a/examples/sleep_timer/pala_app.ld
+++ b/examples/sleep_timer/pala_app.ld
@@ -1,0 +1,8 @@
+ENTRY(app_main)
+SECTIONS {
+    .header   0 : { KEEP(*(.header)) }
+    .literal    : { *(.literal) *(.literal.*) }
+    .text       : { *(.text*) }
+    .rodata     : { *(.rodata*) }
+    .data       : { *(.data*) }
+}


### PR DESCRIPTION
## Summary

Adds a Sleep Timer example app and firmware hooks that let it — and the
existing Reading Streak app — keep working when the user isn't in the
app (i.e. they're actually reading a book, or the device is in deep
sleep).

The design pattern: apps can't run in the background, so each app owns
a `/apps/<name>.dat` file and the firmware reads/writes that same file
when relevant reader events happen. Both sides duplicate the struct
layout, which becomes the wire-format contract.

## What's in this PR

### New: Sleep Timer app — `examples/sleep_timer/`
- Cycle preset durations via click (5/10/15/20/25/30/45/60 min).
- Double-click to start, hold to exit. Click during run cancels.
- State persists in `/apps/sleep_timer.dat` as 5 × `uint32_t`.

### Firmware integration — `Pala_One_2_1/Pala_One_2_1.ino`
A new ~130-line block defines:
- Wire-format structs (`ReadingStreakFile`, `SleepTimerFile`) — MUST
  match the example apps' layouts. Schema version field on both for
  future evolution.
- `readAppDat()` / `writeAppDat()` — thin LittleFS wrappers for
  `/apps/<key>.dat`.
- `streakAutoLogOnPageTurn()` — after `STREAK_PAGES_THRESHOLD` (5)
  page turns on a new day, writes `streak.dat` using the same log
  logic the app uses (bitmap shift, continuation check, etc.). Toast
  on success. Mirrors the app's algorithm exactly so manual taps and
  auto-log produce identical numbers.
- `sleepTimerCheckExpired()` — flips `RUNNING → NEEDS_NOTIFY` exactly
  once when the timer's end-time passes; toast at that moment. The
  app's own UI is the persistent indicator after that.
- `onReaderPageTurn()` — composite hook called after each real
  next/prev page turn.

Inserted call sites:
- 4 page-turn locations in the reader (next/prev × with/without
  save-throttle). Bookmark-add intentionally not hooked — re-renders
  but isn't a reading event.
- `setup()` calls `sleepTimerCheckExpired()` once so wake-from-RTC
  surfaces the toast immediately.
- `goToSleep()` arms `esp_sleep_enable_timer_wakeup(remainingUs)` if a
  timer is running, so the device wakes itself at the timer's end
  rather than waiting for the next button press.

### Reading Streak app — `examples/reading_streak/`
Daily check-in with rolling 32-day bitmap and streak/longest/total
stats. Manual click-to-log still works and writes the same file
format the firmware uses. Unchanged from prior reference work — the
new value is that you rarely need to open it.

### Tooling
- `examples/build.ps1` — Windows-native PowerShell builder. Uses the
  xtensa toolchain Arduino IDE installs at
  `%LOCALAPPDATA%\Arduino15\packages\esp32\tools\esp-x32\` plus your
  system Python. No `make` or Git Bash needed.
- `.gitignore` for `examples/**/*.bin` and `*.elf` artifacts.
- `examples/GETTING_STARTED.md` examples table updated.

## Tested on
- Heltec Wireless Paper **V1.2** (please test V1.1 too if you have one)
- Sleep timer in active reading: toast fires on next page turn after
  expiration.
-  Sleep timer deep-sleep wake: device wakes from RTC alarm, toast
  renders on the library/reader render that follows.
- Streak auto-log: streak advances after ≥5 page turns on a new day.
- Sleep timer cancel mid-run: returns cleanly to setup state.
-  Both apps compile to valid `PalaAppHeader` (verified via `build.ps1`).

## Tradeoffs / knobs
- `STREAK_PAGES_THRESHOLD = 5` — too low: idle browsing counts;
  too high: short sessions miss. Easy to tune.
- `TOAST_MS = 650` is the existing toast constant. If the sleep-timer
  toast feels too brief, happy to bump the global or add a
  longer-duration variant for just this case.
- Active RTC wake is a small power-profile change: the device boots
  once per expired timer, runs `setup()`, shows the toast, then
  returns to its normal idle-timeout deep-sleep. Negligible in practice.

