### PR TITLE
build: hide git hash from library header when git unavailable

### DIFF
--- a/scripts/build_info.py
+++ b/scripts/build_info.py
@@ -16,11 +16,21 @@ def _git(*args):
 
 
 def build_id():
-    sha = _git("rev-parse", "--short", "HEAD") or "nogit"
+    sha = _git("rev-parse", "--short", "HEAD")
+    if not sha:
+        return None
     dirty = "-dirty" if _git("status", "--porcelain") else ""
     return sha + dirty
 
 
 value = build_id()
-env.Append(CPPDEFINES=[("BUILD_GIT_HASH", env.StringifyMacro(value))])  # noqa: F821
-print(f"build_info.py: BUILD_GIT_HASH={value}")
+if value:
+    env.Append(CPPDEFINES=[("BUILD_GIT_HASH", env.StringifyMacro(value))])  # noqa: F821
+    print(f"build_info.py: BUILD_GIT_HASH={value}")
+else:
+    # No git checkout (zip download, CI without history, etc.). Force
+    # DEBUG_BUILD=0 so the library-screen header shows plain "Pala One"
+    # instead of "Pala One nogit". config.h's fallback BUILD_GIT_HASH
+    # = "unknown" still feeds FW_BUILD for About / web UI.
+    env.Append(CPPDEFINES=[("DEBUG_BUILD", 0)])  # noqa: F821
+    print("build_info.py: git unavailable, forcing DEBUG_BUILD=0")


### PR DESCRIPTION
scripts/build_info.py used 'nogit' as the fallback string when 'git rev-parse' failed (zip download, CI without history, etc.). That string got baked into BUILD_GIT_HASH and surfaced on the library-screen header as 'Pala One nogit' under the default DEBUG_BUILD=1.

Now: if git is unavailable, the script injects DEBUG_BUILD=0 instead of a sentinel hash. config.h then resolves LIB_HEADER_TITLE to plain 'Pala One'. About + web UI still show FW_BUILD via the existing 'unknown' fallback in config.h.