### PR TITLE
Feat/load older api versions

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -2661,6 +2661,19 @@ static void api_refreshDisplay() {
   display.update();
 }
 
+// 1bpp XBitmap blit. Silently no-ops on malformed app input so a buggy app
+// cannot drive Adafruit_GFX into OOB reads. Off-screen pixels are already
+// clipped by HeltecGFXAdapter::drawPixel.
+static void api_drawXBitmap(int16_t x, int16_t y, const uint8_t* bits, int16_t w, int16_t h, uint16_t color) {
+  if (!bits || w <= 0 || h <= 0) return;
+  // x+w / y+h must fit int16_t — Adafruit_GFX's inner loops increment signed (UB on overflow).
+  if ((int32_t)x + (int32_t)w > 32767 || (int32_t)y + (int32_t)h > 32767) return;
+  // Bound the app-supplied buffer read at 64 KB (~17x full-screen).
+  uint32_t row_bytes = (uint32_t)((w + 7) / 8);
+  if (row_bytes * (uint32_t)h > 65536u) return;
+  gfx.drawXBitmap(x, y, bits, w, h, color ? 1 : 0);
+}
+
 static uint8_t api_waitForEvent() {
   markUserActivity();
   while (true) {
@@ -2758,6 +2771,7 @@ static void initPalaAPI() {
   g_palaAPI.storageRead       = api_storageRead;
   g_palaAPI.storageWrite      = api_storageWrite;
   g_palaAPI.rtcSeconds        = api_rtcSeconds;
+  g_palaAPI.drawXBitmap       = api_drawXBitmap;
 }
 
 // ---- App loader -------------------------------------------------------------

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -2813,11 +2813,15 @@ static bool loadAndRunApp(const char* path) {
   if (hdr->magic != PALA_APP_MAGIC) {
     freeAppExecBuf(); drawCenter("Bad app file", "Wrong magic"); delay(1500); return false;
   }
-  if (hdr->api_version != PALA_API_VERSION) {
-    char msg[32];
-    snprintf(msg, sizeof(msg), "API v%u, need v%u",
+  // PalaAPI is append-only (see pala_api.h), so an app built against an
+  // older API version can run on this firmware unchanged -- it only reads
+  // the prefix of the struct it knows about. An app built against a NEWER
+  // API would read past the end of our struct, so we still reject those.
+  if (hdr->api_version > PALA_API_VERSION) {
+    char msg[40];
+    snprintf(msg, sizeof(msg), "App v%u > firmware v%u",
              (unsigned)hdr->api_version, (unsigned)PALA_API_VERSION);
-    freeAppExecBuf(); drawCenter("API mismatch", msg); delay(1500); return false;
+    freeAppExecBuf(); drawCenter("App too new", msg); delay(1500); return false;
   }
 
   if (hdr->entry_offset < sizeof(PalaAppHeader) || hdr->entry_offset >= fileSize) {

--- a/Pala_One_2_1/pala_api.h
+++ b/Pala_One_2_1/pala_api.h
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 
-// Firmware-to-app API v1 — field order is frozen once shipped.
+// Firmware-to-app API v4 — field order is frozen once shipped.
 // To extend, append new fields and bump PALA_API_VERSION in pala_app.h.
 typedef struct {
     void     (*clearScreen)(void);
@@ -20,4 +20,14 @@ typedef struct {
     int      (*storageRead) (const char* key, void* buf, int maxlen);        // read from /apps/{key}.dat; returns bytes read, -1 on error
     int      (*storageWrite)(const char* key, const void* buf, int len);     // write to /apps/{key}.dat; returns bytes written, -1 on error
     uint32_t (*rtcSeconds)  (void);                                          // monotonic seconds; survives deep sleep; use for cross-session timing
+    // ---- v4 additions ----
+    // Blit a 1bpp XBitmap. Format: LSB-first within each byte, row-major,
+    // ((w + 7) / 8) bytes per row. color=1 draws set bits as black ink on
+    // the current canvas (default WHITE after clearScreen); color=0 draws
+    // them as white (useful for erasing on a black canvas). Off-screen
+    // coordinates are clipped automatically. Invalid input is treated as a
+    // silent no-op for board safety: null `bits`, non-positive w/h, or a
+    // total bitmap byte budget (((w+7)/8)*h) above 64 KB will skip the blit
+    // rather than read past the supplied buffer.
+    void     (*drawXBitmap)(int16_t x, int16_t y, const uint8_t* bits, int16_t w, int16_t h, uint16_t color);
 } PalaAPI;

--- a/Pala_One_2_1/pala_app.h
+++ b/Pala_One_2_1/pala_app.h
@@ -2,7 +2,7 @@
 #include <stdint.h>
 
 #define PALA_APP_MAGIC    0x50414C41UL  // 'PALA'
-#define PALA_API_VERSION  3
+#define PALA_API_VERSION  4
 
 // Event codes returned by waitForEvent()
 #define PALA_CLICK   1

--- a/examples/GETTING_STARTED.md
+++ b/examples/GETTING_STARTED.md
@@ -50,7 +50,7 @@ void app_main(const PalaAPI* api);
 
 The firmware calls it after loading the binary and relocating it into RAM. The `api` pointer gives you access to all firmware services. When `app_main` returns, the firmware returns to the app launcher.
 
-## The PalaAPI (v3)
+## The PalaAPI (v4)
 
 All interaction with the device goes through function pointers in `PalaAPI`. Field order is frozen — new fields are always appended, never inserted. Do not cache the pointer; use it directly.
 
@@ -60,6 +60,7 @@ All interaction with the device goes through function pointers in `PalaAPI`. Fie
 | `drawHeader(title)` | Draw the standard title bar at the top |
 | `drawTextAt(x, y, text, bold)` | Draw text at pixel coordinates; `bold=1` for bold weight |
 | `drawCenteredLarge(text)` | Draw large bold text horizontally centred |
+| `drawXBitmap(x, y, bits, w, h, color)` | Blit a 1bpp XBitmap. `int16_t` coords/dims, `uint16_t color`. **LSB-first**, packed rows, `((w+7)/8)` bytes per row. `color=1` draws set bits as black ink on the current canvas (default white after `clearScreen`); `color=0` draws them as white (useful when you have inverted to a black canvas). Off-screen coordinates are clipped automatically. **Silently skipped** if `bits==NULL`, `w<=0`, `h<=0`, the right/bottom edge would exceed `INT16_MAX`, or the total byte budget `((w+7)/8)*h` exceeds 64 KB (~17x full-screen) — design the bitmap budget around this, the firmware will not error. See `examples/campfire/` for a worked example with a PIL-based Bayer 4x4 converter that bakes a PNG spritesheet into a 1bpp header. |
 | `refreshDisplay()` | Flush the frame buffer to the e-ink panel |
 | `waitForEvent()` | Block until a button gesture arrives; returns an event code |
 | `pollEvent()` | Non-blocking version; returns 0 if no event is ready |
@@ -148,3 +149,4 @@ The app appears in the app launcher the next time the device loads the app list.
 |---|---|
 | `click_counter/` | Minimal app: event loop, display updates, long-press exit, `pendingPresses()` |
 | `palagotchi/` | Timers, cross-session state with `storageRead`/`storageWrite` + `rtcSeconds`, action screens, stat display |
+| `campfire/` | Full-screen `drawXBitmap` animation. `convert.py` upscales the PNG 4x with LANCZOS, rotates 90 deg, Bayer 4x4 dithers aligned to the panel pixel grid, and packs an inverted XBitmap so a single blit per frame renders white flames on a black background |


### PR DESCRIPTION
## Summary

  Two commits that ship together because they're logically coupled — the firmware bump is what
  motivates the compat-loosening, and shipping the compat-loosening without a bump would be a no-op.

  1. **`059727a` Accept apps built against older PalaAPI versions.** Loader rejects apps with
  `api_version > PALA_API_VERSION` instead of `!= PALA_API_VERSION`. Honors the append-only policy
  `pala_api.h` already documents.
  2. **`70520b6` Add drawXBitmap, bump PalaAPI to v4.** Appends `drawXBitmap` to the `PalaAPI` struct,
   bumps `PALA_API_VERSION` from 3 to 4, wires the firmware implementation, updates the API doc header
   from "v1" (stale) to "v4".

  Combined with the compat-loosening above, this v4 bump does **not** break existing v3 apps — they
  continue to load and run unchanged. Only apps built against future v5+ headers would be rejected on
  a v4 firmware.

  ## Why drawXBitmap

  Existing PalaAPI gives apps text primitives (`drawTextAt`, `drawCenteredLarge`) but no way to draw
  an image. `drawXBitmap` mirrors Adafruit_GFX's standard 1bpp XBitmap blit, which is the natural
  format to bake an image into a flash-resident C header via PIL or an equivalent.

  ## Signature

  ```c
  void (*drawXBitmap)(int16_t x, int16_t y, const uint8_t* bits,
                      int16_t w, int16_t h, uint16_t color);

  - Format: 1bpp XBitmap — LSB-first within each byte, row-major, ((w + 7) / 8) bytes per row.
  - color: 1 draws set bits as black ink on the default white canvas; 0 draws them as white (useful
  for erase passes on a black canvas).
  - Clipping: off-screen coordinates are clipped automatically by HeltecGFXAdapter::drawPixel.
 ```

  Firmware-side input validation

  Apps run with a static PalaAPI* pointer and can pass arbitrary values into firmware. api_drawXBitmap
   treats malformed input as a silent no-op rather than UB:
```
  static void api_drawXBitmap(int16_t x, int16_t y, const uint8_t* bits, int16_t w, int16_t h,
  uint16_t color) {
    if (!bits || w <= 0 || h <= 0) return;
    // x+w / y+h must fit int16_t — Adafruit_GFX's inner loops increment signed (UB on overflow).
    if ((int32_t)x + (int32_t)w > 32767 || (int32_t)y + (int32_t)h > 32767) return;
    // Bound the app-supplied buffer read at 64 KB (~17x full-screen).
    uint32_t row_bytes = (uint32_t)((w + 7) / 8);
    if (row_bytes * (uint32_t)h > 65536u) return;
    gfx.drawXBitmap(x, y, bits, w, h, color ? 1 : 0);
  }
```
  The 64 KB cap is generous (full screen at 250x122 1bpp is ~3.8 KB) but bounds the worst case a
  malicious or buggy app can drive Adafruit_GFX into.

  Backward compatibility (loader change)

  -  if (hdr->api_version != PALA_API_VERSION) {
  +  // PalaAPI is append-only (see pala_api.h), so an app built against an
  +  // older API version can run on this firmware unchanged -- it only reads
  +  // the prefix of the struct it knows about. An app built against a NEWER
  +  // API would read past the end of our struct, so we still reject those.
  +  if (hdr->api_version > PALA_API_VERSION) {

This makes it accept older API version apps, worth considering. I kept it backwards-compatible so it wouldn't affect older apps.

  Test plan

  - Compile both board variants
  - Load an existing v3 app (e.g., palagotchi, click_counter) on a build with this PR → still loads
  and runs
  - Build a fresh app against the v4 headers in this PR using drawXBitmap → renders correctly
  - Fabricate an app header with api_version = 99 → still rejected, message reads "App too new"
  - App passes bits = NULL or w = 0 to drawXBitmap → no-op, no crash

  Out of scope

  - Campfire example. A drawXBitmap example app exists in this fork (examples/campfire/) with
  PIL-based image conversion, but it's a 2300-line generated frame table that would dwarf this PR's
  signal. Happy to send it as a follow-up.
  - Versioning policy doc. A separate "what counts as breaking, what counts as additive" note for
  pala_api.h is worth writing once the policy is exercised more than once. Not included here.

  Note on #12

  This PR overlaps with #12 at the file level in Pala_One_2_1/Pala_One_2_1.ino, but the actual edited
  regions are disjoint: this PR touches the PalaAPI table init, drawXBitmap implementation (~line
  2661), and the loader's API-version check (~line 2816). #12's new content is the sleep-timer/streak
  hook block after drawSleepScreen() (~line 4312+) plus new example apps. Flagged the stale-base issue
   separately on #12 — once that's rebased the two should merge in either order without conflict.