### PR TITLE
Add build-time language selection (English / Spanish-LA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ build/
 *.bin
 .theia/
 
-# Host-test build artifacts
-test/build/
+# Host-test build artifacts (any test/build* variant — covers per-language
+# host builds like test/build-es/ etc.)
+test/build*/
 
 # OS / editor cruft
 .DS_Store

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -28,6 +28,14 @@
 // #define BOARD_V1_2
 // ────────────────────────────────────────────────────────────────────────────
 
+// ── Language selection: uncomment exactly one (Arduino IDE) ─────────────────
+//   PlatformIO users pick the env in platformio.ini (-en / -es leaf envs)
+//   and can leave these defines commented out. Default if nothing is set:
+//   English (with a #pragma message warning from src/config.h).
+// #define LANG_EN
+// #define LANG_ES_LA
+// ────────────────────────────────────────────────────────────────────────────
+
 // When built with PlatformIO, WIRELESS_PAPER + DISPLAY_V1_x come from
 // build_flags and the BOARD_V1_x macros above stay commented out. When
 // built with Arduino IDE, the macros above drive the same defines so the
@@ -124,7 +132,7 @@ void setup() {
   display.clear();
 
   if (!fsBegin()) {
-    drawCenter("Storage error", "Try factory reset");
+    drawCenter(D_BOOT_STORAGE_ERROR, D_BOOT_TRY_FACTORY_RESET);
     return;
   }
   ensureBooksDir();

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -32,7 +32,7 @@
 //   PlatformIO users pick the env in platformio.ini (-en / -es leaf envs)
 //   and can leave these defines commented out. Default if nothing is set:
 //   English (with a #pragma message warning from src/config.h).
-// #define LANG_EN
+#define LANG_EN
 // #define LANG_ES_LA
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/Pala_One_2_1/src/config.h
+++ b/Pala_One_2_1/src/config.h
@@ -45,6 +45,10 @@
   #define LIB_HEADER_TITLE "Pala One"
 #endif
 
+// Language selection (LANG_EN / LANG_ES_LA) and the LANG_EN fallback live in
+// src/lang/lang.h itself — included at the end of this header so every TU
+// that pulls in config.h transitively sees the D_* macros.
+
 static const int SCREEN_W = 250;
 static const int SCREEN_H = 122;
 
@@ -116,5 +120,11 @@ static const bool ENABLE_DEEP_SLEEP = true;
 // Fonts live behind the role API in `ui/font.h` (Font::useBody/useBold/
 // useUiSmall/useUiTiny). No code outside font.cpp references u8g2 font
 // tables directly.
+
+// Language strings (D_* macros) live in src/lang/. Included here so every
+// TU that pulls in config.h transitively sees the macros without per-file
+// includes. lang.h is pure preprocessor — no Arduino dependencies, host-test
+// safe.
+#include "src/lang/lang.h"
 
 #endif  // PALA_CONFIG_H

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -1,0 +1,355 @@
+#ifndef PALA_LANG_EN_H
+#define PALA_LANG_EN_H
+
+// ============================================================================
+//  English (en) string table — canonical key set.
+//  See src/lang/lang.h for the authoring rule + selection mechanism.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+//  Boot / fatal screens (Pala_One_2_1.ino)
+// ----------------------------------------------------------------------------
+#define D_BOOT_STORAGE_ERROR        "Storage error"
+#define D_BOOT_TRY_FACTORY_RESET    "Try factory reset"
+
+// ----------------------------------------------------------------------------
+//  About screen (src/ui/screens/about_screen.cpp)
+// ----------------------------------------------------------------------------
+#define D_ABOUT_HEADER              "Device"
+#define D_ABOUT_FIRMWARE_PREFIX     "Firmware "
+#define D_ABOUT_GESTURE_NEXT        "1x next / down"
+#define D_ABOUT_GESTURE_OPEN        "2x open / select"
+#define D_ABOUT_GESTURE_HOME        "3x home"
+#define D_ABOUT_GESTURE_BOOKMARK    "Hold bookmark"
+
+// ----------------------------------------------------------------------------
+//  Library screen — section title + system menu entries
+//  (src/ui/screens/library_screen.cpp). The "+ " / "- " expansion indicators
+//  in entryLabel() are visual symbols and intentionally NOT translated.
+// ----------------------------------------------------------------------------
+#define D_MENU_BOOKMARKS            "Bookmarks"
+#define D_MENU_LIST                 "List"
+#define D_MENU_APPS                 "Apps"
+#define D_MENU_DEVICE               "Device"
+#define D_MENU_UPLOAD               "Upload"
+#define D_LIBRARY_OPEN_FAILED       "Open failed"
+#define D_LIBRARY_TRY_UPLOAD        "Try upload again"
+
+// ----------------------------------------------------------------------------
+//  List screen (src/ui/screens/list_screen.cpp)
+// ----------------------------------------------------------------------------
+#define D_LIST_HEADER               "List"
+#define D_LIST_NONE                 "No items"
+
+// ----------------------------------------------------------------------------
+//  Upload screen (src/ui/screens/upload_screen.cpp)
+// ----------------------------------------------------------------------------
+#define D_UPLOAD_HEADER             "Upload"
+#define D_UPLOAD_WIFI               "Wi-Fi"
+#define D_UPLOAD_PASSWORD           "Password"
+#define D_UPLOAD_OPEN               "Open"
+
+// ----------------------------------------------------------------------------
+//  Apps screen (src/ui/screens/apps_screen.cpp)
+// ----------------------------------------------------------------------------
+#define D_APPS_HEADER               "Apps"
+#define D_APPS_NONE                 "No apps installed"
+
+// ----------------------------------------------------------------------------
+//  Bookmarks screens
+//  (src/ui/screens/bookmarks/{book_select_screen,bookmark_list_screen}.cpp)
+// ----------------------------------------------------------------------------
+#define D_BOOKMARKS_HEADER          "Bookmarks"
+#define D_BOOKMARKS_NO_BOOKS        "No books"
+#define D_BOOKMARKS_NONE            "No bookmarks"
+#define D_BOOKMARKS_OPEN_FAILED     "Open failed"
+
+// ----------------------------------------------------------------------------
+//  Reader (src/ui/reader.cpp)
+// ----------------------------------------------------------------------------
+#define D_READER_BOOK_EMPTY         "Book empty"
+#define D_READER_BACK_LIBRARY       "Back to library"
+
+// ----------------------------------------------------------------------------
+//  App loader error overlay (src/ui/pala_api_impl.cpp paintLoadError)
+// ----------------------------------------------------------------------------
+#define D_APP_ERR_TITLE             "App error"
+#define D_APP_ERR_NULL_PATH         "null path"
+#define D_APP_ERR_NOT_FOUND         "App not found"
+#define D_APP_ERR_TOO_SMALL         "App too small"
+#define D_APP_ERR_INVALID_FILE      "Invalid file"
+#define D_APP_ERR_TOO_LARGE         "App too large"
+#define D_APP_ERR_SIZE_LIMIT        "> 48 KB"
+#define D_APP_ERR_READ              "Read error"
+#define D_APP_ERR_PARTIAL_READ      "Partial read"
+#define D_APP_ERR_NO_EXEC_MEM       "No exec memory"
+#define D_APP_ERR_BAD_FILE          "Bad app file"
+#define D_APP_ERR_WRONG_MAGIC       "Wrong magic"
+#define D_APP_ERR_API_MISMATCH      "API mismatch"
+#define D_APP_ERR_API_FMT           "API v%u, need v%u"
+#define D_APP_ERR_BAD_ENTRY         "Bad entry offset"
+#define D_APP_ERR_BAD_RELOC         "Bad reloc table"
+#define D_APP_ERR_RELOC_RANGE       "Reloc out of range"
+
+// ----------------------------------------------------------------------------
+//  Bookmark add toasts (src/pure/bookmarks_codec.cpp)
+//  These are pointers returned from a pure module and rendered via Toast::show
+//  in reader_screen.cpp.
+// ----------------------------------------------------------------------------
+#define D_TOAST_BOOKMARK_EXISTS     "Bookmark exists"
+#define D_TOAST_BOOKMARK_SAVED      "Bookmark saved"
+
+// ============================================================================
+//  Web UI (captive portal) — strings embedded in HTML via adjacent-literal
+//  concatenation. All endpoints declare Content-Type: charset=utf-8 already,
+//  so accented characters survive transit unchanged.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+//  Shared chrome / storage card (src/web/chrome.{h,cpp})
+// ----------------------------------------------------------------------------
+#define D_WEB_STORAGE_HEADING       "Storage"
+#define D_WEB_STORAGE_BOOKS         "Books"
+#define D_WEB_STORAGE_USED          "Used"
+#define D_WEB_STORAGE_FREE          "Free"
+#define D_WEB_STORAGE_TOTAL         "Total"
+#define D_WEB_STORAGE_PCT_SUFFIX    "% of internal storage currently used."
+
+// ----------------------------------------------------------------------------
+//  Navigation links (used across multiple route handlers)
+// ----------------------------------------------------------------------------
+#define D_WEB_NAV_HOME              "Home"
+#define D_WEB_NAV_FILES             "Files"
+#define D_WEB_NAV_BOOKMARKS         "Bookmarks"
+#define D_WEB_NAV_LIST              "List"
+#define D_WEB_NAV_SETTINGS          "Settings"
+#define D_WEB_NAV_FACTORY_RESET     "Factory reset"
+#define D_WEB_NAV_BACK              "Back"
+
+// ----------------------------------------------------------------------------
+//  Home page (src/web/files.cpp handleRoot)
+// ----------------------------------------------------------------------------
+#define D_WEB_HOME_TITLE            "Pala One"
+#define D_WEB_HOME_FW_PREFIX        "Firmware "
+#define D_WEB_HOME_MIDDOT_SEP       " &middot; "
+#define D_WEB_HOME_BOOKS_SUFFIX     " books"
+#define D_WEB_HOME_FREE_LABEL       "Free: "
+#define D_WEB_HOME_STORAGE_WARN     "&#9888; Storage is not available or almost full. If uploads fail, delete books or use Factory reset from this web UI."
+#define D_WEB_UPLOAD_BOOK_HEADING   "Upload book"
+#define D_WEB_UPLOAD_BOOK_DESC      "Send UTF-8 plain text files to <b>/books</b> on the device, then sort them into folders from the Files page."
+#define D_WEB_UPLOAD_BOOK_BUTTON    "Upload"
+#define D_WEB_MANAGE_FILES_BUTTON   "Manage files"
+#define D_WEB_INSTALL_APP_HEADING   "Install app"
+#define D_WEB_INSTALL_APP_DESC      "Upload a Pala app binary (<b>.bin</b>) to <b>/apps</b>. The header is validated before commit; only files with the correct magic and API version are accepted. Open <b>Apps</b> from the library to launch."
+#define D_WEB_INSTALL_APP_BUTTON    "Install app"
+#define D_WEB_NOTES_HEADING         "Notes"
+#define D_WEB_NOTES_DESC            "Uploaded books are normalized and compacted before saving, so a source TXT can be larger than the final stored file. The reader is optimized for UTF-8 plain text and Latin-based languages."
+
+// ----------------------------------------------------------------------------
+//  Files page (src/web/files.cpp handleFiles + folder/move/jump forms)
+// ----------------------------------------------------------------------------
+#define D_WEB_FILES_HEADING         "Files"
+#define D_WEB_FILES_SUBTITLE        "Manage books, folders and library structure for Pala One."
+#define D_WEB_CREATE_FOLDER_HEADING "Create folder"
+#define D_WEB_CREATE_FOLDER_PLACEHOLDER "books or classics/english"
+#define D_WEB_CREATE_FOLDER_BUTTON  "Create folder"
+#define D_WEB_CREATE_FOLDER_HINT    "Folders live inside /books."
+#define D_WEB_FOLDERS_HEADING       "Folders"
+#define D_WEB_NO_FOLDERS            "No folders yet. Books currently live in the root of /books."
+#define D_WEB_CONFIRM_DELETE_FOLDER "Delete folder? Only empty folders can be deleted."
+#define D_WEB_DELETE_BUTTON         "Delete"
+#define D_WEB_LIBRARY_FILES_HEADING "Library files"
+#define D_WEB_LIBRARY_FULL_WARN     "&#9888; Library full (80 books max). Delete books to make room."
+#define D_WEB_FOLDER_LIMIT_WARN     "&#9888; Folder limit reached (32 max)."
+#define D_WEB_NO_BOOKS_UPLOADED     "No books uploaded yet."
+#define D_WEB_BOOK_ROOT             "Root"
+#define D_WEB_BOOK_BYTES_LABEL      " bytes"
+#define D_WEB_BOOK_FOLDER_LABEL     " &middot; folder: "
+#define D_WEB_BOOK_CURRENT_PAGE     " &middot; current page: "
+#define D_WEB_JUMP_BUTTON           "Jump"
+#define D_WEB_JUMP_HINT             "Set the page that should open next on the device."
+#define D_WEB_JUMP_HINT2            "The first open may take a moment."
+#define D_WEB_PAGE_PLACEHOLDER      "Page"
+#define D_WEB_MOVE_BUTTON           "Move"
+#define D_WEB_MOVE_HINT             "Use the exact folder path."
+#define D_WEB_MOVE_PLACEHOLDER      "leave blank for root"
+#define D_WEB_CONFIRM_DELETE_FILE   "Delete file?"
+#define D_WEB_APPS_PAGE_HEADING     "Apps"
+#define D_WEB_NO_APPS_INSTALLED     "No apps installed."
+#define D_WEB_CONFIRM_DELETE_APP    "Delete app?"
+
+// ----------------------------------------------------------------------------
+//  Plain-text 4xx/5xx error bodies (src/web/files.cpp, bookmarks.cpp,
+//  apps_upload.cpp). These reach the browser on misformed requests; they
+//  surface as page content if the user navigates a bad URL.
+// ----------------------------------------------------------------------------
+#define D_WEB_ERR_MISSING_ID            "missing id"
+#define D_WEB_ERR_BAD_ID                "bad id"
+#define D_WEB_ERR_MISSING_FOLDER        "missing folder"
+#define D_WEB_ERR_BAD_FOLDER            "bad folder"
+#define D_WEB_ERR_FOLDER_LIMIT          "folder limit reached"
+#define D_WEB_ERR_MKDIR_FAILED          "mkdir failed"
+#define D_WEB_ERR_FOLDER_NOT_FOUND      "folder not found"
+#define D_WEB_ERR_FOLDER_NOT_EMPTY      "folder not empty"
+#define D_WEB_ERR_DELETE_FAILED         "delete failed"
+#define D_WEB_ERR_FOLDER_CREATE_FAILED  "folder create failed"
+#define D_WEB_ERR_DEST_EXISTS           "destination exists"
+#define D_WEB_ERR_MOVE_FAILED           "move failed"
+#define D_WEB_ERR_MISSING_ID_PAGE       "missing id/page"
+#define D_WEB_ERR_MISSING_BOOK_IDX      "missing book/idx"
+#define D_WEB_ERR_BAD_BOOK              "bad book"
+#define D_WEB_ERR_BAD_IDX               "bad idx"
+#define D_WEB_ERR_MISSING_BOOK          "missing book"
+#define D_WEB_ERR_MISSING_NAME          "missing name"
+#define D_WEB_ERR_INVALID_NAME          "invalid name"
+
+// ----------------------------------------------------------------------------
+//  List page (src/web/list.cpp)
+// ----------------------------------------------------------------------------
+#define D_WEB_LIST_HEADING          "List"
+#define D_WEB_LIST_SUBTITLE         "Create a simple shopping or to-do list for Pala One."
+#define D_WEB_LIST_EDIT_HEADING     "Edit list"
+#define D_WEB_LIST_EDIT_DESC        "Items appear on the device only when at least one line contains text. Hold the button on the device to mark an item as done."
+#define D_WEB_LIST_ITEM_PLACEHOLDER "List item"
+#define D_WEB_LIST_SAVE_BUTTON      "Save list"
+#define D_WEB_LIST_DELETE_DONE      "Delete checked items"
+#define D_WEB_LIST_HINT             "Blank rows are ignored. Checked rows can be removed directly."
+
+// ----------------------------------------------------------------------------
+//  Reset page (src/web/reset.cpp)
+// ----------------------------------------------------------------------------
+#define D_WEB_RESET_HEADING         "Factory Reset"
+#define D_WEB_RESET_SUBTITLE        "Erase all books, bookmarks, progress, and custom assets."
+#define D_WEB_RESET_CONFIRM_HEADING "Confirm reset"
+#define D_WEB_RESET_WARNING         "This will delete ALL books, bookmarks and reading progress."
+#define D_WEB_RESET_DETAIL          "The device filesystem will be formatted and settings will return to defaults."
+#define D_WEB_RESET_YES_BUTTON      "Yes, reset"
+#define D_WEB_RESET_COMPLETE_HEADING "Factory reset complete"
+#define D_WEB_RESET_COMPLETE_DESC   "All books, bookmarks, progress and custom assets were removed. The device is now back to a clean state."
+#define D_WEB_GO_HOME_BUTTON        "Go to home"
+#define D_WEB_OPEN_FILES_BUTTON     "Open files"
+#define D_WEB_RESET_SUCCESS_TITLE   "Reset complete"
+#define D_WEB_RESET_SUCCESS_SUBTITLE "Pala One was reset successfully."
+#define D_WEB_RESET_BANNER          "&#10003; Factory reset complete."
+
+// ----------------------------------------------------------------------------
+//  Settings page (src/web/settings.cpp)
+// ----------------------------------------------------------------------------
+#define D_WEB_SETTINGS_TITLE        "Pala One Settings"
+#define D_WEB_SETTINGS_SUBTITLE_PREFIX "Firmware "
+#define D_WEB_SETTINGS_SUBTITLE_SUFFIX " configuration page stored directly on the device."
+#define D_WEB_SETTINGS_BACK_NAV     "&#8592; Home"
+#define D_WEB_READING_HEADING       "Reading"
+#define D_WEB_FONT_SIZE_LABEL       "Font size"
+#define D_WEB_FONT_SIZE_8           "8px &mdash; tiny"
+#define D_WEB_FONT_SIZE_10          "10px &mdash; small"
+#define D_WEB_FONT_SIZE_12          "12px &mdash; medium"
+#define D_WEB_FONT_SIZE_14          "14px &mdash; large"
+#define D_WEB_FONT_SIZE_HINT        "Controls how many lines fit on each page."
+#define D_WEB_SLEEP_AFTER_LABEL     "Sleep after"
+#define D_WEB_SLEEP_30S             "30 seconds"
+#define D_WEB_SLEEP_1M              "1 minute"
+#define D_WEB_SLEEP_2M              "2 minutes"
+#define D_WEB_SLEEP_5M              "5 minutes"
+#define D_WEB_SLEEP_10M             "10 minutes"
+#define D_WEB_SLEEP_30M             "30 minutes"
+#define D_WEB_SLEEP_HINT            "Auto-sleep keeps battery draw low while idle."
+#define D_WEB_LINE_SPACING_LABEL    "Line spacing"
+#define D_WEB_LINE_SPACING_0        "0 px &mdash; compact"
+#define D_WEB_LINE_SPACING_1        "1 px &mdash; normal"
+#define D_WEB_LINE_SPACING_2        "2 px &mdash; relaxed"
+#define D_WEB_LINE_SPACING_3        "3 px &mdash; loose"
+#define D_WEB_LINE_SPACING_HINT     "A small change here can make text much easier to scan."
+#define D_WEB_SAVE_SETTINGS_BUTTON  "Save settings"
+#define D_WEB_SETTINGS_NO_EXTRAS    "No extra files, scripts, or fonts."
+#define D_WEB_SCREENSAVER_HEADING   "Screensaver"
+#define D_WEB_SCREENSAVER_SPECS     "Upload raw XBM bytes: <b>3904 bytes</b>, 250&times;122 px, 1-bit, LSB-first, 32 bytes per row."
+#define D_WEB_SCREENSAVER_TIP       "Tip: use <a class='link' href='https://javl.github.io/image2cpp/' target='_blank'>image2cpp</a> with <b>Plain bytes</b>. Invert colors if needed."
+#define D_WEB_SCREENSAVER_ACTIVE    "&#10003; Custom screensaver active."
+#define D_WEB_CONFIRM_DEL_SCREENSAVER "Delete custom screensaver?"
+#define D_WEB_SCREENSAVER_DEFAULT   "Using built-in screensaver."
+#define D_WEB_SLEEP_IMAGE_LABEL     "Sleep image file"
+#define D_WEB_SCREENSAVER_UPLOAD_BUTTON "Upload image"
+
+// ----------------------------------------------------------------------------
+//  Upload (book + sleep image) routes (src/web/upload.cpp)
+// ----------------------------------------------------------------------------
+#define D_WEB_UPLOAD_COMPLETE_HEADING "Upload complete"
+#define D_WEB_UPLOAD_COMPLETE_DESC  "Your book is now stored on the device and available in the library."
+#define D_WEB_UPLOAD_BOOK_LABEL     "Book"
+#define D_WEB_UPLOAD_STORED_SIZE    "Stored size"
+#define D_WEB_UPLOAD_BOOKS_NOW      "Books now"
+#define D_WEB_UPLOAD_FREE_SPACE     "Free space"
+#define D_WEB_UPLOAD_ANOTHER        "Upload another"
+#define D_WEB_UPLOAD_BOOK_SAVED     "Book saved successfully."
+#define D_WEB_UPLOAD_FINISHED       "&#10003; Upload finished."
+#define D_WEB_UPLOAD_ERR_FALLBACK   "Upload failed"
+#define D_WEB_ERR_LIBRARY_FULL      "Library full"
+#define D_WEB_ERR_NOT_ENOUGH_SPACE  "Not enough free space"
+#define D_WEB_ERR_CANT_CREATE_TEMP_BOOK "Cannot create temp upload file"
+#define D_WEB_ERR_WRITE_FAILED      "Write failed (out of space?)"
+#define D_WEB_ERR_FINALIZE_UPLOAD   "Failed to finalize upload"
+#define D_WEB_ERR_EMPTY_UPLOAD      "Empty upload"
+#define D_WEB_ERR_UPLOAD_ABORTED    "Upload aborted"
+#define D_WEB_SLEEP_UPLOAD_ERR_FALLBACK "Sleep image upload failed"
+#define D_WEB_SLEEP_UPLOAD_HEADING  "Screensaver updated"
+#define D_WEB_SLEEP_UPLOAD_DESC     "Your custom sleep image was saved successfully and will be shown the next time the device goes to sleep."
+#define D_WEB_BACK_TO_SETTINGS      "Back to settings"
+#define D_WEB_SLEEP_UPLOAD_SUBTITLE "Screensaver saved successfully."
+#define D_WEB_SLEEP_UPLOAD_BANNER   "&#10003; Custom sleep image uploaded."
+#define D_WEB_SLEEP_ERR_TEMP        "Cannot create temp sleep file"
+#define D_WEB_SLEEP_ERR_SIZE        "Sleep image must be exactly 3904 bytes"
+#define D_WEB_SLEEP_ERR_SAVE        "Failed to save sleep image"
+#define D_WEB_SLEEP_ERR_ABORTED     "Sleep image upload aborted"
+
+// ----------------------------------------------------------------------------
+//  App upload route (src/web/apps_upload.cpp)
+// ----------------------------------------------------------------------------
+#define D_WEB_APP_UPLOAD_ERR_FALLBACK "App upload failed"
+#define D_WEB_APP_INSTALLED_HEADING "App installed"
+#define D_WEB_APP_INSTALLED_DESC    "Open the device, scroll the library to <b>Apps</b>, and double-click to launch."
+#define D_WEB_APP_LABEL             "App"
+#define D_WEB_APPS_NOW              "Apps now"
+#define D_WEB_APP_INSTALLED_SUBTITLE "App saved to /apps/."
+#define D_WEB_APP_INSTALLED_BANNER  "&#10003; App ready to run."
+#define D_WEB_APP_VALID_OK          "OK"
+#define D_WEB_APP_VALID_TOO_SMALL   "Invalid app (file too small)"
+#define D_WEB_APP_VALID_BAD_MAGIC   "Invalid app (bad magic)"
+#define D_WEB_APP_VALID_BAD_ENTRY   "Invalid app (bad entry offset)"
+#define D_WEB_APP_VALID_BAD_RELOC   "Invalid app (bad reloc table)"
+#define D_WEB_APP_VALID_API_FMT     "Invalid app (API v%u, need v%u)"
+#define D_WEB_APP_VALID_INVALID     "Invalid app"
+#define D_WEB_APPS_DIR_FULL         "Apps directory full"
+#define D_WEB_ERR_CANT_CREATE_TEMP_APP "Cannot create temp app file"
+#define D_WEB_APP_TOO_LARGE         "App too large (> 48 KB)"
+#define D_WEB_APP_BINARY_TOO_SMALL  "App binary too small"
+#define D_WEB_APP_CANT_READ_HEADER  "Could not read app header"
+#define D_WEB_APP_FINALIZE_FAILED   "Failed to finalize app upload"
+#define D_WEB_APP_UPLOAD_ABORTED    "App upload aborted"
+
+// ----------------------------------------------------------------------------
+//  Bookmarks web page (src/web/bookmarks.cpp)
+// ----------------------------------------------------------------------------
+#define D_WEB_BOOKMARKS_HEADING     "Bookmarks"
+#define D_WEB_BOOKMARKS_SUBTITLE    "Saved reading positions for Pala One, grouped by book."
+#define D_WEB_NO_BOOKS_YET          "No books available yet."
+#define D_WEB_NO_BOOKMARKS_CARD     "No bookmarks"
+#define D_WEB_BOOKMARKS_OPEN_FAILED_CARD "Open failed"
+#define D_WEB_BOOKMARK_PILL_PREFIX  "Bookmark "
+#define D_WEB_BOOKMARK_VIEW         "View"
+#define D_WEB_CONFIRM_DELETE_BOOKMARK "Delete bookmark?"
+#define D_WEB_BOOKMARK_DOWNLOAD_ALL "Download all bookmarks"
+#define D_WEB_BOOKMARK_VIEW_HEADING "Bookmark View"
+#define D_WEB_BOOKMARK_VIEW_SUBTITLE "Preview the saved page text for this bookmark."
+#define D_WEB_BOOKMARK_VIEW_BACK_NAV "&#8592; Back"
+#define D_WEB_BOOKMARK_PAGE_EMPTY   "(empty)"
+#define D_WEB_BOOKMARK_OPEN_FAILED_DOT "Open failed."
+
+// Bookmark export plaintext labels (the .txt file downloads).
+// Separators (==== / ----) stay verbatim and are NOT translated.
+#define D_WEB_BMEXPORT_BOOK         "Book: "
+#define D_WEB_BMEXPORT_BOOKMARKS    "Bookmarks: "
+#define D_WEB_BMEXPORT_BOOKMARK_LBL "Bookmark "
+#define D_WEB_NO_BOOKMARKS_THIS_BOOK "No bookmarks for this book"
+
+#endif  // PALA_LANG_EN_H

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -1,0 +1,350 @@
+#ifndef PALA_LANG_ES_LA_H
+#define PALA_LANG_ES_LA_H
+
+// ============================================================================
+//  Spanish (Latin America) string table — es_LA.
+//  Mirror of en.h; the key set MUST stay identical. Adding new keys: edit en.h
+//  first, then add the same key here. See src/lang/lang.h for the rule.
+//
+//  Glyph coverage: all accents used here (á é í ó ú ñ ¿ ¡ ü) are in u8g2's
+//  Latin Extended (_te) font set already linked by src/ui/font.cpp, so no
+//  font change is required. Web responses already declare charset=utf-8.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+//  Boot / fatal screens
+// ----------------------------------------------------------------------------
+#define D_BOOT_STORAGE_ERROR        "Error de almacenamiento"
+#define D_BOOT_TRY_FACTORY_RESET    "Pruebe reinicio de fábrica"
+
+// ----------------------------------------------------------------------------
+//  About screen
+// ----------------------------------------------------------------------------
+#define D_ABOUT_HEADER              "Dispositivo"
+#define D_ABOUT_FIRMWARE_PREFIX     "Firmware "
+#define D_ABOUT_GESTURE_NEXT        "1x siguiente / abajo"
+#define D_ABOUT_GESTURE_OPEN        "2x abrir / elegir"
+#define D_ABOUT_GESTURE_HOME        "3x inicio"
+#define D_ABOUT_GESTURE_BOOKMARK    "Mantener: marcapáginas"
+
+// ----------------------------------------------------------------------------
+//  Library menu entries
+// ----------------------------------------------------------------------------
+#define D_MENU_BOOKMARKS            "Marcapáginas"
+#define D_MENU_LIST                 "Lista"
+#define D_MENU_APPS                 "Apps"
+#define D_MENU_DEVICE               "Dispositivo"
+#define D_MENU_UPLOAD               "Conectar"
+#define D_LIBRARY_OPEN_FAILED       "Error al abrir"
+#define D_LIBRARY_TRY_UPLOAD        "Intente subir de nuevo"
+
+// ----------------------------------------------------------------------------
+//  List screen
+// ----------------------------------------------------------------------------
+#define D_LIST_HEADER               "Lista"
+#define D_LIST_NONE                 "Sin elementos"
+
+// ----------------------------------------------------------------------------
+//  Upload screen
+// ----------------------------------------------------------------------------
+#define D_UPLOAD_HEADER             "Subir"
+#define D_UPLOAD_WIFI               "Wi-Fi"
+#define D_UPLOAD_PASSWORD           "Contraseña"
+#define D_UPLOAD_OPEN               "Abrir"
+
+// ----------------------------------------------------------------------------
+//  Apps screen
+// ----------------------------------------------------------------------------
+#define D_APPS_HEADER               "Apps"
+#define D_APPS_NONE                 "Sin apps"
+
+// ----------------------------------------------------------------------------
+//  Bookmarks screens
+// ----------------------------------------------------------------------------
+#define D_BOOKMARKS_HEADER          "Marcapáginas"
+#define D_BOOKMARKS_NO_BOOKS        "Sin libros"
+#define D_BOOKMARKS_NONE            "Sin marcapáginas"
+#define D_BOOKMARKS_OPEN_FAILED     "Error al abrir"
+
+// ----------------------------------------------------------------------------
+//  Reader
+// ----------------------------------------------------------------------------
+#define D_READER_BOOK_EMPTY         "Libro vacío"
+#define D_READER_BACK_LIBRARY       "Volver a biblioteca"
+
+// ----------------------------------------------------------------------------
+//  App loader error overlay
+// ----------------------------------------------------------------------------
+#define D_APP_ERR_TITLE             "Error de app"
+#define D_APP_ERR_NULL_PATH         "ruta nula"
+#define D_APP_ERR_NOT_FOUND         "App no encontrada"
+#define D_APP_ERR_TOO_SMALL         "App muy pequeña"
+#define D_APP_ERR_INVALID_FILE      "Archivo inválido"
+#define D_APP_ERR_TOO_LARGE         "App muy grande"
+#define D_APP_ERR_SIZE_LIMIT        "> 48 KB"
+#define D_APP_ERR_READ              "Error de lectura"
+#define D_APP_ERR_PARTIAL_READ      "Lectura parcial"
+#define D_APP_ERR_NO_EXEC_MEM       "Sin memoria ejec."
+#define D_APP_ERR_BAD_FILE          "App inválida"
+#define D_APP_ERR_WRONG_MAGIC       "Firma incorrecta"
+#define D_APP_ERR_API_MISMATCH      "API incompatible"
+#define D_APP_ERR_API_FMT           "API v%u, requiere v%u"
+#define D_APP_ERR_BAD_ENTRY         "Entrada inválida"
+#define D_APP_ERR_BAD_RELOC         "Tabla reloc inválida"
+#define D_APP_ERR_RELOC_RANGE       "Reloc fuera de rango"
+
+// ----------------------------------------------------------------------------
+//  Bookmark add toasts
+// ----------------------------------------------------------------------------
+#define D_TOAST_BOOKMARK_EXISTS     "Marcapáginas ya existe"
+#define D_TOAST_BOOKMARK_SAVED      "Marcapáginas guardado"
+
+// ============================================================================
+//  Web UI
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+//  Shared chrome / storage card
+// ----------------------------------------------------------------------------
+#define D_WEB_STORAGE_HEADING       "Almacenamiento"
+#define D_WEB_STORAGE_BOOKS         "Libros"
+#define D_WEB_STORAGE_USED          "Usado"
+#define D_WEB_STORAGE_FREE          "Libre"
+#define D_WEB_STORAGE_TOTAL         "Total"
+#define D_WEB_STORAGE_PCT_SUFFIX    "% del almacenamiento interno en uso."
+
+// ----------------------------------------------------------------------------
+//  Navigation links
+// ----------------------------------------------------------------------------
+#define D_WEB_NAV_HOME              "Inicio"
+#define D_WEB_NAV_FILES             "Archivos"
+#define D_WEB_NAV_BOOKMARKS         "Marcapáginas"
+#define D_WEB_NAV_LIST              "Lista"
+#define D_WEB_NAV_SETTINGS          "Ajustes"
+#define D_WEB_NAV_FACTORY_RESET     "Reinicio de fábrica"
+#define D_WEB_NAV_BACK              "Atrás"
+
+// ----------------------------------------------------------------------------
+//  Home page
+// ----------------------------------------------------------------------------
+#define D_WEB_HOME_TITLE            "Pala One"
+#define D_WEB_HOME_FW_PREFIX        "Firmware "
+#define D_WEB_HOME_MIDDOT_SEP       " &middot; "
+#define D_WEB_HOME_BOOKS_SUFFIX     " libros"
+#define D_WEB_HOME_FREE_LABEL       "Libre: "
+#define D_WEB_HOME_STORAGE_WARN     "&#9888; Almacenamiento no disponible o casi lleno. Si las subidas fallan, elimine libros o use Reinicio de fábrica desde esta interfaz web."
+#define D_WEB_UPLOAD_BOOK_HEADING   "Subir libro"
+#define D_WEB_UPLOAD_BOOK_DESC      "Envíe archivos UTF-8 de texto plano a <b>/books</b> en el dispositivo, luego organícelos en carpetas desde la página Archivos."
+#define D_WEB_UPLOAD_BOOK_BUTTON    "Subir"
+#define D_WEB_MANAGE_FILES_BUTTON   "Administrar archivos"
+#define D_WEB_INSTALL_APP_HEADING   "Instalar app"
+#define D_WEB_INSTALL_APP_DESC      "Suba un binario de app Pala (<b>.bin</b>) a <b>/apps</b>. El encabezado se valida antes de confirmar; solo se aceptan archivos con la firma y versión de API correctas. Abra <b>Apps</b> desde la biblioteca para ejecutarla."
+#define D_WEB_INSTALL_APP_BUTTON    "Instalar app"
+#define D_WEB_NOTES_HEADING         "Notas"
+#define D_WEB_NOTES_DESC            "Los libros subidos se normalizan y compactan antes de guardarse, por lo que un TXT de origen puede ser más grande que el archivo final almacenado. El lector está optimizado para texto plano UTF-8 e idiomas con alfabeto latino."
+
+// ----------------------------------------------------------------------------
+//  Files page
+// ----------------------------------------------------------------------------
+#define D_WEB_FILES_HEADING         "Archivos"
+#define D_WEB_FILES_SUBTITLE        "Administre libros, carpetas y estructura de la biblioteca de Pala One."
+#define D_WEB_CREATE_FOLDER_HEADING "Crear carpeta"
+#define D_WEB_CREATE_FOLDER_PLACEHOLDER "libros o clasicos/espanol"
+#define D_WEB_CREATE_FOLDER_BUTTON  "Crear carpeta"
+#define D_WEB_CREATE_FOLDER_HINT    "Las carpetas viven dentro de /books."
+#define D_WEB_FOLDERS_HEADING       "Carpetas"
+#define D_WEB_NO_FOLDERS            "Aún no hay carpetas. Los libros viven en la raíz de /books."
+#define D_WEB_CONFIRM_DELETE_FOLDER "¿Eliminar carpeta? Solo se pueden eliminar carpetas vacías."
+#define D_WEB_DELETE_BUTTON         "Eliminar"
+#define D_WEB_LIBRARY_FILES_HEADING "Archivos de biblioteca"
+#define D_WEB_LIBRARY_FULL_WARN     "&#9888; Biblioteca llena (máx. 80 libros). Elimine libros para hacer espacio."
+#define D_WEB_FOLDER_LIMIT_WARN     "&#9888; Límite de carpetas alcanzado (máx. 32)."
+#define D_WEB_NO_BOOKS_UPLOADED     "Aún no se han subido libros."
+#define D_WEB_BOOK_ROOT             "Raíz"
+#define D_WEB_BOOK_BYTES_LABEL      " bytes"
+#define D_WEB_BOOK_FOLDER_LABEL     " &middot; carpeta: "
+#define D_WEB_BOOK_CURRENT_PAGE     " &middot; página actual: "
+#define D_WEB_JUMP_BUTTON           "Ir"
+#define D_WEB_JUMP_HINT             "Establezca la página que se abrirá la próxima vez en el dispositivo."
+#define D_WEB_JUMP_HINT2            "La primera apertura puede tardar un momento."
+#define D_WEB_PAGE_PLACEHOLDER      "Página"
+#define D_WEB_MOVE_BUTTON           "Mover"
+#define D_WEB_MOVE_HINT             "Use la ruta exacta de la carpeta."
+#define D_WEB_MOVE_PLACEHOLDER      "vacío para raíz"
+#define D_WEB_CONFIRM_DELETE_FILE   "¿Eliminar archivo?"
+#define D_WEB_APPS_PAGE_HEADING     "Apps"
+#define D_WEB_NO_APPS_INSTALLED     "Sin apps instaladas."
+#define D_WEB_CONFIRM_DELETE_APP    "¿Eliminar app?"
+
+// ----------------------------------------------------------------------------
+//  Plain-text 4xx/5xx error bodies
+// ----------------------------------------------------------------------------
+#define D_WEB_ERR_MISSING_ID            "id faltante"
+#define D_WEB_ERR_BAD_ID                "id inválido"
+#define D_WEB_ERR_MISSING_FOLDER        "carpeta faltante"
+#define D_WEB_ERR_BAD_FOLDER            "carpeta inválida"
+#define D_WEB_ERR_FOLDER_LIMIT          "límite de carpetas alcanzado"
+#define D_WEB_ERR_MKDIR_FAILED          "fallo al crear carpeta"
+#define D_WEB_ERR_FOLDER_NOT_FOUND      "carpeta no encontrada"
+#define D_WEB_ERR_FOLDER_NOT_EMPTY      "carpeta no vacía"
+#define D_WEB_ERR_DELETE_FAILED         "fallo al eliminar"
+#define D_WEB_ERR_FOLDER_CREATE_FAILED  "fallo al crear carpeta"
+#define D_WEB_ERR_DEST_EXISTS           "destino ya existe"
+#define D_WEB_ERR_MOVE_FAILED           "fallo al mover"
+#define D_WEB_ERR_MISSING_ID_PAGE       "id/página faltante"
+#define D_WEB_ERR_MISSING_BOOK_IDX      "libro/idx faltante"
+#define D_WEB_ERR_BAD_BOOK              "libro inválido"
+#define D_WEB_ERR_BAD_IDX               "idx inválido"
+#define D_WEB_ERR_MISSING_BOOK          "libro faltante"
+#define D_WEB_ERR_MISSING_NAME          "nombre faltante"
+#define D_WEB_ERR_INVALID_NAME          "nombre inválido"
+
+// ----------------------------------------------------------------------------
+//  List page
+// ----------------------------------------------------------------------------
+#define D_WEB_LIST_HEADING          "Lista"
+#define D_WEB_LIST_SUBTITLE         "Cree una lista simple de compras o tareas para Pala One."
+#define D_WEB_LIST_EDIT_HEADING     "Editar lista"
+#define D_WEB_LIST_EDIT_DESC        "Los elementos aparecen en el dispositivo solo cuando al menos una línea contiene texto. Mantenga el botón en el dispositivo para marcar un elemento como hecho."
+#define D_WEB_LIST_ITEM_PLACEHOLDER "Elemento de lista"
+#define D_WEB_LIST_SAVE_BUTTON      "Guardar lista"
+#define D_WEB_LIST_DELETE_DONE      "Eliminar elementos marcados"
+#define D_WEB_LIST_HINT             "Las filas vacías se ignoran. Las filas marcadas se pueden eliminar directamente."
+
+// ----------------------------------------------------------------------------
+//  Reset page
+// ----------------------------------------------------------------------------
+#define D_WEB_RESET_HEADING         "Reinicio de fábrica"
+#define D_WEB_RESET_SUBTITLE        "Borre todos los libros, marcapáginas, progreso y recursos personalizados."
+#define D_WEB_RESET_CONFIRM_HEADING "Confirmar reinicio"
+#define D_WEB_RESET_WARNING         "Esto eliminará TODOS los libros, marcapáginas y progreso de lectura."
+#define D_WEB_RESET_DETAIL          "El sistema de archivos del dispositivo se formateará y los ajustes volverán a los valores predeterminados."
+#define D_WEB_RESET_YES_BUTTON      "Sí, reiniciar"
+#define D_WEB_RESET_COMPLETE_HEADING "Reinicio de fábrica completo"
+#define D_WEB_RESET_COMPLETE_DESC   "Todos los libros, marcapáginas, progreso y recursos personalizados fueron eliminados. El dispositivo está ahora en un estado limpio."
+#define D_WEB_GO_HOME_BUTTON        "Ir al inicio"
+#define D_WEB_OPEN_FILES_BUTTON     "Abrir archivos"
+#define D_WEB_RESET_SUCCESS_TITLE   "Reinicio completo"
+#define D_WEB_RESET_SUCCESS_SUBTITLE "Pala One se reinició con éxito."
+#define D_WEB_RESET_BANNER          "&#10003; Reinicio de fábrica completo."
+
+// ----------------------------------------------------------------------------
+//  Settings page
+// ----------------------------------------------------------------------------
+#define D_WEB_SETTINGS_TITLE        "Ajustes de Pala One"
+#define D_WEB_SETTINGS_SUBTITLE_PREFIX "Firmware "
+#define D_WEB_SETTINGS_SUBTITLE_SUFFIX " — página de configuración almacenada directamente en el dispositivo."
+#define D_WEB_SETTINGS_BACK_NAV     "&#8592; Inicio"
+#define D_WEB_READING_HEADING       "Lectura"
+#define D_WEB_FONT_SIZE_LABEL       "Tamaño de fuente"
+#define D_WEB_FONT_SIZE_8           "8px &mdash; diminuto"
+#define D_WEB_FONT_SIZE_10          "10px &mdash; pequeño"
+#define D_WEB_FONT_SIZE_12          "12px &mdash; mediano"
+#define D_WEB_FONT_SIZE_14          "14px &mdash; grande"
+#define D_WEB_FONT_SIZE_HINT        "Controla cuántas líneas caben en cada página."
+#define D_WEB_SLEEP_AFTER_LABEL     "Suspender después de"
+#define D_WEB_SLEEP_30S             "30 segundos"
+#define D_WEB_SLEEP_1M              "1 minuto"
+#define D_WEB_SLEEP_2M              "2 minutos"
+#define D_WEB_SLEEP_5M              "5 minutos"
+#define D_WEB_SLEEP_10M             "10 minutos"
+#define D_WEB_SLEEP_30M             "30 minutos"
+#define D_WEB_SLEEP_HINT            "La suspensión automática mantiene bajo el consumo de batería en reposo."
+#define D_WEB_LINE_SPACING_LABEL    "Espaciado de línea"
+#define D_WEB_LINE_SPACING_0        "0 px &mdash; compacto"
+#define D_WEB_LINE_SPACING_1        "1 px &mdash; normal"
+#define D_WEB_LINE_SPACING_2        "2 px &mdash; relajado"
+#define D_WEB_LINE_SPACING_3        "3 px &mdash; suelto"
+#define D_WEB_LINE_SPACING_HINT     "Un pequeño cambio aquí puede facilitar mucho la lectura."
+#define D_WEB_SAVE_SETTINGS_BUTTON  "Guardar ajustes"
+#define D_WEB_SETTINGS_NO_EXTRAS    "Sin archivos extra, scripts ni fuentes."
+#define D_WEB_SCREENSAVER_HEADING   "Salvapantallas"
+#define D_WEB_SCREENSAVER_SPECS     "Suba bytes XBM en bruto: <b>3904 bytes</b>, 250&times;122 px, 1 bit, LSB primero, 32 bytes por fila."
+#define D_WEB_SCREENSAVER_TIP       "Consejo: use <a class='link' href='https://javl.github.io/image2cpp/' target='_blank'>image2cpp</a> con <b>Plain bytes</b>. Invierta los colores si es necesario."
+#define D_WEB_SCREENSAVER_ACTIVE    "&#10003; Salvapantallas personalizado activo."
+#define D_WEB_CONFIRM_DEL_SCREENSAVER "¿Eliminar salvapantallas personalizado?"
+#define D_WEB_SCREENSAVER_DEFAULT   "Usando salvapantallas predeterminado."
+#define D_WEB_SLEEP_IMAGE_LABEL     "Archivo de imagen de suspensión"
+#define D_WEB_SCREENSAVER_UPLOAD_BUTTON "Subir imagen"
+
+// ----------------------------------------------------------------------------
+//  Upload routes
+// ----------------------------------------------------------------------------
+#define D_WEB_UPLOAD_COMPLETE_HEADING "Subida completa"
+#define D_WEB_UPLOAD_COMPLETE_DESC  "Su libro está ahora almacenado en el dispositivo y disponible en la biblioteca."
+#define D_WEB_UPLOAD_BOOK_LABEL     "Libro"
+#define D_WEB_UPLOAD_STORED_SIZE    "Tamaño almacenado"
+#define D_WEB_UPLOAD_BOOKS_NOW      "Libros ahora"
+#define D_WEB_UPLOAD_FREE_SPACE     "Espacio libre"
+#define D_WEB_UPLOAD_ANOTHER        "Subir otro"
+#define D_WEB_UPLOAD_BOOK_SAVED     "Libro guardado con éxito."
+#define D_WEB_UPLOAD_FINISHED       "&#10003; Subida finalizada."
+#define D_WEB_UPLOAD_ERR_FALLBACK   "Subida fallida"
+#define D_WEB_ERR_LIBRARY_FULL      "Biblioteca llena"
+#define D_WEB_ERR_NOT_ENOUGH_SPACE  "Espacio insuficiente"
+#define D_WEB_ERR_CANT_CREATE_TEMP_BOOK "No se pudo crear archivo temporal de subida"
+#define D_WEB_ERR_WRITE_FAILED      "Fallo de escritura (¿sin espacio?)"
+#define D_WEB_ERR_FINALIZE_UPLOAD   "Fallo al finalizar la subida"
+#define D_WEB_ERR_EMPTY_UPLOAD      "Subida vacía"
+#define D_WEB_ERR_UPLOAD_ABORTED    "Subida abortada"
+#define D_WEB_SLEEP_UPLOAD_ERR_FALLBACK "Fallo al subir imagen de suspensión"
+#define D_WEB_SLEEP_UPLOAD_HEADING  "Salvapantallas actualizado"
+#define D_WEB_SLEEP_UPLOAD_DESC     "Su imagen de suspensión personalizada se guardó con éxito y se mostrará la próxima vez que el dispositivo se suspenda."
+#define D_WEB_BACK_TO_SETTINGS      "Volver a ajustes"
+#define D_WEB_SLEEP_UPLOAD_SUBTITLE "Salvapantallas guardado con éxito."
+#define D_WEB_SLEEP_UPLOAD_BANNER   "&#10003; Imagen de suspensión personalizada subida."
+#define D_WEB_SLEEP_ERR_TEMP        "No se pudo crear archivo temporal de suspensión"
+#define D_WEB_SLEEP_ERR_SIZE        "La imagen de suspensión debe ser exactamente 3904 bytes"
+#define D_WEB_SLEEP_ERR_SAVE        "Fallo al guardar imagen de suspensión"
+#define D_WEB_SLEEP_ERR_ABORTED     "Subida de imagen de suspensión abortada"
+
+// ----------------------------------------------------------------------------
+//  App upload route
+// ----------------------------------------------------------------------------
+#define D_WEB_APP_UPLOAD_ERR_FALLBACK "Subida de app fallida"
+#define D_WEB_APP_INSTALLED_HEADING "App instalada"
+#define D_WEB_APP_INSTALLED_DESC    "Abra el dispositivo, vaya a <b>Apps</b> en la biblioteca y haga doble clic para ejecutarla."
+#define D_WEB_APP_LABEL             "App"
+#define D_WEB_APPS_NOW              "Apps ahora"
+#define D_WEB_APP_INSTALLED_SUBTITLE "App guardada en /apps/."
+#define D_WEB_APP_INSTALLED_BANNER  "&#10003; App lista para ejecutarse."
+#define D_WEB_APP_VALID_OK          "OK"
+#define D_WEB_APP_VALID_TOO_SMALL   "App inválida (archivo muy pequeño)"
+#define D_WEB_APP_VALID_BAD_MAGIC   "App inválida (firma incorrecta)"
+#define D_WEB_APP_VALID_BAD_ENTRY   "App inválida (entrada inválida)"
+#define D_WEB_APP_VALID_BAD_RELOC   "App inválida (tabla reloc inválida)"
+#define D_WEB_APP_VALID_API_FMT     "App inválida (API v%u, requiere v%u)"
+#define D_WEB_APP_VALID_INVALID     "App inválida"
+#define D_WEB_APPS_DIR_FULL         "Directorio de apps lleno"
+#define D_WEB_ERR_CANT_CREATE_TEMP_APP "No se pudo crear archivo temporal de app"
+#define D_WEB_APP_TOO_LARGE         "App muy grande (> 48 KB)"
+#define D_WEB_APP_BINARY_TOO_SMALL  "Binario de app muy pequeño"
+#define D_WEB_APP_CANT_READ_HEADER  "No se pudo leer el encabezado de la app"
+#define D_WEB_APP_FINALIZE_FAILED   "Fallo al finalizar la subida de la app"
+#define D_WEB_APP_UPLOAD_ABORTED    "Subida de app abortada"
+
+// ----------------------------------------------------------------------------
+//  Bookmarks web page
+// ----------------------------------------------------------------------------
+#define D_WEB_BOOKMARKS_HEADING     "Marcapáginas"
+#define D_WEB_BOOKMARKS_SUBTITLE    "Posiciones de lectura guardadas para Pala One, agrupadas por libro."
+#define D_WEB_NO_BOOKS_YET          "Aún no hay libros disponibles."
+#define D_WEB_NO_BOOKMARKS_CARD     "Sin marcapáginas"
+#define D_WEB_BOOKMARKS_OPEN_FAILED_CARD "Error al abrir"
+#define D_WEB_BOOKMARK_PILL_PREFIX  "Marcapáginas "
+#define D_WEB_BOOKMARK_VIEW         "Ver"
+#define D_WEB_CONFIRM_DELETE_BOOKMARK "¿Eliminar marcapáginas?"
+#define D_WEB_BOOKMARK_DOWNLOAD_ALL "Descargar todos los marcapáginas"
+#define D_WEB_BOOKMARK_VIEW_HEADING "Vista de marcapáginas"
+#define D_WEB_BOOKMARK_VIEW_SUBTITLE "Previsualice el texto de página guardado para este marcapáginas."
+#define D_WEB_BOOKMARK_VIEW_BACK_NAV "&#8592; Atrás"
+#define D_WEB_BOOKMARK_PAGE_EMPTY   "(vacío)"
+#define D_WEB_BOOKMARK_OPEN_FAILED_DOT "Error al abrir."
+
+// Bookmark export plaintext labels
+#define D_WEB_BMEXPORT_BOOK         "Libro: "
+#define D_WEB_BMEXPORT_BOOKMARKS    "Marcapáginas: "
+#define D_WEB_BMEXPORT_BOOKMARK_LBL "Marcapáginas "
+#define D_WEB_NO_BOOKMARKS_THIS_BOOK "Sin marcapáginas para este libro"
+
+#endif  // PALA_LANG_ES_LA_H

--- a/Pala_One_2_1/src/lang/lang.h
+++ b/Pala_One_2_1/src/lang/lang.h
@@ -1,0 +1,49 @@
+#ifndef PALA_LANG_H
+#define PALA_LANG_H
+
+// ============================================================================
+//  Language selector — included transitively via src/config.h, so every
+//  translation unit sees the D_* string-literal macros without an extra
+//  per-file include.
+//
+//  Selection mechanism mirrors src/config.h's BOARD_V1_X / DISPLAY_V1_X
+//  pattern: a single LANG_* build flag picks one per-language header.
+//    PlatformIO: -D LANG_EN / -D LANG_ES_LA in build_flags.
+//    Arduino IDE: uncomment LANG_EN or LANG_ES_LA in Pala_One_2_1.ino.
+//
+//  All D_* values are plain string-literal #defines. Adjacent string-literal
+//  concatenation is exploited at call sites, e.g.
+//    out += "<h2>" D_WEB_FILES_HEADING "</h2>";
+//  The compiler folds these into a single literal — zero runtime cost.
+//
+//  Authoring rule:
+//    1. Add new keys to en.h FIRST. Then mirror them in es_la.h.
+//    2. The key set across en.h and es_la.h MUST stay in sync — a missing
+//       key in es_la.h produces a "use of undeclared identifier" against the
+//       Spanish build.
+//    3. Preserve %u / %d / %s placeholders verbatim across languages.
+//    4. HTML entities (&middot; &mdash; &#10003; &#9888; &times; &#8592;)
+//       and tags (<b> </b>) survive intact across translations.
+//    5. D_WEB_CONFIRM_* strings are inlined inside JS confirm('...') calls in
+//       HTML onclick attributes. They MUST NOT contain a single quote (') or
+//       backslash (\) — either breaks attribute parsing and the destructive
+//       form submits without prompting the user. If a translation needs a
+//       contraction, rephrase or use a different punctuation mark.
+// ============================================================================
+
+// Default to English when nothing was picked. Lives here (not in config.h) so
+// that any TU which reaches lang.h before config.h — e.g. via src/web/chrome.h
+// — still gets the fallback. Removing this block re-enables a hard #error
+// when neither LANG_* is set.
+#if !defined(LANG_EN) && !defined(LANG_ES_LA)
+  #pragma message ("No LANG_* selected; defaulting to LANG_EN. Pick LANG_EN or LANG_ES_LA explicitly to silence this.")
+  #define LANG_EN
+#endif
+
+#if defined(LANG_ES_LA)
+  #include "src/lang/es_la.h"
+#elif defined(LANG_EN)
+  #include "src/lang/en.h"
+#endif
+
+#endif  // PALA_LANG_H

--- a/Pala_One_2_1/src/pure/arduino_compat.h
+++ b/Pala_One_2_1/src/pure/arduino_compat.h
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <ostream>   // operator<<(std::ostream&, const String&) below
+#include <ostream>
 #include <string>
 
 // Minimal Arduino `String` shim. Only the methods used by the pure modules

--- a/Pala_One_2_1/src/pure/arduino_compat.h
+++ b/Pala_One_2_1/src/pure/arduino_compat.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <ostream>   // operator<<(std::ostream&, const String&) below
 #include <string>
 
 // Minimal Arduino `String` shim. Only the methods used by the pure modules

--- a/Pala_One_2_1/src/pure/bookmarks_codec.cpp
+++ b/Pala_One_2_1/src/pure/bookmarks_codec.cpp
@@ -52,7 +52,7 @@ size_t encodeBookmarks(const Bookmarks& bm, uint8_t* outBuf) {
 
 BookmarkAddResult addBookmark(Bookmarks& bm, uint16_t page, uint32_t offset) {
   for (uint8_t i = 0; i < bm.count; i++) {
-    if (bm.pages[i] == page) return {false, "Bookmark exists"};
+    if (bm.pages[i] == page) return {false, D_TOAST_BOOKMARK_EXISTS};
   }
 
   if (bm.count < MAX_BOOKMARKS) {
@@ -84,5 +84,5 @@ BookmarkAddResult addBookmark(Bookmarks& bm, uint16_t page, uint32_t offset) {
     }
   }
 
-  return {true, "Bookmark saved"};
+  return {true, D_TOAST_BOOKMARK_SAVED};
 }

--- a/Pala_One_2_1/src/ui/font.cpp
+++ b/Pala_One_2_1/src/ui/font.cpp
@@ -12,8 +12,11 @@ namespace Font {
 // role accessors (useBody, useBold, ...).
 static const uint8_t* s_body    = u8g2_font_helvR08_te;
 static const uint8_t* s_bold    = u8g2_font_helvB08_te;
+// _tf = ASCII only. Translated strings must NOT use these — see font.h.
 static const uint8_t* s_uiSmall = u8g2_font_6x10_tf;
 static const uint8_t* s_uiTiny  = u8g2_font_5x8_tf;
+// _te = Latin Extended. Used by toasts so translations with accents render.
+static const uint8_t* s_toast   = u8g2_font_helvR08_te;
 
 // Owned settings. `s_size` mirrors which Helvetica size is currently active;
 // `s_lineGap` is the user-configurable extra spacing between body lines.
@@ -55,6 +58,7 @@ static void applyLineGap(int gap) {
 
 void useBody()     { u8g2.setFont(s_body); }
 void useBold()     { u8g2.setFont(s_bold); }
+void useToast()    { u8g2.setFont(s_toast); }
 void useUiSmall()  { u8g2.setFont(s_uiSmall); }
 void useUiTiny()   { u8g2.setFont(s_uiTiny); }
 void useAppLarge() { u8g2.setFont(u8g2_font_helvB14_te); }

--- a/Pala_One_2_1/src/ui/font.h
+++ b/Pala_One_2_1/src/ui/font.h
@@ -11,11 +11,19 @@
 //  Roles:
 //    Body / Bold   Helvetica regular/bold at the user-chosen body size
 //                  (8/10/12/14). Reader text, menu rows, section headers.
-//    UiSmall       Fixed 6x10. Toast text + battery percentage.
-//    UiTiny        Fixed 5x8.  Page number in the reader status bar.
+//    Toast         Helvetica regular 8 — Latin Extended (accent-capable);
+//                  used for toast text where translated strings may carry
+//                  á é í ó ú ñ ¿ ¡ ü.
+//    UiSmall       Fixed 6x10 (ASCII only). Battery percentage — digits/% only.
+//    UiTiny        Fixed 5x8  (ASCII only). Page number in the status bar.
 //
 //  Roles, not tables: nothing outside font.cpp references u8g2 font
 //  identifiers directly. Adding/changing a font is a one-file change.
+//
+//  Glyph coverage: UiSmall / UiTiny tables are _tf (ASCII printable only).
+//  Do NOT route translated user-visible strings through them — they will
+//  render missing-glyph boxes for any accent. Use Toast (or Body/Bold) for
+//  anything that could contain a translation.
 // ============================================================================
 namespace Font {
 
@@ -23,6 +31,7 @@ namespace Font {
 // u8g2 calls (setCursor/print/getUTF8Width) all use the role's table.
 void useBody();
 void useBold();
+void useToast();
 void useUiSmall();
 void useUiTiny();
 

--- a/Pala_One_2_1/src/ui/pala_api_impl.cpp
+++ b/Pala_One_2_1/src/ui/pala_api_impl.cpp
@@ -193,7 +193,7 @@ static void paintLoadError(const char* line1, const char* line2 = nullptr) {
 
 void runApp(const char* path) {
   if (!path) {
-    paintLoadError("App error", "null path");
+    paintLoadError(D_APP_ERR_TITLE, D_APP_ERR_NULL_PATH);
     return;
   }
   uint32_t fileApiVer = 0;
@@ -203,38 +203,41 @@ void runApp(const char* path) {
       // App ran to completion. AppsScreen will repaint itself on return.
       return;
     case LoadResult::FileNotFound:
-      paintLoadError("App not found", path);
+      paintLoadError(D_APP_ERR_NOT_FOUND, path);
       return;
     case LoadResult::FileTooSmall:
-      paintLoadError("App too small", "Invalid file");
+      paintLoadError(D_APP_ERR_TOO_SMALL, D_APP_ERR_INVALID_FILE);
       return;
     case LoadResult::FileTooLarge:
-      paintLoadError("App too large", "> 48 KB");
+      paintLoadError(D_APP_ERR_TOO_LARGE, D_APP_ERR_SIZE_LIMIT);
       return;
     case LoadResult::ReadError:
-      paintLoadError("Read error", "Partial read");
+      paintLoadError(D_APP_ERR_READ, D_APP_ERR_PARTIAL_READ);
       return;
     case LoadResult::OutOfMemory:
-      paintLoadError("No exec memory", nullptr);
+      paintLoadError(D_APP_ERR_NO_EXEC_MEM, nullptr);
       return;
     case LoadResult::BadMagic:
-      paintLoadError("Bad app file", "Wrong magic");
+      paintLoadError(D_APP_ERR_BAD_FILE, D_APP_ERR_WRONG_MAGIC);
       return;
     case LoadResult::ApiMismatch: {
-      char msg[32];
-      snprintf(msg, sizeof(msg), "API v%u, need v%u",
+      // 64 to match the upload-side buffer in web/apps_upload.cpp. Worst-case
+      // current expansion ("API v4294967295, requiere v4294967295") = 38 bytes;
+      // keeps room for translation/format changes without re-validating here.
+      char msg[64];
+      snprintf(msg, sizeof(msg), D_APP_ERR_API_FMT,
                (unsigned)fileApiVer, (unsigned)PALA_API_VERSION);
-      paintLoadError("API mismatch", msg);
+      paintLoadError(D_APP_ERR_API_MISMATCH, msg);
       return;
     }
     case LoadResult::BadEntryOffset:
-      paintLoadError("Bad entry offset", nullptr);
+      paintLoadError(D_APP_ERR_BAD_ENTRY, nullptr);
       return;
     case LoadResult::BadRelocTable:
-      paintLoadError("Bad reloc table", nullptr);
+      paintLoadError(D_APP_ERR_BAD_RELOC, nullptr);
       return;
     case LoadResult::BadRelocEntry:
-      paintLoadError("Reloc out of range", nullptr);
+      paintLoadError(D_APP_ERR_RELOC_RANGE, nullptr);
       return;
   }
 }

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -253,7 +253,7 @@ void renderCurrentPage() {
   // Strong invariant: if we got here, a book is open. The reader screen
   // is never active otherwise.
   if (!prepareForRender()) {
-    drawCenter("Book empty", "Back to library");
+    drawCenter(D_READER_BOOK_EMPTY, D_READER_BACK_LIBRARY);
     navigateToLibraryRoot();
     return;
   }

--- a/Pala_One_2_1/src/ui/screens/about_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/about_screen.cpp
@@ -14,14 +14,14 @@ void AboutScreen::draw() {
   Font::useBody();
   int ascent = u8g2.getFontAscent();
   int lineH = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 1;
-  int y = drawSectionHeader("Device");
+  int y = drawSectionHeader(D_ABOUT_HEADER);
 
   String rows[5] = {
-    "Firmware " FW_BUILD,
-    "1x next / down",
-    "2x open / select",
-    "3x home",
-    "Hold bookmark"
+    D_ABOUT_FIRMWARE_PREFIX FW_BUILD,
+    D_ABOUT_GESTURE_NEXT,
+    D_ABOUT_GESTURE_OPEN,
+    D_ABOUT_GESTURE_HOME,
+    D_ABOUT_GESTURE_BOOKMARK
   };
 
   for (int i = 0; i < 5; i++) {

--- a/Pala_One_2_1/src/ui/screens/apps_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/apps_screen.cpp
@@ -23,10 +23,10 @@ void AppsScreen::onEnter() {
 void AppsScreen::draw() {
   prepareMenuFrame();
   Font::useBody();
-  int y = drawSectionHeader("Apps");
+  int y = drawSectionHeader(D_APPS_HEADER);
 
   if (g_apps.count == 0) {
-    drawMenuRow(y, "No apps installed", false);
+    drawMenuRow(y, D_APPS_NONE, false);
     display.update();
     return;
   }

--- a/Pala_One_2_1/src/ui/screens/bookmarks/book_select_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/bookmarks/book_select_screen.cpp
@@ -15,10 +15,10 @@ void BookmarkBookSelectScreen::onEnter() {
 void BookmarkBookSelectScreen::draw() {
   prepareMenuFrame();
   Font::useBody();
-  int y = drawSectionHeader("Bookmarks");
+  int y = drawSectionHeader(D_BOOKMARKS_HEADER);
 
   if (g_library.bookCount == 0) {
-    drawMenuRow(y, "No books", false);
+    drawMenuRow(y, D_BOOKMARKS_NO_BOOKS, false);
     display.update();
     return;
   }

--- a/Pala_One_2_1/src/ui/screens/bookmarks/bookmark_list_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/bookmarks/bookmark_list_screen.cpp
@@ -20,7 +20,7 @@ void BookmarkListScreen::onEnter() {
 void BookmarkListScreen::draw() {
   prepareMenuFrame();
   Font::useBody();
-  int y = drawSectionHeader("Bookmarks");
+  int y = drawSectionHeader(D_BOOKMARKS_HEADER);
 
   String bookPath = String(g_library.books[g_bookmarkSession.bookIndex].path);
   String key = prefKeyForBook(bookPath);
@@ -29,14 +29,14 @@ void BookmarkListScreen::draw() {
     g_bookmarkSession.selectedIndex = max(0, (int)g_bookmarkSession.count - 1);
 
   if (g_bookmarkSession.count == 0) {
-    drawMenuRow(y, "No bookmarks", false);
+    drawMenuRow(y, D_BOOKMARKS_NONE, false);
     display.update();
     return;
   }
 
   File f = FS.open(bookPath, "r");
   if (!f) {
-    drawMenuRow(y, "Open failed", false);
+    drawMenuRow(y, D_BOOKMARKS_OPEN_FAILED, false);
     display.update();
     return;
   }

--- a/Pala_One_2_1/src/ui/screens/library_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/library_screen.cpp
@@ -120,11 +120,11 @@ static String entryLabel(const LibEntry& e) {
       return prefix + folderLeafLabel(String(g_library.folders[e.ref]));
     }
     case LIB_ENTRY_BOOK:      return bookLeafLabel(String(g_library.books[e.ref].path));
-    case LIB_ENTRY_BOOKMARKS: return "Bookmarks";
-    case LIB_ENTRY_LIST:      return "List";
-    case LIB_ENTRY_APPS:      return "Apps";
-    case LIB_ENTRY_ABOUT:     return "Device";
-    case LIB_ENTRY_UPLOAD:    return "Upload";
+    case LIB_ENTRY_BOOKMARKS: return D_MENU_BOOKMARKS;
+    case LIB_ENTRY_LIST:      return D_MENU_LIST;
+    case LIB_ENTRY_APPS:      return D_MENU_APPS;
+    case LIB_ENTRY_ABOUT:     return D_MENU_DEVICE;
+    case LIB_ENTRY_UPLOAD:    return D_MENU_UPLOAD;
   }
   return "";
 }
@@ -216,7 +216,7 @@ void LibraryScreen::onButton(const ButtonEvent& e) {
     if (openBookByIndex(sel.ref)) {
       nextScreen = &g_readerScreen;
     } else {
-      drawCenter("Open failed", "Try upload again");
+      drawCenter(D_LIBRARY_OPEN_FAILED, D_LIBRARY_TRY_UPLOAD);
       draw();
     }
     return;

--- a/Pala_One_2_1/src/ui/screens/list_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/list_screen.cpp
@@ -13,10 +13,10 @@ void ListScreen::onEnter() {
 void ListScreen::draw() {
   prepareMenuFrame();
   Font::useBody();
-  int y = drawSectionHeader("List");
+  int y = drawSectionHeader(D_LIST_HEADER);
 
   if (!listHasVisibleItems()) {
-    drawMenuRow(y, "No items", false);
+    drawMenuRow(y, D_LIST_NONE, false);
     display.update();
     return;
   }

--- a/Pala_One_2_1/src/ui/screens/upload_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/upload_screen.cpp
@@ -18,11 +18,11 @@ void UploadScreen::onEnter() {
 void UploadScreen::draw() {
   prepareMenuFrame();
 
-  int y = drawSectionHeader("Upload");
+  int y = drawSectionHeader(D_UPLOAD_HEADER);
 
   Font::useBold();
   u8g2.setCursor(MARGIN_X, y);
-  u8g2.print("Wi-Fi");
+  u8g2.print(D_UPLOAD_WIFI);
   y += 14;
 
   Font::useBody();
@@ -32,7 +32,7 @@ void UploadScreen::draw() {
 
   Font::useBold();
   u8g2.setCursor(MARGIN_X, y);
-  u8g2.print("Password");
+  u8g2.print(D_UPLOAD_PASSWORD);
   y += 14;
 
   Font::useBody();
@@ -42,7 +42,7 @@ void UploadScreen::draw() {
 
   Font::useBold();
   u8g2.setCursor(MARGIN_X, y);
-  u8g2.print("Open");
+  u8g2.print(D_UPLOAD_OPEN);
   y += 14;
 
   Font::useBody();

--- a/Pala_One_2_1/src/ui/toast.cpp
+++ b/Pala_One_2_1/src/ui/toast.cpp
@@ -41,7 +41,7 @@ void draw() {
   const int yTop = SCREEN_H - STATUS_H;
   gfx.fillRect(0, yTop, SCREEN_W, STATUS_H, 0);
 
-  Font::useUiSmall();
+  Font::useToast();   // Latin Extended — translated strings may carry accents
   int textY = SCREEN_H - 1;
   u8g2.setCursor(MARGIN_X, textY);
   u8g2.print(s_msg.c_str());

--- a/Pala_One_2_1/src/web/apps_upload.cpp
+++ b/Pala_One_2_1/src/web/apps_upload.cpp
@@ -49,7 +49,7 @@ static void handleUploadAppDone() {
   AppUpload& s = s_app;
   if (!s.ok) {
     server.send(400, "text/plain; charset=utf-8",
-                s.error.length() ? s.error : String("App upload failed"));
+                s.error.length() ? s.error : String(D_WEB_APP_UPLOAD_ERR_FALLBACK));
     return;
   }
 
@@ -62,20 +62,20 @@ static void handleUploadAppDone() {
 
   String inner;
   inner.reserve(900);
-  inner += "<div class='card'><h2>App installed</h2>";
-  inner += "<p class='muted'>Open the device, scroll the library to <b>Apps</b>, and double-click to launch.</p>";
+  inner += "<div class='card'><h2>" D_WEB_APP_INSTALLED_HEADING "</h2>";
+  inner += "<p class='muted'>" D_WEB_APP_INSTALLED_DESC "</p>";
   inner += "<div class='stats'>";
-  inner += "<div class='stat'><span class='muted'>App</span><b>"        + htmlEscape(s.finalName)      + "</b></div>";
-  inner += "<div class='stat'><span class='muted'>Stored size</span><b>"+ humanBytes(storedSize)        + "</b></div>";
-  inner += "<div class='stat'><span class='muted'>Apps now</span><b>"   + String(g_apps.count)          + "</b></div>";
-  inner += "<div class='stat'><span class='muted'>Free space</span><b>" + humanBytes(fsFreeBytesSafe()) + "</b></div>";
-  inner += "</div><div class='actions'><a class='btn' href='/'>Upload another</a></div></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_APP_LABEL          "</span><b>" + htmlEscape(s.finalName)      + "</b></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_UPLOAD_STORED_SIZE "</span><b>" + humanBytes(storedSize)        + "</b></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_APPS_NOW           "</span><b>" + String(g_apps.count)          + "</b></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_UPLOAD_FREE_SPACE  "</span><b>" + humanBytes(fsFreeBytesSafe()) + "</b></div>";
+  inner += "</div><div class='actions'><a class='btn' href='/'>" D_WEB_UPLOAD_ANOTHER "</a></div></div>";
   inner += storageCardHtml();
 
   String page = successPage(
-    "App installed",
-    "App saved to /apps/.",
-    "&#10003; App ready to run.",
+    D_WEB_APP_INSTALLED_HEADING,
+    D_WEB_APP_INSTALLED_SUBTITLE,
+    D_WEB_APP_INSTALLED_BANNER,
     inner
   );
   server.send(200, "text/html; charset=utf-8", page);
@@ -85,19 +85,19 @@ static void handleUploadAppDone() {
 // runApp switch in ui/pala_api_impl.cpp; lives here so the upload route
 // can present the same diagnostics at install time.
 static const char* validationErrorMessage(AppHeaderStatus s, uint32_t fileApiVer) {
-  static char buf[48];
+  static char buf[64];
   switch (s) {
-    case AppHeaderStatus::Ok:             return "OK";
-    case AppHeaderStatus::TooSmall:       return "Invalid app (file too small)";
-    case AppHeaderStatus::BadMagic:       return "Invalid app (bad magic)";
-    case AppHeaderStatus::BadEntryOffset: return "Invalid app (bad entry offset)";
-    case AppHeaderStatus::BadRelocTable:  return "Invalid app (bad reloc table)";
+    case AppHeaderStatus::Ok:             return D_WEB_APP_VALID_OK;
+    case AppHeaderStatus::TooSmall:       return D_WEB_APP_VALID_TOO_SMALL;
+    case AppHeaderStatus::BadMagic:       return D_WEB_APP_VALID_BAD_MAGIC;
+    case AppHeaderStatus::BadEntryOffset: return D_WEB_APP_VALID_BAD_ENTRY;
+    case AppHeaderStatus::BadRelocTable:  return D_WEB_APP_VALID_BAD_RELOC;
     case AppHeaderStatus::ApiMismatch:
-      snprintf(buf, sizeof(buf), "Invalid app (API v%u, need v%u)",
+      snprintf(buf, sizeof(buf), D_WEB_APP_VALID_API_FMT,
                (unsigned)fileApiVer, (unsigned)PALA_API_VERSION);
       return buf;
   }
-  return "Invalid app";
+  return D_WEB_APP_VALID_INVALID;
 }
 
 static void handleUploadAppStream() {
@@ -113,7 +113,7 @@ static void handleUploadAppStream() {
     // Defensive — protects MAX_APPS check from a stale catalog.
     loadApps();
     if (g_apps.count >= MAX_APPS) {
-      s.error = "Apps directory full";
+      s.error = D_WEB_APPS_DIR_FULL;
       return;
     }
 
@@ -122,7 +122,7 @@ static void handleUploadAppStream() {
     // MAX_APP_BINARY. Lets us fail fast if storage is nearly full
     // rather than burning the whole transfer.
     if (fsFreeBytesSafe() < MAX_APP_BINARY) {
-      s.error = "Not enough free space";
+      s.error = D_WEB_ERR_NOT_ENOUGH_SPACE;
       return;
     }
 
@@ -136,7 +136,7 @@ static void handleUploadAppStream() {
     if (FS.exists(s.tmpPath)) FS.remove(s.tmpPath);
     s.tmpFile = FS.open(s.tmpPath, "w");
     if (!s.tmpFile) {
-      s.error = "Cannot create temp app file";
+      s.error = D_WEB_ERR_CANT_CREATE_TEMP_APP;
       s.tmpPath = "";
     }
   }
@@ -150,7 +150,7 @@ static void handleUploadAppStream() {
       s.tmpFile.close();
       if (FS.exists(s.tmpPath)) FS.remove(s.tmpPath);
       s.tmpPath = "";
-      s.error = "App too large (> 48 KB)";
+      s.error = D_WEB_APP_TOO_LARGE;
       return;
     }
     s.tmpFile.write(up.buf, up.currentSize);
@@ -161,7 +161,7 @@ static void handleUploadAppStream() {
 
     if (up.totalSize < sizeof(PalaAppHeader) + 4) {
       if (FS.exists(s.tmpPath)) FS.remove(s.tmpPath);
-      s.error = "App binary too small";
+      s.error = D_WEB_APP_BINARY_TOO_SMALL;
       s.tmpPath = "";
       return;
     }
@@ -178,7 +178,7 @@ static void handleUploadAppStream() {
     }
     if (!readOk) {
       if (FS.exists(s.tmpPath)) FS.remove(s.tmpPath);
-      s.error = "Could not read app header";
+      s.error = D_WEB_APP_CANT_READ_HEADER;
       s.tmpPath = "";
       return;
     }
@@ -202,7 +202,7 @@ static void handleUploadAppStream() {
       s.ok = true;
     } else {
       if (FS.exists(s.tmpPath)) FS.remove(s.tmpPath);
-      s.error = "Failed to finalize app upload";
+      s.error = D_WEB_APP_FINALIZE_FAILED;
     }
     s.tmpPath = "";
   }
@@ -211,18 +211,18 @@ static void handleUploadAppStream() {
     if (s.tmpPath.length() > 0 && FS.exists(s.tmpPath)) FS.remove(s.tmpPath);
     s.tmpPath = "";
     s.ok = false;
-    s.error = "App upload aborted";
+    s.error = D_WEB_APP_UPLOAD_ABORTED;
   }
 }
 
 static void handleDeleteApp() {
   if (!server.hasArg("name")) {
-    server.send(400, "text/plain; charset=utf-8", "missing name");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_NAME);
     return;
   }
   String name = server.arg("name");
   if (name.indexOf('/') >= 0 || name.indexOf('\\') >= 0 || !name.endsWith(".bin")) {
-    server.send(400, "text/plain; charset=utf-8", "invalid name");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_INVALID_NAME);
     return;
   }
   String path = String("/apps/") + name;

--- a/Pala_One_2_1/src/web/bookmarks.cpp
+++ b/Pala_One_2_1/src/web/bookmarks.cpp
@@ -16,26 +16,26 @@
 // strings are user-facing for this download flow).
 static String readPageTextForWeb(const String& path, int page) {
   File f = FS.open(path, "r");
-  if (!f) return String("Open failed.");
+  if (!f) return String(D_WEB_BOOKMARK_OPEN_FAILED_DOT);
   uint32_t off = pageOffsetForPage(f, path, page);
   String out;
   out.reserve(900);
   (void)extractPageText(f, off, out);
   f.close();
   out.trim();
-  if (out.length() == 0) out = "(empty)";
+  if (out.length() == 0) out = D_WEB_BOOKMARK_PAGE_EMPTY;
   return out;
 }
 
 static void handleBookmarksWeb() {
   String out = webPageStart(
-    "Bookmarks",
-    "Saved reading positions for Pala One, grouped by book.",
-    "<a href='/'>Home</a><a href='/files'>Files</a><a href='/settings'>Settings</a>",
+    D_WEB_BOOKMARKS_HEADING,
+    D_WEB_BOOKMARKS_SUBTITLE,
+    "<a href='/'>" D_WEB_NAV_HOME "</a><a href='/files'>" D_WEB_NAV_FILES "</a><a href='/settings'>" D_WEB_NAV_SETTINGS "</a>",
     true
   );
 
-  if (g_library.bookCount == 0) out += "<div class='card'><p class='muted'>No books available yet.</p></div>";
+  if (g_library.bookCount == 0) out += "<div class='card'><p class='muted'>" D_WEB_NO_BOOKS_YET "</p></div>";
 
   for (int i = 0; i < g_library.bookCount; i++) {
     String bookPath = String(g_library.books[i].path);
@@ -49,13 +49,13 @@ static void handleBookmarksWeb() {
     out += "</h2>";
 
     if (count == 0) {
-      out += "<p class='muted'>No bookmarks</p></div>";
+      out += "<p class='muted'>" D_WEB_NO_BOOKMARKS_CARD "</p></div>";
       continue;
     }
 
     File f = FS.open(bookPath, "r");
     if (!f) {
-      out += "<p class='muted'>Open failed</p></div>";
+      out += "<p class='muted'>" D_WEB_BOOKMARKS_OPEN_FAILED_CARD "</p></div>";
       continue;
     }
 
@@ -68,19 +68,19 @@ static void handleBookmarksWeb() {
       uint32_t pageOff = resolveBookmarkOffset(bookPath, (uint16_t)targetPage, offsets[j]);
       FileReadStream fs(f);
       String sn = readBookmarkLabelAtOffset(fs, pageOff, targetPage);
-      out += "<li><div class='row'><div><div class='pill'>Bookmark ";
+      out += "<li><div class='row'><div><div class='pill'>" D_WEB_BOOKMARK_PILL_PREFIX;
       out += String(j + 1);
       out += "</div><p class='meta' style='margin-top:8px'>";
       out += htmlEscape(sn);
-      out += "</p></div><div><a class='link' href='/viewbm?book=" + String(i) + "&idx=" + String(j) + "'>View</a> | ";
+      out += "</p></div><div><a class='link' href='/viewbm?book=" + String(i) + "&idx=" + String(j) + "'>" D_WEB_BOOKMARK_VIEW "</a> | ";
       out += "<form method='POST' action='/delbm' style='display:inline'>";
       out += "<input type='hidden' name='book' value='" + String(i) + "'>";
       out += "<input type='hidden' name='idx' value='" + String(j) + "'>";
-      out += "<button type='submit' class='btn secondary' style='padding:4px 8px;font-size:13px' onclick=\"return confirm('Delete bookmark?')\">Delete</button>";
+      out += "<button type='submit' class='btn secondary' style='padding:4px 8px;font-size:13px' onclick=\"return confirm('" D_WEB_CONFIRM_DELETE_BOOKMARK "')\">" D_WEB_DELETE_BUTTON "</button>";
       out += "</form></div></div></li>";
     }
 
-    out += "</ul><div class='actions'><a class='btn secondary' href='/exportbm?book=" + String(i) + "'>Download all bookmarks</a></div></div>";
+    out += "</ul><div class='actions'><a class='btn secondary' href='/exportbm?book=" + String(i) + "'>" D_WEB_BOOKMARK_DOWNLOAD_ALL "</a></div></div>";
     f.close();
   }
 
@@ -90,14 +90,14 @@ static void handleBookmarksWeb() {
 
 static void handleDeleteBookmarkWeb() {
   if (!server.hasArg("book") || !server.hasArg("idx")) {
-    server.send(400, "text/plain; charset=utf-8", "missing book/idx");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_BOOK_IDX);
     return;
   }
 
   int b   = server.arg("book").toInt();
   int idx = server.arg("idx").toInt();
   if (b < 0 || b >= g_library.bookCount) {
-    server.send(400, "text/plain; charset=utf-8", "bad book");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_BOOK);
     return;
   }
 
@@ -106,7 +106,7 @@ static void handleDeleteBookmarkWeb() {
   uint32_t offsets[MAX_BOOKMARKS];
   uint8_t count = loadBookmarksForKey(key, pages, offsets);
   if (idx < 0 || idx >= count) {
-    server.send(400, "text/plain; charset=utf-8", "bad idx");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_IDX);
     return;
   }
 
@@ -123,14 +123,14 @@ static void handleDeleteBookmarkWeb() {
 
 static void handleViewBookmarkWeb() {
   if (!server.hasArg("book") || !server.hasArg("idx")) {
-    server.send(400, "text/plain; charset=utf-8", "missing book/idx");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_BOOK_IDX);
     return;
   }
 
   int b   = server.arg("book").toInt();
   int idx = server.arg("idx").toInt();
   if (b < 0 || b >= g_library.bookCount) {
-    server.send(400, "text/plain; charset=utf-8", "bad book");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_BOOK);
     return;
   }
 
@@ -139,7 +139,7 @@ static void handleViewBookmarkWeb() {
   uint32_t offsets[MAX_BOOKMARKS];
   uint8_t count = loadBookmarksForKey(key, pages, offsets);
   if (idx < 0 || idx >= count) {
-    server.send(400, "text/plain; charset=utf-8", "bad idx");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_IDX);
     return;
   }
 
@@ -148,42 +148,42 @@ static void handleViewBookmarkWeb() {
   File vf = FS.open(bookPath, "r");
   String txt;
   if (!vf) {
-    txt = "Open failed.";
+    txt = D_WEB_BOOKMARK_OPEN_FAILED_DOT;
   } else {
     uint32_t off = resolveBookmarkOffset(bookPath, (uint16_t)page, offsets[idx]);
     txt.reserve(900);
     (void)extractPageText(vf, off, txt);
     vf.close();
     txt.trim();
-    if (txt.length() == 0) txt = "(empty)";
+    if (txt.length() == 0) txt = D_WEB_BOOKMARK_PAGE_EMPTY;
   }
   String out = webPageStart(
-    "Bookmark View",
-    "Preview the saved page text for this bookmark.",
-    "<a href='/bookmarks'>&#8592; Back</a><a href='/files'>Files</a><a href='/'>Home</a>",
+    D_WEB_BOOKMARK_VIEW_HEADING,
+    D_WEB_BOOKMARK_VIEW_SUBTITLE,
+    "<a href='/bookmarks'>" D_WEB_BOOKMARK_VIEW_BACK_NAV "</a><a href='/files'>" D_WEB_NAV_FILES "</a><a href='/'>" D_WEB_NAV_HOME "</a>",
     true
   );
 
   out += "<div class='card'><h2>";
   out += htmlEscape(String(g_library.books[b].name));
-  out += "</h2><p class='muted'>Bookmark ";
+  out += "</h2><p class='muted'>" D_WEB_BOOKMARK_PILL_PREFIX;
   out += String(idx + 1);
   out += "</p><pre class='pre'>";
   out += htmlEscape(txt);
-  out += "</pre><div class='actions'><a class='btn secondary' href='/exportbm?book=" + String(b) + "'>Download all bookmarks</a></div></div>";
+  out += "</pre><div class='actions'><a class='btn secondary' href='/exportbm?book=" + String(b) + "'>" D_WEB_BOOKMARK_DOWNLOAD_ALL "</a></div></div>";
   out += webPageEnd();
   server.send(200, "text/html; charset=utf-8", out);
 }
 
 static void handleExportBookmarksWeb() {
   if (!server.hasArg("book")) {
-    server.send(400, "text/plain; charset=utf-8", "missing book");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_BOOK);
     return;
   }
 
   int b = server.arg("book").toInt();
   if (b < 0 || b >= g_library.bookCount) {
-    server.send(400, "text/plain; charset=utf-8", "bad book");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_BOOK);
     return;
   }
 
@@ -194,13 +194,13 @@ static void handleExportBookmarksWeb() {
   uint8_t count = loadBookmarksForKey(key, pages, offsets);
 
   if (count == 0) {
-    server.send(404, "text/plain; charset=utf-8", "No bookmarks for this book");
+    server.send(404, "text/plain; charset=utf-8", D_WEB_NO_BOOKMARKS_THIS_BOOK);
     return;
   }
 
   File f = FS.open(bookPath, "r");
   if (!f) {
-    server.send(500, "text/plain; charset=utf-8", "Open failed");
+    server.send(500, "text/plain; charset=utf-8", D_WEB_BOOKMARKS_OPEN_FAILED_CARD);
     return;
   }
 
@@ -211,11 +211,11 @@ static void handleExportBookmarksWeb() {
   String out;
   out.reserve(8192);
 
-  out += "Book: ";
+  out += D_WEB_BMEXPORT_BOOK;
   out += stripTxtExt(lastPathComponent(bookPath));
   out += "\n";
 
-  out += "Bookmarks: ";
+  out += D_WEB_BMEXPORT_BOOKMARKS;
   out += String(count);
   out += "\n\n";
 
@@ -229,7 +229,7 @@ static void handleExportBookmarksWeb() {
     String txt = readPageTextForWeb(bookPath, targetPage);
 
     out += "==================================================\n";
-    out += "Bookmark ";
+    out += D_WEB_BMEXPORT_BOOKMARK_LBL;
     out += String(i + 1);
     out += "\n";
     out += label;

--- a/Pala_One_2_1/src/web/chrome.cpp
+++ b/Pala_One_2_1/src/web/chrome.cpp
@@ -100,7 +100,7 @@ String webPageEnd() {
 String successPage(const String& title, const String& subtitle,
                    const String& banner, const String& innerHtml) {
   String out = webPageStart(title, subtitle,
-    "<a href='/'>Home</a><a href='/files'>Files</a><a href='/settings'>Settings</a>");
+    "<a href='/'>" D_WEB_NAV_HOME "</a><a href='/files'>" D_WEB_NAV_FILES "</a><a href='/settings'>" D_WEB_NAV_SETTINGS "</a>");
   out += "<div class='banner-ok'>" + banner + "</div>";
   out += innerHtml;
   out += webPageEnd();
@@ -152,11 +152,11 @@ String storageCardHtml(const char* title) {
   out += "<div class='card'><h2>";
   out += title;
   out += "</h2><div class='stats'>";
-  out += "<div class='stat'><span class='muted'>Books</span><b>" + String(g_library.bookCount) + "</b></div>";
-  out += "<div class='stat'><span class='muted'>Used</span><b>"  + humanBytes(usedBytes)  + "</b></div>";
-  out += "<div class='stat'><span class='muted'>Free</span><b>"  + humanBytes(freeBytes)  + "</b></div>";
-  out += "<div class='stat'><span class='muted'>Total</span><b>" + humanBytes(totalBytes) + "</b></div>";
+  out += "<div class='stat'><span class='muted'>" D_WEB_STORAGE_BOOKS "</span><b>" + String(g_library.bookCount) + "</b></div>";
+  out += "<div class='stat'><span class='muted'>" D_WEB_STORAGE_USED  "</span><b>" + humanBytes(usedBytes)         + "</b></div>";
+  out += "<div class='stat'><span class='muted'>" D_WEB_STORAGE_FREE  "</span><b>" + humanBytes(freeBytes)         + "</b></div>";
+  out += "<div class='stat'><span class='muted'>" D_WEB_STORAGE_TOTAL "</span><b>" + humanBytes(totalBytes)        + "</b></div>";
   out += "</div><div class='bar'><span style='width:" + String(pct) + "%'></span></div>";
-  out += "<div class='muted' style='margin-top:8px'>" + String(pct) + "% of internal storage currently used.</div></div>";
+  out += "<div class='muted' style='margin-top:8px'>" + String(pct) + D_WEB_STORAGE_PCT_SUFFIX "</div></div>";
   return out;
 }

--- a/Pala_One_2_1/src/web/chrome.h
+++ b/Pala_One_2_1/src/web/chrome.h
@@ -2,6 +2,7 @@
 #define PALA_WEB_CHROME_H
 
 #include "src/pure/arduino_compat.h"  // String
+#include "src/config.h"                // D_WEB_STORAGE_HEADING default for storageCardHtml (via lang.h)
 
 // ============================================================================
 //  Web page chrome — shared helpers used by every route group.
@@ -30,8 +31,8 @@ String htmlEscape(const String& in);
 String humanBytes(size_t bytes);
 
 // Used + free + total + percent-used storage card. Title is the card heading
-// (defaults to "Storage").
-String storageCardHtml(const char* title = "Storage");
+// (defaults to the language-appropriate "Storage" string).
+String storageCardHtml(const char* title = D_WEB_STORAGE_HEADING);
 
 // For external callers that want just the percent (e.g. banners).
 int storageUsedPct();

--- a/Pala_One_2_1/src/web/files.cpp
+++ b/Pala_One_2_1/src/web/files.cpp
@@ -23,44 +23,46 @@
 // ============================================================================
 
 static void handleRoot() {
-  String subtitle = "Firmware ";
+  String subtitle = D_WEB_HOME_FW_PREFIX;
   subtitle += FW_BUILD;
-  subtitle += " &middot; ";
+  subtitle += D_WEB_HOME_MIDDOT_SEP;
   subtitle += String(g_library.bookCount);
-  subtitle += " books &middot; Free: ";
+  subtitle += D_WEB_HOME_BOOKS_SUFFIX;
+  subtitle += D_WEB_HOME_MIDDOT_SEP;
+  subtitle += D_WEB_HOME_FREE_LABEL;
   subtitle += humanBytes(fsFreeBytesSafe());
   subtitle += " / ";
   subtitle += humanBytes(fsTotalBytesSafe());
 
   String out = webPageStart(
-    "Pala One",
+    D_WEB_HOME_TITLE,
     subtitle,
-    "<a href='/files'>Files</a><a href='/bookmarks'>Bookmarks</a><a href='/list'>List</a><a href='/settings'>Settings</a><a href='/reset'>Factory reset</a>"
+    "<a href='/files'>" D_WEB_NAV_FILES "</a><a href='/bookmarks'>" D_WEB_NAV_BOOKMARKS "</a><a href='/list'>" D_WEB_NAV_LIST "</a><a href='/settings'>" D_WEB_NAV_SETTINGS "</a><a href='/reset'>" D_WEB_NAV_FACTORY_RESET "</a>"
   );
 
   out += storageCardHtml();
 
   if (fsTotalBytesSafe() == 0 || fsFreeBytesSafe() < 8192) {
-    out += "<div class='banner-warn'>&#9888; Storage is not available or almost full. If uploads fail, delete books or use Factory reset from this web UI.</div>";
+    out += "<div class='banner-warn'>" D_WEB_HOME_STORAGE_WARN "</div>";
   }
 
   out +=
-    "<div class='card'><h2>Upload book</h2>"
-    "<p class='muted'>Send UTF-8 plain text files to <b>/books</b> on the device, then sort them into folders from the Files page.</p>"
+    "<div class='card'><h2>" D_WEB_UPLOAD_BOOK_HEADING "</h2>"
+    "<p class='muted'>" D_WEB_UPLOAD_BOOK_DESC "</p>"
     "<form method='POST' action='/upload' enctype='multipart/form-data' accept-charset='UTF-8' style='margin-top:14px'>"
     "<input type='file' name='file' accept='.txt,text/plain' required>"
-    "<div class='actions'><button type='submit'>Upload</button><a class='btn secondary' href='/files'>Manage files</a></div>"
+    "<div class='actions'><button type='submit'>" D_WEB_UPLOAD_BOOK_BUTTON "</button><a class='btn secondary' href='/files'>" D_WEB_MANAGE_FILES_BUTTON "</a></div>"
     "</form></div>";
 
   out +=
-    "<div class='card'><h2>Install app</h2>"
-    "<p class='muted'>Upload a Pala app binary (<b>.bin</b>) to <b>/apps</b>. The header is validated before commit; only files with the correct magic and API version are accepted. Open <b>Apps</b> from the library to launch.</p>"
+    "<div class='card'><h2>" D_WEB_INSTALL_APP_HEADING "</h2>"
+    "<p class='muted'>" D_WEB_INSTALL_APP_DESC "</p>"
     "<form method='POST' action='/upload-app' enctype='multipart/form-data' style='margin-top:14px'>"
     "<input type='file' name='file' accept='.bin' required>"
-    "<div class='actions'><button type='submit'>Install app</button></div>"
+    "<div class='actions'><button type='submit'>" D_WEB_INSTALL_APP_BUTTON "</button></div>"
     "</form></div>";
 
-  out += "<div class='card'><h2>Notes</h2><p class='muted'>Uploaded books are normalized and compacted before saving, so a source TXT can be larger than the final stored file. The reader is optimized for UTF-8 plain text and Latin-based languages.</p></div>";
+  out += "<div class='card'><h2>" D_WEB_NOTES_HEADING "</h2><p class='muted'>" D_WEB_NOTES_DESC "</p></div>";
 
   out += webPageEnd();
   server.send(200, "text/html; charset=utf-8", out);
@@ -68,22 +70,22 @@ static void handleRoot() {
 
 static void handleFiles() {
   String out = webPageStart(
-    "Files",
-    "Manage books, folders and library structure for Pala One.",
-    "<a href='/'>Home</a><a href='/bookmarks'>Bookmarks</a><a href='/settings'>Settings</a>",
+    D_WEB_FILES_HEADING,
+    D_WEB_FILES_SUBTITLE,
+    "<a href='/'>" D_WEB_NAV_HOME "</a><a href='/bookmarks'>" D_WEB_NAV_BOOKMARKS "</a><a href='/settings'>" D_WEB_NAV_SETTINGS "</a>",
     true
   );
 
   out +=
-    "<div class='card'><h2>Create folder</h2>"
+    "<div class='card'><h2>" D_WEB_CREATE_FOLDER_HEADING "</h2>"
     "<form method='POST' action='/mkdir' class='stack' accept-charset='UTF-8' style='margin-top:12px'>"
-    "<input type='text' name='folder' placeholder='books or classics/english' maxlength='64'>"
-    "<div class='actions'><button type='submit'>Create folder</button><span class='muted'>Folders live inside /books.</span></div>"
+    "<input type='text' name='folder' placeholder='" D_WEB_CREATE_FOLDER_PLACEHOLDER "' maxlength='64'>"
+    "<div class='actions'><button type='submit'>" D_WEB_CREATE_FOLDER_BUTTON "</button><span class='muted'>" D_WEB_CREATE_FOLDER_HINT "</span></div>"
     "</form></div>";
 
-  out += "<div class='card'><h2>Folders</h2>";
+  out += "<div class='card'><h2>" D_WEB_FOLDERS_HEADING "</h2>";
   if (g_library.folderCount == 0) {
-    out += "<p class='muted'>No folders yet. Books currently live in the root of /books.</p>";
+    out += "<p class='muted'>" D_WEB_NO_FOLDERS "</p>";
   } else {
     out += "<ul class='list'>";
     for (int i = 0; i < g_library.folderCount; i++) {
@@ -92,23 +94,23 @@ static void handleFiles() {
       out += "</span></div><div><form method='POST' action='/rmdir' style='display:inline'>";
       out += "<input type='hidden' name='folder' value='";
       out += htmlEscape(g_library.folders[i]);
-      out += "'><button type='submit' class='btn secondary' onclick=\"return confirm('Delete folder? Only empty folders can be deleted.')\">Delete</button></form></div></div></li>";
+      out += "'><button type='submit' class='btn secondary' onclick=\"return confirm('" D_WEB_CONFIRM_DELETE_FOLDER "')\">" D_WEB_DELETE_BUTTON "</button></form></div></div></li>";
     }
     out += "</ul>";
   }
   out += "</div>";
 
-  out += "<div class='card'><h2>Library files</h2>";
-  if (g_library.bookCount   >= MAX_BOOKS)   out += "<p style='color:#b91c1c;font-weight:600'>&#9888; Library full (80 books max). Delete books to make room.</p>";
-  if (g_library.folderCount >= MAX_FOLDERS) out += "<p style='color:#b91c1c;font-weight:600'>&#9888; Folder limit reached (32 max).</p>";
+  out += "<div class='card'><h2>" D_WEB_LIBRARY_FILES_HEADING "</h2>";
+  if (g_library.bookCount   >= MAX_BOOKS)   out += "<p style='color:#b91c1c;font-weight:600'>" D_WEB_LIBRARY_FULL_WARN "</p>";
+  if (g_library.folderCount >= MAX_FOLDERS) out += "<p style='color:#b91c1c;font-weight:600'>" D_WEB_FOLDER_LIMIT_WARN "</p>";
 
   if (g_library.bookCount == 0) {
-    out += "<p class='muted'>No books uploaded yet.</p>";
+    out += "<p class='muted'>" D_WEB_NO_BOOKS_UPLOADED "</p>";
   } else {
     out += "<ul class='list'>";
     for (int i = 0; i < g_library.bookCount; i++) {
       String bookPath = String(g_library.books[i].path);
-      String folderLabel = g_library.books[i].folder[0] ? prettyRelativeLabel(g_library.books[i].folder) : String("Root");
+      String folderLabel = g_library.books[i].folder[0] ? prettyRelativeLabel(g_library.books[i].folder) : String(D_WEB_BOOK_ROOT);
       int savedPage = savedPageForBookPath(bookPath) + 1;
       if (savedPage < 1) savedPage = 1;
 
@@ -116,32 +118,32 @@ static void handleFiles() {
       out += htmlEscape(String(g_library.books[i].name));
       out += "</h3><div class='meta'>";
       out += String((int)g_library.books[i].size);
-      out += " bytes &middot; folder: ";
+      out += D_WEB_BOOK_BYTES_LABEL D_WEB_BOOK_FOLDER_LABEL;
       out += htmlEscape(folderLabel);
-      out += " &middot; current page: ";
+      out += D_WEB_BOOK_CURRENT_PAGE;
       out += String(savedPage);
       out += "</div>";
 
       out += "<form method='POST' action='/jumppage' class='stack small' accept-charset='UTF-8' style='margin-top:10px'>";
       out += "<input type='hidden' name='id' value='" + String(i) + "'>";
-      out += "<div class='row' style='align-items:end;gap:10px'><div style='flex:1'><input type='text' name='page' value='" + String(savedPage) + "' inputmode='numeric' placeholder='Page'></div><div><button type='submit'>Jump</button></div></div>";
-      out += "<div class='muted'>Set the page that should open next on the device.<br><span class='muted'>The first open may take a moment.</span></div></form>";
+      out += "<div class='row' style='align-items:end;gap:10px'><div style='flex:1'><input type='text' name='page' value='" + String(savedPage) + "' inputmode='numeric' placeholder='" D_WEB_PAGE_PLACEHOLDER "'></div><div><button type='submit'>" D_WEB_JUMP_BUTTON "</button></div></div>";
+      out += "<div class='muted'>" D_WEB_JUMP_HINT "<br><span class='muted'>" D_WEB_JUMP_HINT2 "</span></div></form>";
 
       out += "<form method='POST' action='/move' class='stack small' accept-charset='UTF-8' style='margin-top:10px'>";
       out += "<input type='hidden' name='id' value='" + String(i) + "'>";
-      out += "<input type='text' name='folder' value='" + htmlEscape(String(g_library.books[i].folder)) + "' placeholder='leave blank for root' maxlength='64'>";
-      out += "<div class='actions'><button type='submit'>Move</button><span class='muted'>Use the exact folder path.</span></div></form></div>";
+      out += "<input type='text' name='folder' value='" + htmlEscape(String(g_library.books[i].folder)) + "' placeholder='" D_WEB_MOVE_PLACEHOLDER "' maxlength='64'>";
+      out += "<div class='actions'><button type='submit'>" D_WEB_MOVE_BUTTON "</button><span class='muted'>" D_WEB_MOVE_HINT "</span></div></form></div>";
       out += "<div><form method='POST' action='/del' style='display:inline'><input type='hidden' name='id' value='" + String(i) + "'>";
-      out += "<button type='submit' class='btn secondary' onclick=\"return confirm('Delete file?')\">Delete</button></form></div></div></li>";
+      out += "<button type='submit' class='btn secondary' onclick=\"return confirm('" D_WEB_CONFIRM_DELETE_FILE "')\">" D_WEB_DELETE_BUTTON "</button></form></div></div></li>";
     }
     out += "</ul>";
   }
 
   out += "</div>";
 
-  out += "<div class='card'><h2>Apps</h2>";
+  out += "<div class='card'><h2>" D_WEB_APPS_PAGE_HEADING "</h2>";
   if (g_apps.count == 0) {
-    out += "<p class='muted'>No apps installed.</p>";
+    out += "<p class='muted'>" D_WEB_NO_APPS_INSTALLED "</p>";
   } else {
     out += "<ul class='list'>";
     for (int i = 0; i < g_apps.count; i++) {
@@ -155,12 +157,12 @@ static void handleFiles() {
       out += htmlEscape(String(g_apps.entries[i].name));
       out += "</h3><div class='meta'>";
       out += String((int)sz);
-      out += " bytes &middot; ";
+      out += D_WEB_BOOK_BYTES_LABEL " &middot; ";
       out += htmlEscape(fileName);
       out += "</div></div><div><form method='POST' action='/del-app' style='display:inline'>";
       out += "<input type='hidden' name='name' value='";
       out += htmlEscape(fileName);
-      out += "'><button type='submit' class='btn secondary' onclick=\"return confirm('Delete app?')\">Delete</button></form></div></div></li>";
+      out += "'><button type='submit' class='btn secondary' onclick=\"return confirm('" D_WEB_CONFIRM_DELETE_APP "')\">" D_WEB_DELETE_BUTTON "</button></form></div></div></li>";
     }
     out += "</ul>";
   }
@@ -172,13 +174,13 @@ static void handleFiles() {
 
 static void handleDelete() {
   if (!server.hasArg("id")) {
-    server.send(400, "text/plain; charset=utf-8", "missing id");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_ID);
     return;
   }
 
   int id = server.arg("id").toInt();
   if (id < 0 || id >= g_library.bookCount) {
-    server.send(400, "text/plain; charset=utf-8", "bad id");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_ID);
     return;
   }
 
@@ -195,23 +197,23 @@ static void handleDelete() {
 static void handleCreateFolder() {
   ensureBooksDir();
   if (!server.hasArg("folder")) {
-    server.send(400, "text/plain; charset=utf-8", "missing folder");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_FOLDER);
     return;
   }
 
   String folder = sanitizeFolderInput(server.arg("folder"));
   if (folder.length() == 0) {
-    server.send(400, "text/plain; charset=utf-8", "bad folder");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_FOLDER);
     return;
   }
   if (g_library.folderCount >= MAX_FOLDERS) {
-    server.send(409, "text/plain; charset=utf-8", "folder limit reached");
+    server.send(409, "text/plain; charset=utf-8", D_WEB_ERR_FOLDER_LIMIT);
     return;
   }
 
   String fullPath = "/books/" + folder;
   if (!ensureDirRecursive(fullPath)) {
-    server.send(500, "text/plain; charset=utf-8", "mkdir failed");
+    server.send(500, "text/plain; charset=utf-8", D_WEB_ERR_MKDIR_FAILED);
     return;
   }
   loadBooks();   // refresh catalog so the new folder appears
@@ -222,27 +224,27 @@ static void handleCreateFolder() {
 
 static void handleDeleteFolder() {
   if (!server.hasArg("folder")) {
-    server.send(400, "text/plain; charset=utf-8", "missing folder");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_FOLDER);
     return;
   }
 
   String folder = sanitizeFolderInput(server.arg("folder"));
   if (folder.length() == 0) {
-    server.send(400, "text/plain; charset=utf-8", "bad folder");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_FOLDER);
     return;
   }
 
   String fullPath = "/books/" + folder;
   if (!FS.exists(fullPath)) {
-    server.send(404, "text/plain; charset=utf-8", "folder not found");
+    server.send(404, "text/plain; charset=utf-8", D_WEB_ERR_FOLDER_NOT_FOUND);
     return;
   }
   if (!isDirEmpty(fullPath)) {
-    server.send(409, "text/plain; charset=utf-8", "folder not empty");
+    server.send(409, "text/plain; charset=utf-8", D_WEB_ERR_FOLDER_NOT_EMPTY);
     return;
   }
   if (!FS.rmdir(fullPath)) {
-    server.send(500, "text/plain; charset=utf-8", "delete failed");
+    server.send(500, "text/plain; charset=utf-8", D_WEB_ERR_DELETE_FAILED);
     return;
   }
   loadBooks();   // refresh catalog so the folder disappears
@@ -253,13 +255,13 @@ static void handleDeleteFolder() {
 
 static void handleMoveBook() {
   if (!server.hasArg("id")) {
-    server.send(400, "text/plain; charset=utf-8", "missing id");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_ID);
     return;
   }
 
   int id = server.arg("id").toInt();
   if (id < 0 || id >= g_library.bookCount) {
-    server.send(400, "text/plain; charset=utf-8", "bad id");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_ID);
     return;
   }
 
@@ -268,7 +270,7 @@ static void handleMoveBook() {
   String destDir = (folder.length() == 0) ? String("/books") : String("/books/") + folder;
 
   if (!ensureDirRecursive(destDir)) {
-    server.send(500, "text/plain; charset=utf-8", "folder create failed");
+    server.send(500, "text/plain; charset=utf-8", D_WEB_ERR_FOLDER_CREATE_FAILED);
     return;
   }
 
@@ -279,13 +281,13 @@ static void handleMoveBook() {
     return;
   }
   if (FS.exists(newPath)) {
-    server.send(409, "text/plain; charset=utf-8", "destination exists");
+    server.send(409, "text/plain; charset=utf-8", D_WEB_ERR_DEST_EXISTS);
     return;
   }
 
   // Library entry already cleared g_bookview; no book is "current" here.
   if (!FS.rename(oldPath, newPath)) {
-    server.send(500, "text/plain; charset=utf-8", "move failed");
+    server.send(500, "text/plain; charset=utf-8", D_WEB_ERR_MOVE_FAILED);
     return;
   }
 
@@ -298,13 +300,13 @@ static void handleMoveBook() {
 
 static void handleJumpPageWeb() {
   if (!server.hasArg("id") || !server.hasArg("page")) {
-    server.send(400, "text/plain; charset=utf-8", "missing id/page");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_MISSING_ID_PAGE);
     return;
   }
 
   int id = server.arg("id").toInt();
   if (id < 0 || id >= g_library.bookCount) {
-    server.send(400, "text/plain; charset=utf-8", "bad id");
+    server.send(400, "text/plain; charset=utf-8", D_WEB_ERR_BAD_ID);
     return;
   }
 

--- a/Pala_One_2_1/src/web/list.cpp
+++ b/Pala_One_2_1/src/web/list.cpp
@@ -10,20 +10,20 @@
 
 static void handleListWeb() {
   String out = webPageStart(
-    "List",
-    "Create a simple shopping or to-do list for Pala One.",
-    "<a href='/'>Home</a><a href='/files'>Files</a><a href='/bookmarks'>Bookmarks</a><a href='/settings'>Settings</a>",
+    D_WEB_LIST_HEADING,
+    D_WEB_LIST_SUBTITLE,
+    "<a href='/'>" D_WEB_NAV_HOME "</a><a href='/files'>" D_WEB_NAV_FILES "</a><a href='/bookmarks'>" D_WEB_NAV_BOOKMARKS "</a><a href='/settings'>" D_WEB_NAV_SETTINGS "</a>",
     true
   );
 
-  out += "<div class='card'><h2>Edit list</h2><p class='muted'>Items appear on the device only when at least one line contains text. Hold the button on the device to mark an item as done.</p>";
+  out += "<div class='card'><h2>" D_WEB_LIST_EDIT_HEADING "</h2><p class='muted'>" D_WEB_LIST_EDIT_DESC "</p>";
   out += "<form method='POST' action='/list' class='stack' accept-charset='UTF-8' style='margin-top:12px'>";
   for (int i = 0; i < MAX_LIST_ITEMS; i++) {
     String value   = (i < g_list.count) ? htmlEscape(String(g_list.items[i].text)) : String("");
     String checked = (i < g_list.count && g_list.items[i].done) ? " checked" : "";
-    out += "<div class='row' style='align-items:center;gap:10px'><div style='width:26px;text-align:center'><input type='checkbox' name='done" + String(i) + "' value='1'" + checked + "></div><div style='flex:1'><input type='text' name='item" + String(i) + "' value='" + value + "' maxlength='64' placeholder='List item'></div></div>";
+    out += "<div class='row' style='align-items:center;gap:10px'><div style='width:26px;text-align:center'><input type='checkbox' name='done" + String(i) + "' value='1'" + checked + "></div><div style='flex:1'><input type='text' name='item" + String(i) + "' value='" + value + "' maxlength='64' placeholder='" D_WEB_LIST_ITEM_PLACEHOLDER "'></div></div>";
   }
-  out += "<div class='actions'><button type='submit'>Save list</button><button type='submit' formaction='/list-clear-done'>Delete checked items</button><span class='muted'>Blank rows are ignored. Checked rows can be removed directly.</span></div></form></div>";
+  out += "<div class='actions'><button type='submit'>" D_WEB_LIST_SAVE_BUTTON "</button><button type='submit' formaction='/list-clear-done'>" D_WEB_LIST_DELETE_DONE "</button><span class='muted'>" D_WEB_LIST_HINT "</span></div></form></div>";
   out += webPageEnd();
   server.send(200, "text/html; charset=utf-8", out);
 }

--- a/Pala_One_2_1/src/web/reset.cpp
+++ b/Pala_One_2_1/src/web/reset.cpp
@@ -27,15 +27,15 @@ static void doFactoryReset() {
 
 static void handleResetConfirm() {
   String out = webPageStart(
-    "Factory Reset",
-    "Erase all books, bookmarks, progress, and custom assets.",
-    "<a href='/'>Back</a>"
+    D_WEB_RESET_HEADING,
+    D_WEB_RESET_SUBTITLE,
+    "<a href='/'>" D_WEB_NAV_BACK "</a>"
   );
   out +=
-    "<div class='card'><h2>Confirm reset</h2>"
-    "<p><strong>This will delete ALL books, bookmarks and reading progress.</strong></p>"
-    "<p class='muted'>The device filesystem will be formatted and settings will return to defaults.</p>"
-    "<form method='POST' action='/reset' style='margin-top:14px'><button class='danger' type='submit'>Yes, reset</button></form>"
+    "<div class='card'><h2>" D_WEB_RESET_CONFIRM_HEADING "</h2>"
+    "<p><strong>" D_WEB_RESET_WARNING "</strong></p>"
+    "<p class='muted'>" D_WEB_RESET_DETAIL "</p>"
+    "<form method='POST' action='/reset' style='margin-top:14px'><button class='danger' type='submit'>" D_WEB_RESET_YES_BUTTON "</button></form>"
     "</div>";
   out += webPageEnd();
   server.send(200, "text/html; charset=utf-8", out);
@@ -46,13 +46,13 @@ static void handleResetDo() {
 
   String inner;
   inner.reserve(600);
-  inner += "<div class='card'><h2>Factory reset complete</h2><p class='muted'>All books, bookmarks, progress and custom assets were removed. The device is now back to a clean state.</p><div class='actions'><a class='btn' href='/'>Go to home</a><a class='btn secondary' href='/files'>Open files</a></div></div>";
+  inner += "<div class='card'><h2>" D_WEB_RESET_COMPLETE_HEADING "</h2><p class='muted'>" D_WEB_RESET_COMPLETE_DESC "</p><div class='actions'><a class='btn' href='/'>" D_WEB_GO_HOME_BUTTON "</a><a class='btn secondary' href='/files'>" D_WEB_OPEN_FILES_BUTTON "</a></div></div>";
   inner += storageCardHtml();
 
   String page = successPage(
-    "Reset complete",
-    "Pala One was reset successfully.",
-    "&#10003; Factory reset complete.",
+    D_WEB_RESET_SUCCESS_TITLE,
+    D_WEB_RESET_SUCCESS_SUBTITLE,
+    D_WEB_RESET_BANNER,
     inner
   );
   server.send(200, "text/html; charset=utf-8", page);

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -30,53 +30,53 @@ static void handleSettings() {
   bool hasSleepImg = FS.exists("/sleep.bin");
 
   String out = webPageStart(
-    "Pala One Settings",
-    "Firmware " FW_BUILD " configuration page stored directly on the device.",
-    "<a href='/'>&#8592; Home</a>"
+    D_WEB_SETTINGS_TITLE,
+    D_WEB_SETTINGS_SUBTITLE_PREFIX FW_BUILD D_WEB_SETTINGS_SUBTITLE_SUFFIX,
+    "<a href='/'>" D_WEB_SETTINGS_BACK_NAV "</a>"
   );
   out.reserve(out.length() + 4000);
 
   out +=
-    "<div class='card'><h2>Reading</h2>"
+    "<div class='card'><h2>" D_WEB_READING_HEADING "</h2>"
     "<form method='POST' action='/settings' accept-charset='UTF-8'>"
     "<div class='grid cols-2'>"
-    "<div><label for='font'>Font size</label><select id='font' name='font'>"
-    "<option value='8'";  out += sel8;  out += ">8px &mdash; tiny</option>"
-    "<option value='10'"; out += sel10; out += ">10px &mdash; small</option>"
-    "<option value='12'"; out += sel12; out += ">12px &mdash; medium</option>"
-    "<option value='14'"; out += sel14; out += ">14px &mdash; large</option>"
-    "</select><div class='hint'>Controls how many lines fit on each page.</div></div>"
-    "<div><label for='sleep'>Sleep after</label><select id='sleep' name='sleep'>"
-    "<option value='30'";   out += ss30;   out += ">30 seconds</option>"
-    "<option value='60'";   out += ss60;   out += ">1 minute</option>"
-    "<option value='120'";  out += ss120;  out += ">2 minutes</option>"
-    "<option value='300'";  out += ss300;  out += ">5 minutes</option>"
-    "<option value='600'";  out += ss600;  out += ">10 minutes</option>"
-    "<option value='1800'"; out += ss1800; out += ">30 minutes</option>"
-    "</select><div class='hint'>Auto-sleep keeps battery draw low while idle.</div></div>"
-    "<div><label for='lgap'>Line spacing</label><select id='lgap' name='lgap'>"
-    "<option value='0'"; out += lg0; out += ">0 px &mdash; compact</option>"
-    "<option value='1'"; out += lg1; out += ">1 px &mdash; normal</option>"
-    "<option value='2'"; out += lg2; out += ">2 px &mdash; relaxed</option>"
-    "<option value='3'"; out += lg3; out += ">3 px &mdash; loose</option>"
-    "</select><div class='hint'>A small change here can make text much easier to scan.</div></div>"
+    "<div><label for='font'>" D_WEB_FONT_SIZE_LABEL "</label><select id='font' name='font'>"
+    "<option value='8'";  out += sel8;  out += ">" D_WEB_FONT_SIZE_8  "</option>"
+    "<option value='10'"; out += sel10; out += ">" D_WEB_FONT_SIZE_10 "</option>"
+    "<option value='12'"; out += sel12; out += ">" D_WEB_FONT_SIZE_12 "</option>"
+    "<option value='14'"; out += sel14; out += ">" D_WEB_FONT_SIZE_14 "</option>"
+    "</select><div class='hint'>" D_WEB_FONT_SIZE_HINT "</div></div>"
+    "<div><label for='sleep'>" D_WEB_SLEEP_AFTER_LABEL "</label><select id='sleep' name='sleep'>"
+    "<option value='30'";   out += ss30;   out += ">" D_WEB_SLEEP_30S "</option>"
+    "<option value='60'";   out += ss60;   out += ">" D_WEB_SLEEP_1M  "</option>"
+    "<option value='120'";  out += ss120;  out += ">" D_WEB_SLEEP_2M  "</option>"
+    "<option value='300'";  out += ss300;  out += ">" D_WEB_SLEEP_5M  "</option>"
+    "<option value='600'";  out += ss600;  out += ">" D_WEB_SLEEP_10M "</option>"
+    "<option value='1800'"; out += ss1800; out += ">" D_WEB_SLEEP_30M "</option>"
+    "</select><div class='hint'>" D_WEB_SLEEP_HINT "</div></div>"
+    "<div><label for='lgap'>" D_WEB_LINE_SPACING_LABEL "</label><select id='lgap' name='lgap'>"
+    "<option value='0'"; out += lg0; out += ">" D_WEB_LINE_SPACING_0 "</option>"
+    "<option value='1'"; out += lg1; out += ">" D_WEB_LINE_SPACING_1 "</option>"
+    "<option value='2'"; out += lg2; out += ">" D_WEB_LINE_SPACING_2 "</option>"
+    "<option value='3'"; out += lg3; out += ">" D_WEB_LINE_SPACING_3 "</option>"
+    "</select><div class='hint'>" D_WEB_LINE_SPACING_HINT "</div></div>"
     "</div>"
-    "<div class='actions' style='margin-top:24px'><button type='submit'>Save settings</button><span class='muted'>No extra files, scripts, or fonts.</span></div>"
+    "<div class='actions' style='margin-top:24px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button><span class='muted'>" D_WEB_SETTINGS_NO_EXTRAS "</span></div>"
     "</form></div>"
-    "<div class='card'><h2>Screensaver</h2>"
-    "<p>Upload raw XBM bytes: <b>3904 bytes</b>, 250&times;122 px, 1-bit, LSB-first, 32 bytes per row.</p>"
-    "<p class='muted'>Tip: use <a class='link' href='https://javl.github.io/image2cpp/' target='_blank'>image2cpp</a> with <b>Plain bytes</b>. Invert colors if needed.</p>";
+    "<div class='card'><h2>" D_WEB_SCREENSAVER_HEADING "</h2>"
+    "<p>" D_WEB_SCREENSAVER_SPECS "</p>"
+    "<p class='muted'>" D_WEB_SCREENSAVER_TIP "</p>";
 
   if (hasSleepImg) {
-    out += "<div class='status ok'>&#10003; Custom screensaver active. <form method='POST' action='/del-sleep' style='display:inline;margin-left:6px'><button type='submit' class='btn secondary' onclick=\"return confirm('Delete custom screensaver?')\">Delete</button></form></div>";
+    out += "<div class='status ok'>" D_WEB_SCREENSAVER_ACTIVE " <form method='POST' action='/del-sleep' style='display:inline;margin-left:6px'><button type='submit' class='btn secondary' onclick=\"return confirm('" D_WEB_CONFIRM_DEL_SCREENSAVER "')\">" D_WEB_DELETE_BUTTON "</button></form></div>";
   } else {
-    out += "<div class='status idle'>Using built-in screensaver.</div>";
+    out += "<div class='status idle'>" D_WEB_SCREENSAVER_DEFAULT "</div>";
   }
 
   out +=
     "<form method='POST' action='/upload-sleep' enctype='multipart/form-data' style='margin-top:14px'>"
-    "<div class='grid'><div><label for='file'>Sleep image file</label><input id='file' type='file' name='file' accept='.bin'></div></div>"
-    "<div class='actions'><button type='submit'>Upload image</button></div>"
+    "<div class='grid'><div><label for='file'>" D_WEB_SLEEP_IMAGE_LABEL "</label><input id='file' type='file' name='file' accept='.bin'></div></div>"
+    "<div class='actions'><button type='submit'>" D_WEB_SCREENSAVER_UPLOAD_BUTTON "</button></div>"
     "</form></div>";
 
   out += webPageEnd();

--- a/Pala_One_2_1/src/web/upload.cpp
+++ b/Pala_One_2_1/src/web/upload.cpp
@@ -63,7 +63,7 @@ static void handleUploadDone() {
     server.send(400, "text/plain; charset=utf-8",
                 s_book.error.length()
                   ? s_book.error
-                  : "Upload failed");
+                  : String(D_WEB_UPLOAD_ERR_FALLBACK));
     return;
   }
 
@@ -79,19 +79,19 @@ static void handleUploadDone() {
 
   String inner;
   inner.reserve(1200);
-  inner += "<div class='card'><h2>Upload complete</h2><p class='muted'>Your book is now stored on the device and available in the library.</p>";
+  inner += "<div class='card'><h2>" D_WEB_UPLOAD_COMPLETE_HEADING "</h2><p class='muted'>" D_WEB_UPLOAD_COMPLETE_DESC "</p>";
   inner += "<div class='stats'>";
-  inner += "<div class='stat'><span class='muted'>Book</span><b>"        + htmlEscape(s_book.finalName) + "</b></div>";
-  inner += "<div class='stat'><span class='muted'>Stored size</span><b>" + humanBytes(storedSize)                          + "</b></div>";
-  inner += "<div class='stat'><span class='muted'>Books now</span><b>"   + String(g_library.bookCount)                     + "</b></div>";
-  inner += "<div class='stat'><span class='muted'>Free space</span><b>"  + humanBytes(fsFreeBytesSafe())                   + "</b></div>";
-  inner += "</div><div class='actions'><a class='btn' href='/'>Upload another</a><a class='btn secondary' href='/files'>Open files</a></div></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_UPLOAD_BOOK_LABEL  "</span><b>" + htmlEscape(s_book.finalName) + "</b></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_UPLOAD_STORED_SIZE "</span><b>" + humanBytes(storedSize)         + "</b></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_UPLOAD_BOOKS_NOW   "</span><b>" + String(g_library.bookCount)    + "</b></div>";
+  inner += "<div class='stat'><span class='muted'>" D_WEB_UPLOAD_FREE_SPACE  "</span><b>" + humanBytes(fsFreeBytesSafe())  + "</b></div>";
+  inner += "</div><div class='actions'><a class='btn' href='/'>" D_WEB_UPLOAD_ANOTHER "</a><a class='btn secondary' href='/files'>" D_WEB_OPEN_FILES_BUTTON "</a></div></div>";
   inner += storageCardHtml();
 
   String page = successPage(
-    "Upload complete",
-    "Book saved successfully.",
-    "&#10003; Upload finished.",
+    D_WEB_UPLOAD_COMPLETE_HEADING,
+    D_WEB_UPLOAD_BOOK_SAVED,
+    D_WEB_UPLOAD_FINISHED,
     inner
   );
   server.send(200, "text/html; charset=utf-8", page);
@@ -111,13 +111,13 @@ static void handleUploadBookStream() {
 
     loadBooks();   // defensive — protects MAX_BOOKS check from a stale catalog
     if (g_library.bookCount >= MAX_BOOKS) {
-      s_book.error = "Library full";
+      s_book.error = D_WEB_ERR_LIBRARY_FULL;
       return;
     }
 
     size_t freeBytes = fsFreeBytesSafe();
     if (freeBytes < 8192) {
-      s_book.error = "Not enough free space";
+      s_book.error = D_WEB_ERR_NOT_ENOUGH_SPACE;
       return;
     }
 
@@ -128,7 +128,7 @@ static void handleUploadBookStream() {
     if (FS.exists(s_book.tmpPath)) FS.remove(s_book.tmpPath);
     s_book.tmpFile = FS.open(s_book.tmpPath, "w");
     if (!s_book.tmpFile) {
-      s_book.error = "Cannot create temp upload file";
+      s_book.error = D_WEB_ERR_CANT_CREATE_TEMP_BOOK;
       s_book.tmpPath = "";
     }
   }
@@ -155,7 +155,7 @@ static void handleUploadBookStream() {
         if (wrote != cleanedLen) {
           // Short write — out of space or FS error. Abort so a truncated
           // file isn't promoted to a finalized book.
-          s_book.error = "Write failed (out of space?)";
+          s_book.error = D_WEB_ERR_WRITE_FAILED;
           s_book.tmpFile.close();
           if (s_book.tmpPath.length() > 0
               && FS.exists(s_book.tmpPath)) {
@@ -177,7 +177,7 @@ static void handleUploadBookStream() {
         size_t cleanedLen = cleaned.length();
         size_t wrote = s_book.tmpFile.print(cleaned);
         if (wrote != cleanedLen && s_book.error.length() == 0) {
-          s_book.error = "Write failed (out of space?)";
+          s_book.error = D_WEB_ERR_WRITE_FAILED;
         }
         s_book.pendingUtf8Tail = "";
       }
@@ -197,16 +197,16 @@ static void handleUploadBookStream() {
           s_book.ok = true;
         } else {
           if (FS.exists(s_book.tmpPath)) FS.remove(s_book.tmpPath);
-          s_book.error = "Failed to finalize upload";
+          s_book.error = D_WEB_ERR_FINALIZE_UPLOAD;
         }
       } else {
         if (s_book.tmpPath.length() > 0 && FS.exists(s_book.tmpPath)) FS.remove(s_book.tmpPath);
-        s_book.error = "Empty upload";
+        s_book.error = D_WEB_ERR_EMPTY_UPLOAD;
       }
       s_book.tmpPath = "";
     } else {
       if (s_book.tmpPath.length() > 0 && FS.exists(s_book.tmpPath)) FS.remove(s_book.tmpPath);
-      if (s_book.error.length() == 0) s_book.error = "Upload failed";
+      if (s_book.error.length() == 0) s_book.error = D_WEB_UPLOAD_ERR_FALLBACK;
       s_book.tmpPath = "";
     }
   }
@@ -216,7 +216,7 @@ static void handleUploadBookStream() {
     s_book.pendingUtf8Tail = "";
     s_book.tmpPath = "";
     s_book.ok = false;
-    s_book.error = "Upload aborted";
+    s_book.error = D_WEB_ERR_UPLOAD_ABORTED;
   }
 }
 
@@ -229,18 +229,18 @@ static void handleUploadSleepDone() {
     server.send(400, "text/plain; charset=utf-8",
                 s_sleep.error.length()
                   ? s_sleep.error
-                  : "Sleep image upload failed");
+                  : String(D_WEB_SLEEP_UPLOAD_ERR_FALLBACK));
     return;
   }
 
   String inner;
   inner.reserve(500);
-  inner += "<div class='card'><h2>Screensaver updated</h2><p class='muted'>Your custom sleep image was saved successfully and will be shown the next time the device goes to sleep.</p><div class='actions'><a class='btn' href='/settings'>Back to settings</a><a class='btn secondary' href='/'>Home</a></div></div>";
+  inner += "<div class='card'><h2>" D_WEB_SLEEP_UPLOAD_HEADING "</h2><p class='muted'>" D_WEB_SLEEP_UPLOAD_DESC "</p><div class='actions'><a class='btn' href='/settings'>" D_WEB_BACK_TO_SETTINGS "</a><a class='btn secondary' href='/'>" D_WEB_NAV_HOME "</a></div></div>";
 
   String page = successPage(
-    "Upload complete",
-    "Screensaver saved successfully.",
-    "&#10003; Custom sleep image uploaded.",
+    D_WEB_UPLOAD_COMPLETE_HEADING,
+    D_WEB_SLEEP_UPLOAD_SUBTITLE,
+    D_WEB_SLEEP_UPLOAD_BANNER,
     inner
   );
   server.send(200, "text/html; charset=utf-8", page);
@@ -255,7 +255,7 @@ static void handleUploadSleepStream() {
     s_sleep.tmpPath = "/sleep.bin.tmp";
     if (FS.exists(s_sleep.tmpPath)) FS.remove(s_sleep.tmpPath);
     s_sleep.tmpFile = FS.open(s_sleep.tmpPath, "w");
-    if (!s_sleep.tmpFile) s_sleep.error = "Cannot create temp sleep file";
+    if (!s_sleep.tmpFile) s_sleep.error = D_WEB_SLEEP_ERR_TEMP;
   }
   else if (upS.status == UPLOAD_FILE_WRITE) {
     if (s_sleep.tmpFile) s_sleep.tmpFile.write(upS.buf, upS.currentSize);
@@ -268,14 +268,14 @@ static void handleUploadSleepStream() {
 
     if (sz != 3904) {
       if (FS.exists(s_sleep.tmpPath)) FS.remove(s_sleep.tmpPath);
-      s_sleep.error = "Sleep image must be exactly 3904 bytes";
+      s_sleep.error = D_WEB_SLEEP_ERR_SIZE;
       s_sleep.ok = false;
     } else {
       if (FS.exists("/sleep.bin")) FS.remove("/sleep.bin");
       if (FS.rename(s_sleep.tmpPath, "/sleep.bin")) s_sleep.ok = true;
       else {
         if (FS.exists(s_sleep.tmpPath)) FS.remove(s_sleep.tmpPath);
-        s_sleep.error = "Failed to save sleep image";
+        s_sleep.error = D_WEB_SLEEP_ERR_SAVE;
       }
     }
     s_sleep.tmpPath = "";
@@ -283,7 +283,7 @@ static void handleUploadSleepStream() {
   else if (upS.status == UPLOAD_FILE_ABORTED) {
     if (s_sleep.tmpFile) s_sleep.tmpFile.close();
     if (s_sleep.tmpPath.length() > 0 && FS.exists(s_sleep.tmpPath)) FS.remove(s_sleep.tmpPath);
-    s_sleep.error = "Sleep image upload aborted";
+    s_sleep.error = D_WEB_SLEEP_ERR_ABORTED;
     s_sleep.ok = false;
     s_sleep.tmpPath = "";
   }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ The board version is usually printed on the back of the PCB.
 
 Pick your board's revision in the build step below — either by uncommenting the matching `#define` at the top of `Pala_One_2_1/Pala_One_2_1.ino` (Arduino IDE), or by selecting the matching env (PlatformIO).
 
+## Language
+
+The firmware ships with two built-in languages, selected at build time:
+
+- `LANG_EN` — English (default)
+- `LANG_ES_LA` — Spanish (Latin America)
+
+One language per binary. PlatformIO users pick a leaf env that already encodes both the board and the language (`wireless-paper-v1_2-en`, `wireless-paper-v1_2-es`, `wireless-paper-v1_1-en`, `wireless-paper-v1_1-es`). Arduino IDE users uncomment one of `LANG_EN` / `LANG_ES_LA` near the top of `Pala_One_2_1/Pala_One_2_1.ino`, alongside the board `#define`. If nothing is set, the firmware compiles with `LANG_EN` and a `#pragma message` warning.
+
+Strings live in `Pala_One_2_1/src/lang/` — `en.h` is the canonical key set; `es_la.h` mirrors it. Adding a new language is additive: clone one of the headers, add the include arm in `src/lang/lang.h`, and add two leaf envs in `platformio.ini` (one per board). See `src/lang/lang.h` for the authoring rules (key set, placeholders, JS-confirm quoting constraint).
+
+Glyph coverage: Latin Extended (`á é í ó ú ñ Ñ ¿ ¡ ü Ü`) is provided by `u8g2_font_helv*_te` for body, bold, app-large and toast roles. The small bitmap fonts used for the battery percentage and page-number indicator stay on ASCII-only `_tf` tables — they only render digits / `%`, and any translation routed through them would render missing-glyph boxes. Web responses declare `charset=utf-8`.
+
 ## Building the firmware
 
 The same sources build under either toolchain.
@@ -43,8 +56,10 @@ The same sources build under either toolchain.
 1. Install [PlatformIO Core](https://platformio.org/install/cli) (CLI) or the PlatformIO IDE extension for VS Code.
 2. From the repo root:
    ```
-   pio run -e wireless-paper-v1_2 -t upload    # V1.2 panel
-   pio run -e wireless-paper-v1_1 -t upload    # V1.1 panel
+   pio run -e wireless-paper-v1_2-en -t upload    # V1.2 panel, English
+   pio run -e wireless-paper-v1_2-es -t upload    # V1.2 panel, Spanish-LA
+   pio run -e wireless-paper-v1_1-en -t upload    # V1.1 panel, English
+   pio run -e wireless-paper-v1_1-es -t upload    # V1.1 panel, Spanish-LA
    ```
 3. Serial monitor:
    ```

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,6 +45,10 @@ lib_deps =
   adafruit/Adafruit GFX Library @ 1.12.6
   olikraus/U8g2_for_Adafruit_GFX @ 1.8.0
 
+; Base envs — set the board / display flags. They're not the recommended
+; build targets directly; pick a language-qualified leaf env below instead.
+; (Building one of these without a LANG_* falls back to LANG_EN with a
+; #pragma message from src/config.h, so they still compile.)
 [env:wireless-paper-v1_2]
 build_flags =
   -D WIRELESS_PAPER
@@ -54,3 +58,24 @@ build_flags =
 build_flags =
   -D WIRELESS_PAPER
   -D DISPLAY_V1_1
+
+; Per-language leaf envs — pick one of these to flash. The same source
+; tree builds 4 firmware images: (V1.1 | V1.2) x (English | Spanish-LA).
+; Adding a third language: clone en.h / es_la.h to <lang>.h, mirror the
+; key set, add the include arm in src/lang/lang.h, then add two leaf envs
+; here (one per board).
+[env:wireless-paper-v1_2-en]
+extends = env:wireless-paper-v1_2
+build_flags = ${env:wireless-paper-v1_2.build_flags} -D LANG_EN
+
+[env:wireless-paper-v1_2-es]
+extends = env:wireless-paper-v1_2
+build_flags = ${env:wireless-paper-v1_2.build_flags} -D LANG_ES_LA
+
+[env:wireless-paper-v1_1-en]
+extends = env:wireless-paper-v1_1
+build_flags = ${env:wireless-paper-v1_1.build_flags} -D LANG_EN
+
+[env:wireless-paper-v1_1-es]
+extends = env:wireless-paper-v1_1
+build_flags = ${env:wireless-paper-v1_1.build_flags} -D LANG_ES_LA

--- a/test/test_bookmarks_codec.cpp
+++ b/test/test_bookmarks_codec.cpp
@@ -67,7 +67,15 @@ TEST_CASE("addBookmark refuses duplicate page") {
   addBookmark(bm, 5, 500);
   BookmarkAddResult r = addBookmark(bm, 5, 555);
   CHECK(!r.added);
+  // Compare against the language macro, not the English literal, so the
+  // test still passes if someone builds the host tests with -DLANG_ES_LA.
+  // Host default (no LANG_* flag) falls back to LANG_EN via src/lang/lang.h.
+  CHECK_EQ(String(r.message), String(D_TOAST_BOOKMARK_EXISTS));
+#ifdef LANG_EN
+  // Under the default English build, also pin the literal so a key swap
+  // (e.g. {added:false} returning the wrong toast) gets caught.
   CHECK_EQ(String(r.message), String("Bookmark exists"));
+#endif
   CHECK_EQ(bm.count, 1);
 }
 


### PR DESCRIPTION
## Summary

Adds build-time language selection to the firmware using a Tasmota/Marlin-style preprocessor mechanism. One language per binary; selected by a `LANG_*` build flag. All on-device and captive-portal UI strings now go through `D_*` macros (~246 keys), concatenated adjacent-literal at the call site — zero runtime cost, binary byte-identical to the prior inline literals under `LANG_EN`.

Two languages ship:
- `LANG_EN` — English (default; identical to pre-PR output)
- `LANG_ES_LA` — Spanish (Latin America)

## How it's selected

| Build system | How to pick the language |
|---|---|
| **PlatformIO** | New leaf envs combine board × language via `extends`: `wireless-paper-v1_{1,2}-{en,es}`. The bare board envs remain as the base. |
| **Arduino IDE** | Uncomment `LANG_EN` or `LANG_ES_LA` near the top of `Pala_One_2_1.ino`, alongside the `BOARD_V1_X` block. |

If neither macro is set, `src/lang/lang.h` defaults to `LANG_EN` with a `#pragma message` — so host CMake tests and uncustomised Arduino IDE builds still compile.

## Where strings live

```
Pala_One_2_1/src/lang/
  lang.h     # selector + LANG_EN fallback
  en.h       # canonical key set (~246 D_* defines, sectioned by surface)
  es_la.h    # Spanish-LA mirror — every key present
```

`en.h` is the source of truth for the key set. A missing key in `es_la.h` produces a compile error against the `-es` build (undeclared identifier), so drift is structurally detected. Authoring rules — placeholders, HTML entities, JS-confirm quoting — are documented at the top of `lang.h`.

## Glyph coverage

Spanish-LA needs `á é í ó ú ñ Ñ ¿ ¡ ü Ü`. Body / bold / app-large / toast roles use the existing `u8g2_font_helv*_te` Latin Extended tables. A new `Font::useToast()` role splits toasts off `useUiSmall` so translated toasts can render accents. `useUiSmall` (battery %) and `useUiTiny` (page number) intentionally stay on ASCII-only `_tf` tables — they only render digits/% and a switch would resize the battery indicator. Web responses already declare `charset=utf-8`.

## Out of scope

- Runtime language switching (build-time-only by design).
- Languages outside Latin Extended (Cyrillic / CJK would require different u8g2 fonts — separate decision).
- CI matrix to build all 4 binaries on tag — project has no CI today.

## Incidental

Added `#include <ostream>` to `src/pure/arduino_compat.h` — fixes a pre-existing MSVC host-test build error where the friend `operator<<(std::ostream&, const String&)` was declared without the complete type in scope. No-op for GCC/Clang (libstdc++ pulled it in transitively via `<string>`); host-only branch — firmware build is unchanged.

## Test plan

- [x] All four PIO envs build cleanly (`wireless-paper-v1_{1,2}-{en,es}`)
- [x] Host CMake tests pass (`ctest --test-dir test/build`) — `test_bookmarks_codec.cpp` updated to compare against `D_TOAST_BOOKMARK_EXISTS` (language-agnostic) with an `#ifdef LANG_EN`-gated literal pin
- [x] Flashed `wireless-paper-v1_2-es` to hardware and walked: library / reader / bookmarks (toast strings) / about / upload / apps / list / app-loader error overlays — no missing-glyph squares, no clipping
- [x] Walked all captive-portal routes on Spanish build via SoftAP (`PALA-XXXXXX` / `palaread` → `192.168.4.1`): `/`, `/files`, `/bookmarks`, `/list`, `/settings`, `/upload-app`, `/reset` — accents render correctly, JS confirm dialogs in Spanish, bookmark export `.txt` carries Spanish labels
- [ ] English build (`wireless-paper-v1_2-en`) walk-through regression spot-check — recommended before merge

## Notes for reviewers

- External app ABI (`pala_api.h`, `pala_app.h`, `PALA_API_VERSION = 3`) is unchanged.
- Adjacent-literal concat means the LANG_EN build produces output byte-identical to the prior inline-literal code at every call site — no behaviour change for the default language.
- Adding a third language is purely additive: clone one of the headers, add an `#elif defined(LANG_*)` arm to `lang.h`, add two leaf envs in `platformio.ini`.
