### PR TITLE
Reader menu and button mapping via webUI

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -2638,16 +2638,10 @@ static void drawReaderMenu() {
   u8g2.print(buf);
   y += lineH;
 
-  // Progress bar — full width, 8px tall.
-  int barX = MARGIN_X;
-  int barW = SCREEN_W - 2 * MARGIN_X;
-  int barH = 8;
-  int filled = (int)((pos * (uint32_t)barW) / (uint32_t)total);
-  if (filled < 0) filled = 0;
-  if (filled > barW) filled = barW;
-  gfx.drawRect(barX, y, barW, barH, 1);
-  if (filled > 2) gfx.fillRect(barX + 1, y + 1, filled - 2, barH - 2, 1);
-  y += barH + 4;
+  // Blank gap so the settings section reads as separate from progress info,
+  // not as a label for any visual above it. (The earlier full-width bar was
+  // visually indistinguishable from the bottom-of-screen statusbar.)
+  y += lineH;
 
   // Statusbar mode row — short-click cycles through the three modes.
   const char* sbName = "Full";

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -4730,7 +4730,14 @@ void setup() {
             mode = MODE_READER;
             g_reader.pageTurnsSinceFull = FULL_REFRESH_EVERY_N_PAGES;
             renderCurrentPage();   // draw first — takes ~300ms, user releases button during this
-            resetInputFrontend();  // then discard the wake-press only
+            if (g_deviceLocked) {
+              // Keep the wake-press edges so a click-then-hold can wake AND
+              // unlock in one motion. resetInputFrontend would otherwise
+              // drain them and force the user to repeat the unlock gesture.
+              markUserActivity();
+            } else {
+              resetInputFrontend();  // discard the wake-press only
+            }
             restored = true;
           }
           break;
@@ -4741,7 +4748,11 @@ void setup() {
 
   if (!restored) {
     drawLibrary();
-    resetInputFrontend();
+    if (g_deviceLocked) {
+      markUserActivity();
+    } else {
+      resetInputFrontend();
+    }
   }
 
   // Drop to 80 MHz for normal operation — saves significant power.

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -116,6 +116,12 @@ enum ReaderLongPressAction {
   LONGPRESS_BOOKMARK = 0
 };
 
+enum StatusbarMode {
+  STATUSBAR_FULL    = 0,  // 8px: page-progress bar + page number
+  STATUSBAR_MINIMAL = 1,  // 1px: single-row progress fraction
+  STATUSBAR_HIDDEN  = 2,  // no statusbar reserve
+};
+
 enum LibraryEntryType {
   LIB_ENTRY_BACK,
   LIB_ENTRY_FOLDER,
@@ -147,6 +153,7 @@ struct RuntimeSettings {
   uint32_t sleepSecs = 120;
   int lineGap = 0;
   int readerLongPressAction = LONGPRESS_BOOKMARK;
+  int statusbarMode = STATUSBAR_FULL;
 };
 
 struct LibraryState {
@@ -449,6 +456,18 @@ static void invalidateMetrics() {
   g_metricsValid = false;
 }
 
+// Pixels reserved at the bottom for the statusbar in the current mode.
+// STATUS_H (8) is the maximum and is what toast overlays use unconditionally;
+// this is the per-mode reservation that subtracts from reader text area.
+static int statusbarReserveH() {
+  switch (g_settings.statusbarMode) {
+    case STATUSBAR_HIDDEN:  return 0;
+    case STATUSBAR_MINIMAL: return 1;
+    case STATUSBAR_FULL:
+    default:                return STATUS_H;
+  }
+}
+
 static const LayoutMetrics& getMetrics() {
   if (!g_metricsValid) {
     u8g2.setFont(MAIN_FONT);
@@ -461,7 +480,7 @@ static const LayoutMetrics& getMetrics() {
     g_metrics.maxWidth = w;
 
     int maxHeight = SCREEN_H - TOP_PAD - BOT_PAD;
-    if (SHOW_PROGRESS_BAR || SHOW_PAGE_NUMBER) maxHeight -= STATUS_H;
+    maxHeight -= statusbarReserveH();
 
     g_metrics.maxLines = maxHeight / g_metrics.lineH;
     if (g_metrics.maxLines < 1) g_metrics.maxLines = 1;
@@ -494,6 +513,11 @@ static void loadSettings() {
   if (g_settings.lineGap > 4) g_settings.lineGap = 4;
 
   g_settings.readerLongPressAction = LONGPRESS_BOOKMARK;
+
+  int sb = prefs.getInt("cfg_statusbar", STATUSBAR_FULL);
+  if (sb < STATUSBAR_FULL || sb > STATUSBAR_HIDDEN) sb = STATUSBAR_FULL;
+  g_settings.statusbarMode = sb;
+
   invalidateMetrics();
 }
 
@@ -2269,8 +2293,19 @@ static bool openBookByIndex(int idx) {
 }
 
 static void drawStatusBar(uint32_t startOffset) {
+  if (g_settings.statusbarMode == STATUSBAR_HIDDEN) return;
+
   size_t total = g_reader.file.size();
   if (total == 0) total = 1;
+
+  if (g_settings.statusbarMode == STATUSBAR_MINIMAL) {
+    int w = SCREEN_W - 2 * MARGIN_X;
+    int filled = (int)((startOffset * (uint32_t)w) / (uint32_t)total);
+    if (filled < 0) filled = 0;
+    if (filled > w) filled = w;
+    if (filled > 0) gfx.drawFastHLine(MARGIN_X, SCREEN_H - 1, filled, 1);
+    return;
+  }
 
   int pageTextW = 0;
   if (SHOW_PAGE_NUMBER) {

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -5168,11 +5168,18 @@ void loop() {
     btns.resetState();
   }
 
-  // Locked state: swallow all input except the gesture currently bound to
-  // ACTION_LOCK, which toggles back to unlocked. Auto-sleep still applies
-  // so an idle locked device re-sleeps instead of draining the battery.
+  // Locked state: swallow all input except any deliberate hold-type
+  // gesture, which unlocks. We accept any of {longClick, veryLongClick,
+  // clickHoldClick} rather than strictly matching the gesture currently
+  // bound to ACTION_LOCK -- after a deep-sleep wake the firmware can't
+  // reliably reconstruct a click-then-hold chord (the wake press's start
+  // edge happens before the ISR is attached), so strict matching would
+  // leave the user unable to unlock if they bound LOCK to the chord.
+  // Auto-sleep still applies so an idle locked device re-sleeps instead
+  // of draining the battery.
   if (g_deviceLocked) {
-    if (btns.anyClick() && currentMappedGestureAction() == ACTION_LOCK) {
+    bool unlockGesture = btns.longClick || btns.veryLongClick || btns.clickHoldClick;
+    if (unlockGesture) {
       g_deviceLocked = false;
       prefs.putBool("cfg_locked", false);
       markUserActivity();

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -2632,11 +2632,23 @@ static void drawReaderMenu() {
   if (filled > barW) filled = barW;
   gfx.drawRect(barX, y, barW, barH, 1);
   if (filled > 2) gfx.fillRect(barX + 1, y + 1, filled - 2, barH - 2, 1);
-  y += barH + 4 + lineH;  // gap after bar, then advance one line
+  y += barH + 4;
+
+  // Statusbar mode row — short-click cycles through the three modes.
+  const char* sbName = "Full";
+  switch (g_settings.statusbarMode) {
+    case STATUSBAR_MINIMAL: sbName = "Minimal"; break;
+    case STATUSBAR_HIDDEN:  sbName = "Hidden";  break;
+    case STATUSBAR_FULL:
+    default:                sbName = "Full";    break;
+  }
+  snprintf(buf, sizeof(buf), "Statusbar: %s", sbName);
+  u8g2.setCursor(MARGIN_X, y);
+  u8g2.print(buf);
 
   // Footer hint at the very bottom.
   u8g2.setCursor(MARGIN_X, SCREEN_H - 2);
-  u8g2.print("click to close");
+  u8g2.print("click: cycle  2x: close");
 
   display.update();
 }
@@ -4919,8 +4931,19 @@ static void handleModeList() {
 }
 
 static void handleModeReader() {
-  // Reader menu overlay: any click closes it and re-renders the page.
+  // Reader menu overlay:
+  //   - shortClick cycles the statusbar mode and redraws the menu in place.
+  //   - any other click closes the menu and returns to the page.
   if (g_readerMenu.active) {
+    if (btns.shortClick) {
+      int next = g_settings.statusbarMode + 1;
+      if (next > STATUSBAR_HIDDEN) next = STATUSBAR_FULL;
+      g_settings.statusbarMode = next;
+      prefs.putInt("cfg_statusbar", next);
+      invalidateMetrics();
+      drawReaderMenu();
+      return;
+    }
     if (btns.anyClick()) {
       g_readerMenu.active = false;
       btns.resetClicks();

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -66,7 +66,6 @@ static const int READER_IDLE_PREFETCH_PAGES = 1;
 static const uint32_t DOUBLE_MS = 300;
 static const uint32_t TRIPLE_MS = 550;
 static const uint32_t LONG_MS = 850;
-static const uint32_t VERY_LONG_MS = 2000;
 static const uint32_t DEBOUNCE_MS = 14;
 
 static const uint32_t SAVE_EVERY_MS = 7000;
@@ -289,7 +288,7 @@ struct ButtonState {
   bool tripleClick = false;
   bool quadClick = false;
   bool longClick = false;
-  bool veryLongClick = false;
+  bool clickHoldClick = false;  // chord: short click immediately followed by a long hold
 
   uint32_t rawPressCount = 0; // every short press-release, unfiltered by multi-click windows
 
@@ -299,7 +298,7 @@ struct ButtonState {
     tripleClick = false;
     quadClick = false;
     longClick = false;
-    veryLongClick = false;
+    clickHoldClick = false;
   }
 
   void resetState() {
@@ -315,7 +314,7 @@ struct ButtonState {
   }
 
   bool anyClick() const {
-    return shortClick || doubleClick || tripleClick || quadClick || longClick || veryLongClick;
+    return shortClick || doubleClick || tripleClick || quadClick || longClick || clickHoldClick;
   }
 
   void poll();
@@ -588,12 +587,15 @@ void ButtonState::poll() {
     if (prevPressed && !stablePressed) {
       if (pressArmed) {
         uint32_t dur = (uint32_t)(edgeT - pressStart);
-        if (dur >= VERY_LONG_MS) {
+        if (dur >= LONG_MS) {
+          // If a short click happened just before this hold, treat the
+          // pair as a click-then-hold chord instead of a plain longClick.
+          if (clickCount == 1) {
+            clickHoldClick = true;
+          } else {
+            longClick = true;
+          }
           clickCount = 0;
-          veryLongClick = true;
-        } else if (dur >= LONG_MS) {
-          clickCount = 0;
-          longClick = true;
         } else {
           rawPressCount++;  // count every short press unconditionally
           clickCount++;
@@ -615,6 +617,11 @@ void ButtonState::poll() {
     bool emit = false;
     if (clickCount <= 2) emit = (uint32_t)(now - lastRelease) > DOUBLE_MS;
     else if (clickCount == 3) emit = (uint32_t)(now - firstClickRelease) > TRIPLE_MS;
+
+    // Defer the emit while the user is still holding the button down -- a
+    // long release coming up may form a click-then-hold chord, and emitting
+    // shortClick here would prematurely fire "next page" before we see it.
+    if (emit && stablePressed) emit = false;
 
     if (emit) {
       if (clickCount == 1) shortClick  = true;
@@ -4953,7 +4960,7 @@ static void handleModeReader() {
     return;
   }
 
-  if (btns.veryLongClick) {
+  if (btns.clickHoldClick) {
     g_readerMenu.active = true;
     drawReaderMenu();
     return;

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -66,6 +66,7 @@ static const int READER_IDLE_PREFETCH_PAGES = 1;
 static const uint32_t DOUBLE_MS = 300;
 static const uint32_t TRIPLE_MS = 550;
 static const uint32_t LONG_MS = 850;
+static const uint32_t VERY_LONG_MS = 2000;
 static const uint32_t DEBOUNCE_MS = 14;
 
 static const uint32_t SAVE_EVERY_MS = 7000;
@@ -121,6 +122,15 @@ enum StatusbarMode {
   STATUSBAR_HIDDEN  = 2,  // no statusbar reserve
 };
 
+// Actions that can be bound to the three "advanced" reader gestures
+// (long press, very-long press, click-then-hold). Stored in prefs.
+enum ButtonAction {
+  ACTION_NONE     = 0,
+  ACTION_BOOKMARK = 1,
+  ACTION_LOCK     = 2,
+  ACTION_MENU     = 3,
+};
+
 enum LibraryEntryType {
   LIB_ENTRY_BACK,
   LIB_ENTRY_FOLDER,
@@ -153,6 +163,10 @@ struct RuntimeSettings {
   int lineGap = 0;
   int readerLongPressAction = LONGPRESS_BOOKMARK;
   int statusbarMode = STATUSBAR_FULL;
+
+  int actionLong      = ACTION_BOOKMARK;  // plain long press
+  int actionExtraLong = ACTION_LOCK;      // very-long press
+  int actionClickHold = ACTION_MENU;      // click then hold
 };
 
 struct LibraryState {
@@ -288,6 +302,7 @@ struct ButtonState {
   bool tripleClick = false;
   bool quadClick = false;
   bool longClick = false;
+  bool veryLongClick = false;   // hold >= VERY_LONG_MS, no preceding click
   bool clickHoldClick = false;  // chord: short click immediately followed by a long hold
 
   uint32_t rawPressCount = 0; // every short press-release, unfiltered by multi-click windows
@@ -298,6 +313,7 @@ struct ButtonState {
     tripleClick = false;
     quadClick = false;
     longClick = false;
+    veryLongClick = false;
     clickHoldClick = false;
   }
 
@@ -314,7 +330,7 @@ struct ButtonState {
   }
 
   bool anyClick() const {
-    return shortClick || doubleClick || tripleClick || quadClick || longClick || clickHoldClick;
+    return shortClick || doubleClick || tripleClick || quadClick || longClick || veryLongClick || clickHoldClick;
   }
 
   void poll();
@@ -340,6 +356,7 @@ ReaderState g_reader;
 BookmarkUiState g_bookmarkUi;
 ToastState g_toast;
 ReaderMenuState g_readerMenu;
+bool g_deviceLocked = false;
 ListState g_list;
 UploadState g_upload;
 BatteryState g_battery;
@@ -522,6 +539,14 @@ static void loadSettings() {
   if (sb < STATUSBAR_FULL || sb > STATUSBAR_HIDDEN) sb = STATUSBAR_FULL;
   g_settings.statusbarMode = sb;
 
+  auto clampAction = [](int v, int defaultV) -> int {
+    if (v < ACTION_NONE || v > ACTION_MENU) return defaultV;
+    return v;
+  };
+  g_settings.actionLong      = clampAction(prefs.getInt("cfg_btnL",  ACTION_BOOKMARK), ACTION_BOOKMARK);
+  g_settings.actionExtraLong = clampAction(prefs.getInt("cfg_btnXL", ACTION_LOCK),     ACTION_LOCK);
+  g_settings.actionClickHold = clampAction(prefs.getInt("cfg_btnCH", ACTION_MENU),     ACTION_MENU);
+
   invalidateMetrics();
 }
 
@@ -588,10 +613,11 @@ void ButtonState::poll() {
       if (pressArmed) {
         uint32_t dur = (uint32_t)(edgeT - pressStart);
         if (dur >= LONG_MS) {
-          // If a short click happened just before this hold, treat the
-          // pair as a click-then-hold chord instead of a plain longClick.
           if (clickCount == 1) {
+            // click-then-hold chord (regardless of hold duration after the click)
             clickHoldClick = true;
+          } else if (dur >= VERY_LONG_MS) {
+            veryLongClick = true;
           } else {
             longClick = true;
           }
@@ -3987,6 +4013,34 @@ static void handleListClearDoneWeb() {
   server.send(302, "text/plain", "");
 }
 
+// Helpers for the remappable-button section of the settings page.
+static void appendActionOption(String& out, int val, const char* label, int current) {
+  out += "<option value='";
+  out += val;
+  out += "'";
+  if (val == current) out += " selected";
+  out += ">";
+  out += label;
+  out += "</option>";
+}
+
+static void appendActionSelect(String& out, const char* nameId, const char* label, int current) {
+  out += "<div><label for='";
+  out += nameId;
+  out += "'>";
+  out += label;
+  out += "</label><select id='";
+  out += nameId;
+  out += "' name='";
+  out += nameId;
+  out += "'>";
+  appendActionOption(out, ACTION_NONE,     "None",          current);
+  appendActionOption(out, ACTION_BOOKMARK, "Bookmark page", current);
+  appendActionOption(out, ACTION_LOCK,     "Lock device",   current);
+  appendActionOption(out, ACTION_MENU,     "Open menu",     current);
+  out += "</select></div>";
+}
+
 static void handleSettings() {
   String sel8 = (g_settings.fontSize == 8) ? " selected" : "";
   String sel10 = (g_settings.fontSize == 10) ? " selected" : "";
@@ -4057,7 +4111,19 @@ static void handleSettings() {
   out +=
     "</select><div class='hint'>A small change here can make text much easier to scan.</div></div>"
     "</div>"
-    "<div class='actions' style='margin-top:24px;'><button type='submit'>Save settings</button><span class='muted'>No extra files, scripts, or fonts.</span></div></form></div>"
+    "<div class='actions' style='margin-top:24px;'><button type='submit'>Save settings</button><span class='muted'>No extra files, scripts, or fonts.</span></div></form></div>";
+
+  out += "<div class='card'><h2>Buttons</h2>";
+  out += "<p class='muted'>1 click = next, 2 = previous, 3 = home. The three holds below are remappable.</p>";
+  out += "<form method='POST' action='/settings' accept-charset='UTF-8'><div class='grid cols-2'>";
+  appendActionSelect(out, "btnL",  "Long press",            g_settings.actionLong);
+  appendActionSelect(out, "btnXL", "Extra-long press",      g_settings.actionExtraLong);
+  appendActionSelect(out, "btnCH", "Click, then hold",      g_settings.actionClickHold);
+  out += "</div><div class='actions' style='margin-top:24px;'><button type='submit'>Save buttons</button>";
+  out += "<span class='muted'>If locked, repeat the same gesture to unlock.</span>";
+  out += "</div></form></div>";
+
+  out +=
     "<div class='card'><h2>Screensaver</h2>"
     "<p>Upload raw XBM bytes: <b>3904 bytes</b>, 250&times;122 px, 1-bit, LSB-first, 32 bytes per row.</p>"
     "<p class='muted'>Tip: use <a class='link' href='https://javl.github.io/image2cpp/' target='_blank'>image2cpp</a> with <b>Plain bytes</b>. Invert colors if needed.</p>";
@@ -4111,6 +4177,19 @@ static void handleSettingsPost() {
       layoutChanged = true;
     }
   }
+
+  auto saveBtnAction = [&](const char* arg, const char* prefKey, int* dest) {
+    if (!server.hasArg(arg)) return;
+    int v = server.arg(arg).toInt();
+    if (v < ACTION_NONE || v > ACTION_MENU) v = ACTION_NONE;
+    if (v != *dest) {
+      *dest = v;
+      prefs.putInt(prefKey, v);
+    }
+  };
+  saveBtnAction("btnL",  "cfg_btnL",  &g_settings.actionLong);
+  saveBtnAction("btnXL", "cfg_btnXL", &g_settings.actionExtraLong);
+  saveBtnAction("btnCH", "cfg_btnCH", &g_settings.actionClickHold);
 
   if (layoutChanged) {
     // invalidateAllPageCaches() already resets pageIndex to 0 for the open book.
@@ -4937,6 +5016,38 @@ static void handleModeList() {
   }
 }
 
+// Returns the user-bound action for the gesture fired in this poll, or
+// ACTION_NONE if no remappable gesture is active.
+static int currentMappedGestureAction() {
+  if (btns.clickHoldClick) return g_settings.actionClickHold;
+  if (btns.veryLongClick)  return g_settings.actionExtraLong;
+  if (btns.longClick)      return g_settings.actionLong;
+  return ACTION_NONE;
+}
+
+// Carries out one of the bindable reader actions. No-op for ACTION_NONE.
+static void performReaderAction(int action) {
+  switch (action) {
+    case ACTION_BOOKMARK: {
+      const char* msg = addBookmarkForCurrentBook();
+      if (msg) showToast(msg);
+      g_reader.pageTurnsSinceFull++;
+      renderCurrentPage();
+      break;
+    }
+    case ACTION_LOCK:
+      g_deviceLocked = true;
+      showToast("Locked");
+      break;
+    case ACTION_MENU:
+      g_readerMenu.active = true;
+      drawReaderMenu();
+      break;
+    default:
+      break;
+  }
+}
+
 static void handleModeReader() {
   // Reader menu overlay:
   //   - shortClick cycles the statusbar mode and redraws the menu in place.
@@ -4961,16 +5072,17 @@ static void handleModeReader() {
   }
 
   if (btns.clickHoldClick) {
-    g_readerMenu.active = true;
-    drawReaderMenu();
+    performReaderAction(g_settings.actionClickHold);
+    return;
+  }
+
+  if (btns.veryLongClick) {
+    performReaderAction(g_settings.actionExtraLong);
     return;
   }
 
   if (btns.longClick) {
-    const char* msg = addBookmarkForCurrentBook();
-    if (msg) showToast(msg);
-    g_reader.pageTurnsSinceFull++;
-    renderCurrentPage();
+    performReaderAction(g_settings.actionLong);
     return;
   }
 
@@ -5028,6 +5140,22 @@ void loop() {
   }
 
   if (btns.anyClick()) markUserActivity();
+
+  // Locked state: swallow all input except the gesture currently bound to
+  // ACTION_LOCK, which toggles back to unlocked. If no gesture is bound to
+  // LOCK, the device cannot be locked in the first place, so this branch
+  // doesn't strand the user.
+  if (g_deviceLocked) {
+    if (btns.anyClick() && currentMappedGestureAction() == ACTION_LOCK) {
+      g_deviceLocked = false;
+      showToast("Unlocked");
+      if (mode == MODE_READER) {
+        g_reader.pageTurnsSinceFull = FULL_REFRESH_EVERY_N_PAGES;
+        renderCurrentPage();
+      }
+    }
+    return;
+  }
 
   if (ENABLE_DEEP_SLEEP && mode != MODE_UPLOAD) {
     if ((uint32_t)(millis() - lastUserActionMs) > sleepAfterMs()) {

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -66,6 +66,7 @@ static const int READER_IDLE_PREFETCH_PAGES = 1;
 static const uint32_t DOUBLE_MS = 300;
 static const uint32_t TRIPLE_MS = 550;
 static const uint32_t LONG_MS = 850;
+static const uint32_t VERY_LONG_MS = 2000;
 static const uint32_t DEBOUNCE_MS = 14;
 
 static const uint32_t SAVE_EVERY_MS = 7000;
@@ -277,6 +278,7 @@ struct ButtonState {
   bool tripleClick = false;
   bool quadClick = false;
   bool longClick = false;
+  bool veryLongClick = false;
 
   uint32_t rawPressCount = 0; // every short press-release, unfiltered by multi-click windows
 
@@ -286,6 +288,7 @@ struct ButtonState {
     tripleClick = false;
     quadClick = false;
     longClick = false;
+    veryLongClick = false;
   }
 
   void resetState() {
@@ -301,7 +304,7 @@ struct ButtonState {
   }
 
   bool anyClick() const {
-    return shortClick || doubleClick || tripleClick || quadClick || longClick;
+    return shortClick || doubleClick || tripleClick || quadClick || longClick || veryLongClick;
   }
 
   void poll();
@@ -556,7 +559,10 @@ void ButtonState::poll() {
     if (prevPressed && !stablePressed) {
       if (pressArmed) {
         uint32_t dur = (uint32_t)(edgeT - pressStart);
-        if (dur >= LONG_MS) {
+        if (dur >= VERY_LONG_MS) {
+          clickCount = 0;
+          veryLongClick = true;
+        } else if (dur >= LONG_MS) {
           clickCount = 0;
           longClick = true;
         } else {

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -209,6 +209,8 @@ struct ToastState {
 
 struct ReaderMenuState {
   bool active = false;
+  bool needsFullRedraw = true;  // set on entry; forces ePaper full clear so the
+                                // old reader page doesn't bleed through partial refresh
 };
 
 struct ListItem {
@@ -2594,6 +2596,13 @@ static void drawListScreen() {
 }
 
 static void drawReaderMenu() {
+  if (g_readerMenu.needsFullRedraw) {
+    // Force a full refresh: we're coming from a different view (the reader
+    // page) and partial refresh would leave the old statusbar / page text
+    // visible underneath the menu rows.
+    menuDrawsSinceFull = MENU_FULL_REFRESH_EVERY;
+    g_readerMenu.needsFullRedraw = false;
+  }
   prepareMenuFrame();
   u8g2.setFont(MAIN_FONT);
   int ascent = u8g2.getFontAscent();
@@ -2613,12 +2622,18 @@ static void drawReaderMenu() {
   if (total == 0) total = 1;
   uint32_t pos = g_reader.lastPageStartOffset;
   int pct = (int)((pos * 100UL) / (uint32_t)total);
-  int totalPages = (g_reader.knownPages > 0) ? g_reader.knownPages : 1;
-  const char* pageSuffix = g_reader.eofReached ? "" : "+";
 
+  // knownPages grows lazily as the reader walks the book; only show it as a
+  // total when pagination has actually reached EOF. Otherwise the "of Y" is
+  // just "how many pages we've cached so far" and reads as a hard cap.
   char buf[64];
-  snprintf(buf, sizeof(buf), "Page %d of %d%s  (%d%%)",
-           g_reader.pageIndex + 1, totalPages, pageSuffix, pct);
+  if (g_reader.eofReached && g_reader.knownPages > 0) {
+    snprintf(buf, sizeof(buf), "Page %d of %d  (%d%%)",
+             g_reader.pageIndex + 1, g_reader.knownPages, pct);
+  } else {
+    snprintf(buf, sizeof(buf), "Page %d  (%d%% of book)",
+             g_reader.pageIndex + 1, pct);
+  }
   u8g2.setCursor(MARGIN_X, y);
   u8g2.print(buf);
   y += lineH;
@@ -4955,6 +4970,7 @@ static void handleModeReader() {
 
   if (btns.veryLongClick) {
     g_readerMenu.active = true;
+    g_readerMenu.needsFullRedraw = true;  // first draw must clear the old reader page
     drawReaderMenu();
     return;
   }

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -4686,6 +4686,18 @@ void setup() {
   pinMode(BTN, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(BTN), btnISR, CHANGE);
 
+  // If we just woke from deep sleep due to a button press (ext0), that
+  // press started BEFORE the ISR was attached, so its leading edge never
+  // made it into the queue. Seed the input state so the upcoming release
+  // edge is classified as a real press, not silently dropped. Required
+  // for "click-then-hold on wake" to work as a single chord gesture.
+  if (digitalRead(BTN) == LOW) {
+    btns.stablePressed   = true;
+    btns.pressArmed      = true;
+    btns.pressStart      = millis();
+    btns.lastStableChange = 0;  // make the first queued edge debounce-eligible
+  }
+
   u8g2.begin(gfx);
   initPalaAPI();
   invalidateMetrics();

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -5165,10 +5165,10 @@ void loop() {
       prefs.putBool("cfg_locked", false);
       markUserActivity();
       showToast("Unlocked");
-      if (mode == MODE_READER) {
-        g_reader.pageTurnsSinceFull = FULL_REFRESH_EVERY_N_PAGES;
-        renderCurrentPage();
-      }
+      // Partial refresh is enough -- the page is already on screen (either
+      // from before the lock, or rendered by setup() after a deep-sleep
+      // wake). We just need a render cycle to paint the toast.
+      if (mode == MODE_READER) renderCurrentPage();
       return;
     }
     // Non-unlock input: ignored. Don't markUserActivity so auto-sleep can fire.

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -209,8 +209,6 @@ struct ToastState {
 
 struct ReaderMenuState {
   bool active = false;
-  bool needsFullRedraw = true;  // set on entry; forces ePaper full clear so the
-                                // old reader page doesn't bleed through partial refresh
 };
 
 struct ListItem {
@@ -2596,13 +2594,6 @@ static void drawListScreen() {
 }
 
 static void drawReaderMenu() {
-  if (g_readerMenu.needsFullRedraw) {
-    // Force a full refresh: we're coming from a different view (the reader
-    // page) and partial refresh would leave the old statusbar / page text
-    // visible underneath the menu rows.
-    menuDrawsSinceFull = MENU_FULL_REFRESH_EVERY;
-    g_readerMenu.needsFullRedraw = false;
-  }
   prepareMenuFrame();
   u8g2.setFont(MAIN_FONT);
   int ascent = u8g2.getFontAscent();
@@ -4964,7 +4955,6 @@ static void handleModeReader() {
 
   if (btns.veryLongClick) {
     g_readerMenu.active = true;
-    g_readerMenu.needsFullRedraw = true;  // first draw must clear the old reader page
     drawReaderMenu();
     return;
   }

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -547,6 +547,8 @@ static void loadSettings() {
   g_settings.actionExtraLong = clampAction(prefs.getInt("cfg_btnXL", ACTION_LOCK),     ACTION_LOCK);
   g_settings.actionClickHold = clampAction(prefs.getInt("cfg_btnCH", ACTION_MENU),     ACTION_MENU);
 
+  g_deviceLocked = prefs.getBool("cfg_locked", false);
+
   invalidateMetrics();
 }
 
@@ -5036,8 +5038,12 @@ static void performReaderAction(int action) {
       break;
     }
     case ACTION_LOCK:
+      // Persist lock state across deep sleep, then sleep immediately.
+      // On wake, loop() sees g_deviceLocked == true (loaded from prefs)
+      // and swallows input until the same gesture unlocks.
       g_deviceLocked = true;
-      showToast("Locked");
+      prefs.putBool("cfg_locked", true);
+      goToSleep();  // does not return
       break;
     case ACTION_MENU:
       g_readerMenu.active = true;
@@ -5139,23 +5145,32 @@ void loop() {
     btns.resetState();
   }
 
-  if (btns.anyClick()) markUserActivity();
-
   // Locked state: swallow all input except the gesture currently bound to
-  // ACTION_LOCK, which toggles back to unlocked. If no gesture is bound to
-  // LOCK, the device cannot be locked in the first place, so this branch
-  // doesn't strand the user.
+  // ACTION_LOCK, which toggles back to unlocked. Auto-sleep still applies
+  // so an idle locked device re-sleeps instead of draining the battery.
   if (g_deviceLocked) {
     if (btns.anyClick() && currentMappedGestureAction() == ACTION_LOCK) {
       g_deviceLocked = false;
+      prefs.putBool("cfg_locked", false);
+      markUserActivity();
       showToast("Unlocked");
       if (mode == MODE_READER) {
         g_reader.pageTurnsSinceFull = FULL_REFRESH_EVERY_N_PAGES;
         renderCurrentPage();
       }
+      return;
+    }
+    // Non-unlock input: ignored. Don't markUserActivity so auto-sleep can fire.
+    if (ENABLE_DEEP_SLEEP && mode != MODE_UPLOAD) {
+      if ((uint32_t)(millis() - lastUserActionMs) > sleepAfterMs()) {
+        goToSleep();  // cfg_locked remains true; we re-sleep still locked
+        return;
+      }
     }
     return;
   }
+
+  if (btns.anyClick()) markUserActivity();
 
   if (ENABLE_DEEP_SLEEP && mode != MODE_UPLOAD) {
     if ((uint32_t)(millis() - lastUserActionMs) > sleepAfterMs()) {

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -207,6 +207,10 @@ struct ToastState {
   uint32_t untilMs = 0;
 };
 
+struct ReaderMenuState {
+  bool active = false;
+};
+
 struct ListItem {
   char text[MAX_LIST_TEXT + 1];
   uint8_t done = 0;
@@ -336,6 +340,7 @@ LibraryState g_library;
 ReaderState g_reader;
 BookmarkUiState g_bookmarkUi;
 ToastState g_toast;
+ReaderMenuState g_readerMenu;
 ListState g_list;
 UploadState g_upload;
 BatteryState g_battery;
@@ -669,6 +674,7 @@ static void resetUiEphemeralState() {
   g_toast.msg = "";
   g_toast.untilMs = 0;
   resetPreviewState();
+  g_readerMenu.active = false;
 }
 
 static void resetNavigationState() {
@@ -695,6 +701,7 @@ static void enterLibraryRoot(bool redraw) {
   safeCloseCurrentBook();
   resetPreviewState();
   resetNavigationState();
+  g_readerMenu.active = false;
   syncWakeState(false);
   mode = MODE_LIBRARY;
   if (redraw) drawLibrary();
@@ -2582,6 +2589,54 @@ static void drawListScreen() {
       u8g2.setFont(MAIN_FONT);
     }
   }
+
+  display.update();
+}
+
+static void drawReaderMenu() {
+  prepareMenuFrame();
+  u8g2.setFont(MAIN_FONT);
+  int ascent = u8g2.getFontAscent();
+  int lineH = (ascent - u8g2.getFontDescent()) + g_settings.lineGap + 1;
+  int y = drawSectionHeader("Reading");
+
+  // Book title (truncated by font; the screen clip handles overflow).
+  String title = lastPathComponent(g_reader.currentBookPath);
+  if (title.endsWith(".txt")) title = title.substring(0, title.length() - 4);
+  u8g2.setFont(BOLD_FONT);
+  u8g2.setCursor(MARGIN_X, y);
+  u8g2.print(title.c_str());
+  y += lineH;
+  u8g2.setFont(MAIN_FONT);
+
+  size_t total = g_reader.file ? g_reader.file.size() : 0;
+  if (total == 0) total = 1;
+  uint32_t pos = g_reader.lastPageStartOffset;
+  int pct = (int)((pos * 100UL) / (uint32_t)total);
+  int totalPages = (g_reader.knownPages > 0) ? g_reader.knownPages : 1;
+  const char* pageSuffix = g_reader.eofReached ? "" : "+";
+
+  char buf[64];
+  snprintf(buf, sizeof(buf), "Page %d of %d%s  (%d%%)",
+           g_reader.pageIndex + 1, totalPages, pageSuffix, pct);
+  u8g2.setCursor(MARGIN_X, y);
+  u8g2.print(buf);
+  y += lineH;
+
+  // Progress bar — full width, 8px tall.
+  int barX = MARGIN_X;
+  int barW = SCREEN_W - 2 * MARGIN_X;
+  int barH = 8;
+  int filled = (int)((pos * (uint32_t)barW) / (uint32_t)total);
+  if (filled < 0) filled = 0;
+  if (filled > barW) filled = barW;
+  gfx.drawRect(barX, y, barW, barH, 1);
+  if (filled > 2) gfx.fillRect(barX + 1, y + 1, filled - 2, barH - 2, 1);
+  y += barH + 4 + lineH;  // gap after bar, then advance one line
+
+  // Footer hint at the very bottom.
+  u8g2.setCursor(MARGIN_X, SCREEN_H - 2);
+  u8g2.print("click to close");
 
   display.update();
 }
@@ -4864,6 +4919,23 @@ static void handleModeList() {
 }
 
 static void handleModeReader() {
+  // Reader menu overlay: any click closes it and re-renders the page.
+  if (g_readerMenu.active) {
+    if (btns.anyClick()) {
+      g_readerMenu.active = false;
+      btns.resetClicks();
+      g_reader.pageTurnsSinceFull = FULL_REFRESH_EVERY_N_PAGES; // force full refresh after menu
+      renderCurrentPage();
+    }
+    return;
+  }
+
+  if (btns.veryLongClick) {
+    g_readerMenu.active = true;
+    drawReaderMenu();
+    return;
+  }
+
   if (btns.longClick) {
     const char* msg = addBookmarkForCurrentBook();
     if (msg) showToast(msg);


### PR DESCRIPTION
## Summary

Adds a reader-menu overlay, a configurable status bar, three remappable
hold gestures, and a device-lock action — all controllable from the
existing web settings page. Single-file diff (firmware only), +279/-8.

## What's in this PR

### Reader-menu overlay (transient, in-reader)

A click-then-hold from the reader opens an info overlay that shows the
book title, current page, and percent through the book. Any other click
closes it and returns to the page. While open, a short click cycles the
statusbar mode in place (described below) so the user can experiment
without leaving the menu.

### Configurable statusbar (`cfg_statusbar`)

The bottom reader statusbar now has three modes:

- **Full** (default, 8px) — unchanged page-progress bar + page number.
- **Minimal** (1px) — single-row horizontal progress fraction at the
  bottom edge; saves 7px of vertical text area.
- **Hidden** (0px) — no statusbar reserve, full screen for text.

`STATUS_H` stays the constant 8 used by toast overlays so toast keeps
working regardless of mode. `getMetrics()` uses a new
`statusbarReserveH()` helper so the text-area line count tracks the
chosen mode after `invalidateMetrics()`.

### Three remappable hold gestures

Short / double / triple click bindings are unchanged (next page / prev
page / home). The three "hold" gestures are now user-bindable:

| Gesture                | Default   | Bindable to                      |
|------------------------|-----------|----------------------------------|
| Long press (≥850ms)    | Bookmark  | None / Bookmark / Lock / Menu    |
| Extra-long press (≥2s) | Lock      | None / Bookmark / Lock / Menu    |
| Click, then hold       | Menu      | None / Bookmark / Lock / Menu    |

Stored in `prefs` as `cfg_btnL` / `cfg_btnXL` / `cfg_btnCH`. Dispatcher
lives in `performReaderAction()`; the three hold paths in
`handleModeReader()` call it instead of hard-coding actions.

### Click-then-hold chord without losing single-click

A single short click already advances the page. To make
"click → press-and-hold" land as a single chord (rather than
"next page" followed by a long hold), `ButtonState::poll()` now defers
the pending `shortClick` emit while the button is still physically
pressed. On release:

- short release, `clickCount == 2` → `doubleClick` (prev page, as before)
- long release, `clickCount == 0` → `longClick` (e.g. bookmark)
- long release, `clickCount == 1` → `clickHoldClick` (the chord)

Single-click, double-click, triple-click, and plain hold all behave
identically to before; the suppression only kicks in while the button
is held.

### Device lock

Any gesture bound to **Lock** toggles `g_deviceLocked`. While locked,
the top of `loop()` drops every button event except the lock-bound
gesture, which toggles back to unlocked. A short toast confirms each
transition.

If no gesture is bound to Lock at all, the locked state is unreachable
— so the binding-set "all three holds set to non-Lock" can't strand the
user.

### Web UI

`/settings` gets a new **Buttons** card with three dropdowns, posted as
an independent form (the existing Reading card is untouched). The POST
handler clamps each value into the `ButtonAction` enum range and
persists. Defaults are written on first load, so reconfigured devices
behave exactly as before this PR.

## Tested on

- Heltec Wireless Paper V1.2
- Click-then-hold from reader → menu opens; statusbar cycle works.
- Extra-long press → device locks; same gesture unlocks; all other
  clicks are correctly swallowed while locked.
- Plain long press → bookmark, as before.
- Web `/settings` "Buttons" card → remap each gesture, reload page,
  selections persist, new bindings take effect immediately.
- Statusbar modes: Full / Minimal / Hidden all render correctly and
  re-flow the text area on change.

## Tradeoffs

- **`LONG_MS = 850`, `VERY_LONG_MS = 2000`** — same press-duration
  thresholds as today. Both are easy constants to tune.
- **Lock without a visible indicator** — the device shows whatever the
  reader was showing when locked. A small "🔒" badge could be drawn in
  a follow-up if it's worth the screen real estate.
- **Triple-click while locked** is also swallowed, so the "global
  triple-click → home" escape hatch is intentionally disabled in
  locked state. Lock gesture is the only way out.
- **`statusbarMode = HIDDEN` and toast** — toast still draws over the
  bottom 8px, briefly covering the lowest line of text. This matches
  current toast-vs-reader behaviour and seemed cheap to live with.
