### PR TITLE
Skip saveList NVS write when stored bytes already match (restore PR #10 fix F)

### DIFF
--- a/Pala_One_2_1/src/storage/list_items.cpp
+++ b/Pala_One_2_1/src/storage/list_items.cpp
@@ -15,6 +15,14 @@ ListData loadList(KeyValueStore& kv) {
 void saveList(KeyValueStore& kv, const ListData& data) {
   uint8_t buf[LIST_ENCODED_MAX_SIZE];
   size_t n = encodeList(data, buf);
+
+  // Skip the NVS write if the stored bytes already match. The list screen
+  // calls saveListItems on every change AND on screen exit; without this
+  // guard, untouched lists still take a flash-write hit on exit.
+  uint8_t existing[LIST_ENCODED_MAX_SIZE];
+  size_t got = kv.getBytes(LIST_KEY, existing, sizeof(existing));
+  if (got == n && std::memcmp(existing, buf, n) == 0) return;
+
   kv.putBytes(LIST_KEY, buf, n);
 }
 

--- a/test/map_kv_store.h
+++ b/test/map_kv_store.h
@@ -34,7 +34,10 @@ public:
   void putBytes(const char* key, const void* buf, size_t len) override {
     auto& v = data_[key];
     v.assign((const uint8_t*)buf, (const uint8_t*)buf + len);
+    putBytesCalls_++;
   }
+
+  size_t putBytesCallCount() const { return putBytesCalls_; }
 
   String getString(const char* key, const String& def) override {
     auto it = strings_.find(key);
@@ -62,4 +65,5 @@ public:
 private:
   std::map<std::string, std::vector<uint8_t>> data_;
   std::map<std::string, std::string> strings_;
+  size_t putBytesCalls_ = 0;
 };

--- a/test/test_list_store.cpp
+++ b/test/test_list_store.cpp
@@ -64,3 +64,25 @@ TEST_CASE("saveList replaces prior content") {
   CHECK_EQ(back.count, 1);
   CHECK_EQ(String(back.items[0].text), String("z"));
 }
+
+TEST_CASE("saveList skips the write when the stored bytes already match") {
+  MapKvStore kv;
+  ListData data;
+  data.count = 2;
+  std::strcpy(data.items[0].text, "alpha");
+  data.items[0].done = 0;
+  std::strcpy(data.items[1].text, "beta");
+  data.items[1].done = 1;
+
+  saveList(kv, data);
+  size_t writesBefore = kv.putBytesCallCount();
+
+  // Same content — must be a no-op (NVS flash-wear guard).
+  saveList(kv, data);
+  CHECK_EQ(kv.putBytesCallCount(), writesBefore);
+
+  // Real change — must write again.
+  data.items[0].done = 1;
+  saveList(kv, data);
+  CHECK(kv.putBytesCallCount() > writesBefore);
+}


### PR DESCRIPTION
## Summary

Restores the compare-before-write guard in `saveList` that was lost when the modular refactor (#14) pulled list persistence out of the monolith into `src/storage/list_items.cpp`. The monolith fixed this regression in #10 (fix "F"); the refactor brought the older buggy code forward and the guard never came with it.

`src/storage/list_items.cpp:15-19` — `saveList` writes to NVS unconditionally. The list screen calls `saveListItems` on every change AND on screen exit, so even an untouched list takes a flash-write hit every time the user opens and closes the list view.

```diff
 void saveList(KeyValueStore& kv, const ListData& data) {
   uint8_t buf[LIST_ENCODED_MAX_SIZE];
   size_t n = encodeList(data, buf);
+
+  // Skip the NVS write if the stored bytes already match. The list screen
+  // calls saveListItems on every change AND on screen exit; without this
+  // guard, untouched lists still take a flash-write hit on exit.
+  uint8_t existing[LIST_ENCODED_MAX_SIZE];
+  size_t got = kv.getBytes(LIST_KEY, existing, sizeof(existing));
+  if (got == n && std::memcmp(existing, buf, n) == 0) return;
+
   kv.putBytes(LIST_KEY, buf, n);
 }
```

Applied at the `KeyValueStore` boundary so both the firmware and host-test builds benefit.

## Tests

`test/test_list_store.cpp` gets one new case that asserts the no-op behavior precisely:

```cpp
TEST_CASE("saveList skips the write when the stored bytes already match") {
  ...
  saveList(kv, data);
  size_t writesBefore = kv.putBytesCallCount();
  saveList(kv, data);                              // same content
  CHECK_EQ(kv.putBytesCallCount(), writesBefore);  // no-op
  data.items[0].done = 1;
  saveList(kv, data);                              // real change
  CHECK(kv.putBytesCallCount() > writesBefore);    // wrote
}
```

`MapKvStore` gains a `putBytesCallCount()` accessor (additive — no change to existing tests).

**Verified locally** when first authored against gnatpat's branch: `cmake --build test/build && .\build\host_tests.exe` — **89 tests, 271 checks, 89 passed, 0 failed**, including the new case. This PR is a clean cherry-pick of that commit onto `dev`; no conflicts.

## Scope / history

Single commit. No public API changes.

Originally authored as gnatpat/pala-one-firmware#4 (against `refactor/platformio-modular` before #14 merged here). That PR bundled this fix with an ISR queue-race fix that gnatpat independently committed in `60ef3e0` — already on this branch — so only the `saveList` half is re-submitted.
