### PR TITLE
Stats app and relevant firmware changes

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -4442,6 +4442,80 @@ static void drawSleepScreen() {
   display.update();
 }
 
+// ============================================================================
+//  Stats: lifetime page-turn + button-press counters
+//  Working counters live in RTC RAM (survive deep sleep, unlimited writes).
+//  Flash flush happens at sleep, library-root transition, and every
+//  STATS_FLUSH_EVERY_EVENTS bumps as a safety fallback. The wire-format
+//  struct below MUST match examples/stats/app.c.
+// ============================================================================
+
+struct StatsFile {
+  uint32_t version;        // == STATS_SCHEMA
+  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
+  uint64_t pagesRead;
+  uint64_t buttonPresses;
+};
+
+static const uint32_t STATS_SCHEMA              = 1;
+static const uint32_t STATS_FLUSH_EVERY_EVENTS  = 100;
+
+RTC_DATA_ATTR uint64_t g_statsPagesRead       = 0;
+RTC_DATA_ATTR uint64_t g_statsButtonPresses   = 0;
+RTC_DATA_ATTR uint32_t g_statsFirstRtcSec     = 0;
+RTC_DATA_ATTR uint32_t g_statsEventsSinceFlush = 0;
+RTC_DATA_ATTR bool     g_statsRtcInit         = false;
+
+static void statsFlushToFile() {
+  StatsFile s;
+  s.version        = STATS_SCHEMA;
+  s.firstRtcSec    = g_statsFirstRtcSec;
+  s.pagesRead      = g_statsPagesRead;
+  s.buttonPresses  = g_statsButtonPresses;
+  api_storageWrite("stats", &s, (int)sizeof(s));
+  g_statsEventsSinceFlush = 0;
+}
+
+// Load from flash on cold boot (RTC RAM lost on power-off); on deep-sleep
+// wake the RTC counters are already authoritative.
+static void statsEnsureLoaded() {
+  if (g_statsRtcInit) return;
+  StatsFile s;
+  int n = api_storageRead("stats", &s, (int)sizeof(s));
+  if (n == (int)sizeof(s) && s.version == STATS_SCHEMA) {
+    g_statsPagesRead     = s.pagesRead;
+    g_statsButtonPresses = s.buttonPresses;
+    g_statsFirstRtcSec   = s.firstRtcSec;
+  } else {
+    g_statsPagesRead     = 0;
+    g_statsButtonPresses = 0;
+    g_statsFirstRtcSec   = api_rtcSeconds();
+  }
+  g_statsEventsSinceFlush = 0;
+  g_statsRtcInit = true;
+}
+
+static inline void statsBumpEventsAndMaybeFlush() {
+  if (++g_statsEventsSinceFlush >= STATS_FLUSH_EVERY_EVENTS) statsFlushToFile();
+}
+
+static inline void statsBumpPages() {
+  g_statsPagesRead++;
+  statsBumpEventsAndMaybeFlush();
+}
+
+static inline void statsBumpButtons(uint32_t delta) {
+  if (delta == 0) return;
+  g_statsButtonPresses += delta;
+  statsBumpEventsAndMaybeFlush();
+}
+
+// Called from the four reader page-turn sites (not from bookmark-add,
+// which re-renders but isn't a real page turn).
+static inline void onReaderPageTurn() {
+  statsBumpPages();
+}
+
 static void goToSleep() {
   if (!ENABLE_DEEP_SLEEP) return;
 
@@ -4475,6 +4549,9 @@ static void goToSleep() {
   Platform::prepareToSleep();
   esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
   esp_sleep_enable_ext0_wakeup((gpio_num_t)BTN, 0);
+
+  statsFlushToFile();
+
   delay(50);
   esp_deep_sleep_start();
 }
@@ -4522,6 +4599,7 @@ void setup() {
   loadBooks();
   registerWebRoutes();
   markUserActivity();
+  statsEnsureLoaded();  // RTC RAM has lifetime stats post-deep-sleep; load from /apps/stats.dat on cold boot
 
   bool restored = false;
   if (prefs.getInt("wake_mode", 0) == 1) {
@@ -4701,6 +4779,7 @@ static void handleModeBookmarkPreview() {
     if (g_reader.pageIndex > 0) {
       g_reader.pageIndex--;
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4713,6 +4792,7 @@ static void handleModeBookmarkPreview() {
     if (g_reader.eofReached && g_reader.pageIndex >= g_reader.knownPages) g_reader.pageIndex = g_reader.knownPages - 1;
     if (g_reader.pageIndex != oldPage) {
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4836,6 +4916,7 @@ static void handleModeReader() {
       g_reader.pageIndex--;
       saveProgressThrottled(false);
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4850,6 +4931,7 @@ static void handleModeReader() {
     if (g_reader.pageIndex != oldPage) {
       saveProgressThrottled(false);
       g_reader.pageTurnsSinceFull++;
+      onReaderPageTurn();
       renderCurrentPage();
     }
     return;
@@ -4882,6 +4964,20 @@ void loop() {
     interrupts();
     clearButtonQueue();
     btns.resetState();
+  }
+
+  // Stats: rawPressCount increments unconditionally for every short
+  // press-release; long-hold releases are NOT counted, matching what a
+  // user would expect to see as a "click". Delta is computed against the
+  // last seen value (resets each cold boot, which is fine -- we accumulate
+  // into the RTC-RAM lifetime counter).
+  {
+    static uint32_t lastSeenPressCount = 0;
+    uint32_t pc = btns.rawPressCount;
+    if (pc != lastSeenPressCount) {
+      statsBumpButtons(pc - lastSeenPressCount);
+      lastSeenPressCount = pc;
+    }
   }
 
   if (btns.anyClick()) markUserActivity();

--- a/examples/stats/Makefile
+++ b/examples/stats/Makefile
@@ -1,0 +1,42 @@
+# Locate the ESP32-S3 toolchain installed by Arduino IDE / arduino-cli.
+# The toolchain ships under esp-x32/<version>/bin on Linux.
+# Override TOOLCHAIN on the command line if it lives elsewhere.
+TOOLCHAIN_BASE ?= $(HOME)/.arduino15/packages/esp32/tools/esp-x32
+TOOLCHAIN_VER  ?= $(shell ls $(TOOLCHAIN_BASE) 2>/dev/null | sort -V | tail -1)
+TOOLCHAIN      ?= $(TOOLCHAIN_BASE)/$(TOOLCHAIN_VER)/bin
+
+CC      = $(TOOLCHAIN)/xtensa-esp32s3-elf-gcc
+OBJCOPY = $(TOOLCHAIN)/xtensa-esp32s3-elf-objcopy
+NM      = $(TOOLCHAIN)/xtensa-esp32s3-elf-nm
+READELF = $(TOOLCHAIN)/xtensa-esp32s3-elf-readelf
+
+CFLAGS = -fPIC -mlongcalls -Os -nostdlib -nodefaultlibs \
+         -I../../Pala_One_2_1
+
+all: stats.bin
+
+stats.elf: app.c pala_app.ld
+	$(CC) $(CFLAGS) -Wl,-T,pala_app.ld -Wl,-shared -o $@ app.c
+
+stats.bin: stats.elf
+	$(OBJCOPY) -O binary $< $@
+	$(eval ENTRY_OFF := $(shell $(NM) $< | awk '/^[0-9a-f]+ [Tt] app_main$$/{print $$1}'))
+	@[ -n "$(ENTRY_OFF)" ] || (echo "ERROR: app_main symbol not found"; exit 1)
+	python3 -c " \
+import struct, subprocess; \
+out=subprocess.check_output(['$(READELF)','-r','$<'],text=True); \
+relocs=[int(ln.split()[0],16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]; \
+d=bytearray(open('$@','rb').read()); \
+struct.pack_into('<I',d,40,int('$(ENTRY_OFF)',16)); \
+reloc_off=len(d) if relocs else 0; \
+d.extend(struct.pack('<'+'I'*len(relocs),*relocs)); \
+struct.pack_into('<I',d,44,reloc_off); \
+struct.pack_into('<I',d,48,len(relocs)); \
+open('$@','wb').write(d); \
+print(f'relocations: {relocs}')"
+	@echo "Built $@: $$(wc -c < $@) bytes, entry=0x$(ENTRY_OFF)"
+
+clean:
+	rm -f stats.elf stats.bin
+
+.PHONY: all clean

--- a/examples/stats/app.c
+++ b/examples/stats/app.c
@@ -1,0 +1,79 @@
+#include "../../Pala_One_2_1/pala_app.h"
+#include "../../Pala_One_2_1/pala_api.h"
+
+__attribute__((section(".header")))
+const PalaAppHeader pala_header = {
+    .magic        = PALA_APP_MAGIC,
+    .api_version  = PALA_API_VERSION,
+    .name         = "Stats",
+    .entry_offset = 0,  // patched by Makefile
+    .reloc_offset = 0,  // patched by Makefile
+    .reloc_count  = 0,  // patched by Makefile
+};
+
+#define LONG_PRESS_MS 850
+#define STATS_SCHEMA  1u
+
+// Must match StatsFile in Pala_One_2_1.ino byte-for-byte.
+typedef struct {
+    uint32_t version;
+    uint32_t firstRtcSec;
+    uint64_t pagesRead;
+    uint64_t buttonPresses;
+} StatsFile;
+
+// snprintf in the app runtime may not advertise %llu support; render
+// values >= 2^32 as a two-segment decimal to avoid relying on it.
+static void formatU64(const PalaAPI* api, char* buf, int len, uint64_t v) {
+    if (v <= 0xFFFFFFFFu) {
+        api->snprintf_wrap(buf, len, "%lu", (unsigned long)v);
+        return;
+    }
+    unsigned long hi = (unsigned long)(v / 1000000000ULL);
+    unsigned long lo = (unsigned long)(v % 1000000000ULL);
+    api->snprintf_wrap(buf, len, "%lu%09lu", hi, lo);
+}
+
+static void drawPage(const PalaAPI* api) {
+    StatsFile s;
+    int n = api->storageRead("stats", &s, (int)sizeof(s));
+    int valid = (n == (int)sizeof(s) && s.version == STATS_SCHEMA);
+
+    api->clearScreen();
+    api->drawHeader("Stats");
+
+    char num[32];
+
+    api->drawTextAt(6, 36, "Pages read", 1);
+    if (valid) formatU64(api, num, sizeof(num), s.pagesRead);
+    else       api->snprintf_wrap(num, sizeof(num), "--");
+    api->drawTextAt(6, 50, num, 0);
+
+    api->drawTextAt(6, 70, "Button presses", 1);
+    if (valid) formatU64(api, num, sizeof(num), s.buttonPresses);
+    else       api->snprintf_wrap(num, sizeof(num), "--");
+    api->drawTextAt(6, 84, num, 0);
+
+    api->drawTextAt(6, 116, "hold to exit", 0);
+    api->refreshDisplay();
+}
+
+void app_main(const PalaAPI* api) {
+    uint32_t pressStart = 0;
+
+    drawPage(api);
+
+    while (1) {
+        // Drive the input frontend so btns.poll() ticks.
+        (void)api->pendingPresses();
+
+        if (api->buttonPressed()) {
+            if (pressStart == 0) pressStart = api->millisNow();
+            if ((api->millisNow() - pressStart) >= LONG_PRESS_MS) return;
+        } else {
+            pressStart = 0;
+        }
+
+        api->delayMs(10);
+    }
+}

--- a/examples/stats/pala_app.ld
+++ b/examples/stats/pala_app.ld
@@ -1,0 +1,8 @@
+ENTRY(app_main)
+SECTIONS {
+    .header   0 : { KEEP(*(.header)) }
+    .literal    : { *(.literal) *(.literal.*) }
+    .text       : { *(.text*) }
+    .rodata     : { *(.rodata*) }
+    .data       : { *(.data*) }
+}


### PR DESCRIPTION
## Summary

Adds lifetime page-turn and button-press counters maintained by the
firmware, plus an example **Stats** app that displays them. Counters
live in RTC slow memory so deep-sleep cycles cost zero flash writes;
batched flushes to `/apps/stats.dat` keep the flash budget tiny
(~3500 writes/year for a heavy reader, vs ~10k–100k per-sector
lifetime).

## What's in this PR

### Firmware — stats subsystem (Pala_One_2_1.ino)

- New wire-format struct `StatsFile { version, firstRtcSec, pagesRead,
  buttonPresses }`. Must stay byte-identical to the matching struct
  in `examples/stats/app.c`.
- Working counters as `RTC_DATA_ATTR`:
  `g_statsPagesRead`, `g_statsButtonPresses`, `g_statsFirstRtcSec`,
  `g_statsEventsSinceFlush`, `g_statsRtcInit`. Survive deep sleep,
  reset on power-off.
- `statsEnsureLoaded()` — called once in `setup()` after `prefs.begin`.
  On cold boot it reads `/apps/stats.dat` and seeds the RTC counters;
  on deep-sleep wake (`g_statsRtcInit` still true from before sleep)
  it's a no-op.
- `statsBumpPages()` / `statsBumpButtons(delta)` — increment the RTC
  counter and bump an "events since last flush" tally. When that hits
  `STATS_FLUSH_EVERY_EVENTS` (100) a flush fires.
- `statsFlushToFile()` — writes the current totals to
  `/apps/stats.dat` via the existing `api_storageWrite` helper, then
  resets the events tally. Also called explicitly from `goToSleep()`
  so any in-flight deltas are persisted before the chip sleeps.
- `onReaderPageTurn()` hook — called from the four real reader
  page-turn sites (next/prev × with/without save-throttle in
  `handleModeReader` and `handleModeBookmarkPreview`).
  Bookmark-add is intentionally not hooked — it re-renders but isn't
  a real page advance.
- Button counting lives in `loop()`: `btns.rawPressCount` already
  increments unconditionally for every short press-release, so we
  just diff it against a `static uint32_t lastSeenPressCount` each
  tick and bump by the delta. Long-hold releases are not counted,
  which matches what users expect to see as a "click".

### App — `examples/stats/`

- `app.c` reads `/apps/stats.dat` once at entry via `api->storageRead`
  and displays:
  - "Pages read" (bold) + value
  - "Button presses" (bold) + value
  - "hold to exit" footer hint
- Long-press (≥850 ms) returns to the launcher, same convention as
  `click_counter`.
- Values are a snapshot at entry. While the app is running, the
  firmware `loop()` is paused, so any presses made while the screen
  is up don't update the displayed numbers until the app is reopened.
  Acceptable for a lifetime-counter readout; flagged here so reviewers
  don't expect a live ticker.

## Flash-wear math

`RTC_DATA_ATTR` storage is in the ESP32 RTC slow memory: unlimited
writes, survives deep sleep, lost on power-off. That's where the
working counters live.

Flush to `/apps/stats.dat` only happens:
- every 100 events (page turns + button presses combined), and
- at `goToSleep()`.

For a heavy reader doing 500 page turns + ~500 clicks per day
(1000 events) → 10 flushes/day → ~3650 writes/year on a single
LittleFS sector. ESP32 NOR flash budget is 10k–100k writes per
sector; this sits well inside the budget for the device's lifetime.

If the user yanks the battery, up to the last 100 events plus
anything since the most recent `goToSleep()` are lost. That's a
deliberate tradeoff to keep the flash quiet.

## Tested on

- Heltec Wireless Paper V1.2
- Page-turn from MODE_READER: lifetime counter increments correctly
  across both with-save and without-save sites; bookmark-add does
  not count.
- Bookmark-preview mode: page turns in the preview do count
  (matches the user-perceived behavior of "I turned a page").
- Button counting: every short press-release increments the counter
  by exactly 1; multi-click groupings (double/triple/quad) increment
  by N once, not separately.
- Deep sleep cycle: counters survive `esp_deep_sleep_start()` and
  resume from RTC RAM without a flash read.
- Cold boot (no `stats.dat` yet): app shows the default zeros, the
  file is created on first flush.
- Existing `stats.dat`: app reads it correctly and the firmware
  picks up where it left off.

## Tradeoffs 
- **No per-day / per-week breakdown** in this PR — `firstRtcSec` is
  stored so a follow-up could surface "days using" or "average
  pages/day" without a schema bump (`version` already reserved).
- **Stats are global, not per-book** — kept the data small and the
  hook surface tiny. A per-book variant would need a much larger
  storage scheme.


## Relationship to other open work

- **PR #12** (sleep_timer + reading_streak) also introduces an
  `onReaderPageTurn()` hook with the same four call sites. The two
  branches don't conflict at the base-commit level (both branch off
  `upstream/main`), but merging both produces a duplicate-function
  compile error. Whichever lands first, the other rebases and the
  stats subsystem either keeps just its bump-logic or drops the
  duplicate hook. Trivial conflict — ~5 lines of `onReaderPageTurn`
  body.
