### PR TITLE
Dev/sleep streak hooks

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -77,6 +77,7 @@
 #include "src/ui/font.h"
 #include "src/ui/pala_api_impl.h"
 #include "src/ui/reader.h"
+#include "src/ui/reading_hooks.h"
 #include "src/ui/screen.h"
 #include "src/ui/widgets.h"  // drawCenter
 #include "src/ui/screens/about_screen.h"
@@ -151,6 +152,10 @@ void setup() {
   initPalaAPI();
   registerWebRoutes();
   markUserActivity();
+
+  // If a sleep timer expired (possibly woke us via RTC alarm), queue the
+  // toast so it appears on whatever screen we render next.
+  sleepTimerCheckExpired();
 
   if (tryRestoreReadingSession()) {
     renderCurrentPage();      // ~300ms draw — wake-press releases during this

--- a/Pala_One_2_1/src/pure/streak_log.cpp
+++ b/Pala_One_2_1/src/pure/streak_log.cpp
@@ -1,0 +1,30 @@
+#include "src/pure/streak_log.h"
+
+StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t today) {
+  StreakLogResult r{};
+  if (current.lastLoggedDay == today) {
+    r.changed = false;
+    r.next    = current;
+    return r;
+  }
+
+  ReadingStreakFile s = current;
+
+  if (today > s.bitmapHead) {
+    uint32_t d = today - s.bitmapHead;
+    s.bitmap     = (d >= 32) ? 0u : (s.bitmap << d);
+    s.bitmapHead = today;
+  }
+  s.bitmap |= 1u;
+
+  bool cont = (s.lastLoggedDay != STREAK_DAY_UNSET)
+           && (today == s.lastLoggedDay + 1);
+  s.currentStreak  = cont ? (s.currentStreak + 1) : 1;
+  if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
+  s.lastLoggedDay  = today;
+  s.totalSessions += 1;
+
+  r.changed = true;
+  r.next    = s;
+  return r;
+}

--- a/Pala_One_2_1/src/pure/streak_log.h
+++ b/Pala_One_2_1/src/pure/streak_log.h
@@ -1,0 +1,54 @@
+#ifndef PALA_PURE_STREAK_LOG_H
+#define PALA_PURE_STREAK_LOG_H
+
+#include "src/pure/arduino_compat.h"  // uint32_t
+
+// ============================================================================
+//  Reading-streak wire format + pure log-advance logic.
+//
+//  Lives in pure/ so the bitmap-shift + continuation rules are host-testable
+//  independent of LittleFS / RTC / Toast. The firmware side (reading_hooks.cpp)
+//  reads /apps/streak.dat into one of these structs, calls `applyStreakLog`
+//  to compute the next state, and writes it back. The same struct layout is
+//  shared with examples/reading_streak/app.c (schema-version gated).
+// ============================================================================
+
+static const uint32_t STREAK_SCHEMA          = 1;
+static const uint32_t STREAK_DAY_SECS        = 86400u;
+static const uint32_t STREAK_DAY_UNSET       = 0xFFFFFFFFu;
+static const int      STREAK_PAGES_THRESHOLD = 5;     // pages today before we log
+
+struct ReadingStreakFile {
+  uint32_t version;        // == STREAK_SCHEMA
+  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
+  uint32_t lastLoggedDay;  // day index, STREAK_DAY_UNSET = never
+  uint32_t currentStreak;
+  uint32_t longestStreak;
+  uint32_t totalSessions;
+  uint32_t bitmapHead;     // day index of bit 0
+  uint32_t bitmap;         // bit i = "logged on day (head - i)"
+};
+
+struct StreakLogResult {
+  bool                changed;  // false = same-day no-op
+  ReadingStreakFile   next;     // valid iff `changed`
+};
+
+// Advance the streak state for a session logged on `today`. Pure — same
+// `current` + `today` always yield the same result.
+//
+// Behaviour:
+//   - If `today == current.lastLoggedDay` → no-op ({false, current}).
+//   - Otherwise:
+//     - bitmap shifts left by `(today - bitmapHead)` (zeros if shift >= 32).
+//     - bit 0 set (today is logged).
+//     - currentStreak = (lastLoggedDay+1 == today) ? prev+1 : 1.
+//     - longestStreak = max(longestStreak, currentStreak).
+//     - totalSessions++.
+//     - lastLoggedDay = today.
+//
+// `STREAK_DAY_UNSET` as `lastLoggedDay` means "never logged before" and
+// breaks continuation (the next log starts streak at 1, not 2).
+StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t today);
+
+#endif  // PALA_PURE_STREAK_LOG_H

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -8,6 +8,7 @@
 #include "src/storage/preferences_store.h"
 
 #include "src/ui/font.h"                    // currentBodySize/currentLineGap for cache stamping
+#include "src/ui/reading_hooks.h"           // onReaderPageTurn — streak + sleep-timer integration
 #include "src/ui/screens/library_screen.h"  // navigateToLibraryRoot — fallback on error
 #include "src/ui/text.h"
 #include "src/ui/toast.h"                   // Toast::isActive / Toast::draw
@@ -312,6 +313,7 @@ bool advancePage() {
   if (targetPage >= g_bookview.pages.count) return false;
   g_bookview.cursor.pageIndex = targetPage;
   g_bookview.cursor.pageTurnsSinceFull++;
+  onReaderPageTurn();
   return true;
 }
 
@@ -319,6 +321,7 @@ bool retreatPage() {
   if (g_bookview.cursor.pageIndex <= 0) return false;
   g_bookview.cursor.pageIndex--;
   g_bookview.cursor.pageTurnsSinceFull++;
+  onReaderPageTurn();
   return true;
 }
 

--- a/Pala_One_2_1/src/ui/reading_hooks.cpp
+++ b/Pala_One_2_1/src/ui/reading_hooks.cpp
@@ -1,7 +1,8 @@
 #include "src/ui/reading_hooks.h"
 
-#include "src/state.h"      // FS (=LittleFS), prefs unused here but matches sibling modules
-#include "src/ui/toast.h"   // Toast::show
+#include "src/pure/streak_log.h"  // ReadingStreakFile + applyStreakLog
+#include "src/state.h"            // FS (=LittleFS)
+#include "src/ui/toast.h"         // Toast::show
 
 // esp_rtc_get_time_us lives in a chip-specific header; forward-declaring it
 // keeps this file building across chip variants. Same pattern as
@@ -9,22 +10,12 @@
 extern "C" uint64_t esp_rtc_get_time_us(void);
 
 // ============================================================================
-//  Wire-format structs — MUST match the SavedState / SleepTimerFile layouts
-//  in examples/reading_streak/app.c and examples/sleep_timer/app.c. Field
-//  order and types are the on-disk format; the schema-version field gates
-//  upgrades.
+//  Sleep-timer wire format — MUST match SleepTimerFile in
+//  examples/sleep_timer/app.c. Field order and types are the on-disk format;
+//  the schema-version field gates upgrades.
+//  (ReadingStreakFile + its constants live in src/pure/streak_log.h so the
+//  log-advance logic is host-testable.)
 // ============================================================================
-
-struct ReadingStreakFile {
-  uint32_t version;        // == STREAK_SCHEMA
-  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
-  uint32_t lastLoggedDay;  // day index, 0xFFFFFFFFu = never
-  uint32_t currentStreak;
-  uint32_t longestStreak;
-  uint32_t totalSessions;
-  uint32_t bitmapHead;     // day index of bit 0
-  uint32_t bitmap;         // bit i = "logged on day (head - i)"
-};
 
 struct SleepTimerFile {
   uint32_t version;        // == SLEEP_TIMER_SCHEMA
@@ -34,10 +25,6 @@ struct SleepTimerFile {
   uint32_t startedRtcSec;
 };
 
-static const uint32_t STREAK_SCHEMA          = 1;
-static const uint32_t STREAK_DAY_SECS        = 86400u;
-static const int      STREAK_PAGES_THRESHOLD = 5;     // pages today before we log
-
 static const uint32_t SLEEP_TIMER_SCHEMA       = 1;
 static const uint32_t SLEEP_TIMER_IDLE         = 0;
 static const uint32_t SLEEP_TIMER_RUNNING      = 1;
@@ -46,7 +33,7 @@ static const uint32_t SLEEP_TIMER_NEEDS_NOTIFY = 2;
 static struct {
   int      pagesToday        = 0;
   uint32_t cachedFirstRtcSec = 0;
-  uint32_t cachedLastDay     = 0xFFFFFFFFu;
+  uint32_t cachedLastDay     = STREAK_DAY_UNSET;
   bool     bootstrapped      = false;
 } g_streakAuto;
 
@@ -75,14 +62,15 @@ static void writeAppDat(const char* key, const void* buf, size_t len) {
 
 // Increment the streak after enough page turns on a new day. Mirrors the
 // log logic in examples/reading_streak/app.c so manual taps and auto-log
-// produce the same numbers.
+// produce the same numbers. The bitmap-shift + continuation rules live in
+// src/pure/streak_log; this function just owns the I/O + threshold gate.
 static void streakAutoLogOnPageTurn() {
   if (!g_streakAuto.bootstrapped) {
     ReadingStreakFile s;
     if (!readAppDat("streak", &s, sizeof(s)) || s.version != STREAK_SCHEMA) {
       s.version       = STREAK_SCHEMA;
       s.firstRtcSec   = rtcSecondsNow();
-      s.lastLoggedDay = 0xFFFFFFFFu;
+      s.lastLoggedDay = STREAK_DAY_UNSET;
       s.currentStreak = 0;
       s.longestStreak = 0;
       s.totalSessions = 0;
@@ -105,23 +93,14 @@ static void streakAutoLogOnPageTurn() {
   ReadingStreakFile s;
   if (!readAppDat("streak", &s, sizeof(s)) || s.version != STREAK_SCHEMA) return;
 
-  bool cont = (s.lastLoggedDay != 0xFFFFFFFFu) && (today == s.lastLoggedDay + 1);
-  if (today > s.bitmapHead) {
-    uint32_t d = today - s.bitmapHead;
-    s.bitmap     = (d >= 32) ? 0 : (s.bitmap << d);
-    s.bitmapHead = today;
-  }
-  s.bitmap        |= 1u;
-  s.currentStreak  = cont ? (s.currentStreak + 1) : 1;
-  if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
-  s.lastLoggedDay  = today;
-  s.totalSessions += 1;
-  writeAppDat("streak", &s, sizeof(s));
+  StreakLogResult r = applyStreakLog(s, today);
+  if (!r.changed) return;
+  writeAppDat("streak", &r.next, sizeof(r.next));
 
   g_streakAuto.cachedLastDay = today;
   g_streakAuto.pagesToday    = 0;
 
-  Toast::show(String("Reading streak: day ") + String(s.currentStreak));
+  Toast::show(String("Reading streak: day ") + String(r.next.currentStreak));
 }
 
 // Flip RUNNING -> NEEDS_NOTIFY exactly once when the timer first expires,

--- a/Pala_One_2_1/src/ui/reading_hooks.cpp
+++ b/Pala_One_2_1/src/ui/reading_hooks.cpp
@@ -1,0 +1,158 @@
+#include "src/ui/reading_hooks.h"
+
+#include "src/state.h"      // FS (=LittleFS), prefs unused here but matches sibling modules
+#include "src/ui/toast.h"   // Toast::show
+
+// esp_rtc_get_time_us lives in a chip-specific header; forward-declaring it
+// keeps this file building across chip variants. Same pattern as
+// src/ui/pala_api_impl.cpp.
+extern "C" uint64_t esp_rtc_get_time_us(void);
+
+// ============================================================================
+//  Wire-format structs — MUST match the SavedState / SleepTimerFile layouts
+//  in examples/reading_streak/app.c and examples/sleep_timer/app.c. Field
+//  order and types are the on-disk format; the schema-version field gates
+//  upgrades.
+// ============================================================================
+
+struct ReadingStreakFile {
+  uint32_t version;        // == STREAK_SCHEMA
+  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
+  uint32_t lastLoggedDay;  // day index, 0xFFFFFFFFu = never
+  uint32_t currentStreak;
+  uint32_t longestStreak;
+  uint32_t totalSessions;
+  uint32_t bitmapHead;     // day index of bit 0
+  uint32_t bitmap;         // bit i = "logged on day (head - i)"
+};
+
+struct SleepTimerFile {
+  uint32_t version;        // == SLEEP_TIMER_SCHEMA
+  uint32_t status;         // SLEEP_TIMER_IDLE / RUNNING / NEEDS_NOTIFY
+  uint32_t endRtcSec;
+  uint32_t durationMin;
+  uint32_t startedRtcSec;
+};
+
+static const uint32_t STREAK_SCHEMA          = 1;
+static const uint32_t STREAK_DAY_SECS        = 86400u;
+static const int      STREAK_PAGES_THRESHOLD = 5;     // pages today before we log
+
+static const uint32_t SLEEP_TIMER_SCHEMA       = 1;
+static const uint32_t SLEEP_TIMER_IDLE         = 0;
+static const uint32_t SLEEP_TIMER_RUNNING      = 1;
+static const uint32_t SLEEP_TIMER_NEEDS_NOTIFY = 2;
+
+static struct {
+  int      pagesToday        = 0;
+  uint32_t cachedFirstRtcSec = 0;
+  uint32_t cachedLastDay     = 0xFFFFFFFFu;
+  bool     bootstrapped      = false;
+} g_streakAuto;
+
+// Same source of truth that the apps see via PalaAPI::rtcSeconds — RTC
+// microsecond counter scaled to seconds. Survives deep sleep.
+static uint32_t rtcSecondsNow() {
+  return (uint32_t)(esp_rtc_get_time_us() / 1000000ULL);
+}
+
+static bool readAppDat(const char* key, void* buf, size_t expected) {
+  String path = String("/apps/") + key + ".dat";
+  File f = FS.open(path, "r");
+  if (!f) return false;
+  size_t n = f.read((uint8_t*)buf, expected);
+  f.close();
+  return n == expected;
+}
+
+static void writeAppDat(const char* key, const void* buf, size_t len) {
+  String path = String("/apps/") + key + ".dat";
+  File f = FS.open(path, "w");
+  if (!f) return;
+  f.write((const uint8_t*)buf, len);
+  f.close();
+}
+
+// Increment the streak after enough page turns on a new day. Mirrors the
+// log logic in examples/reading_streak/app.c so manual taps and auto-log
+// produce the same numbers.
+static void streakAutoLogOnPageTurn() {
+  if (!g_streakAuto.bootstrapped) {
+    ReadingStreakFile s;
+    if (!readAppDat("streak", &s, sizeof(s)) || s.version != STREAK_SCHEMA) {
+      s.version       = STREAK_SCHEMA;
+      s.firstRtcSec   = rtcSecondsNow();
+      s.lastLoggedDay = 0xFFFFFFFFu;
+      s.currentStreak = 0;
+      s.longestStreak = 0;
+      s.totalSessions = 0;
+      s.bitmapHead    = 0;
+      s.bitmap        = 0;
+      writeAppDat("streak", &s, sizeof(s));
+    }
+    g_streakAuto.cachedFirstRtcSec = s.firstRtcSec;
+    g_streakAuto.cachedLastDay     = s.lastLoggedDay;
+    g_streakAuto.bootstrapped      = true;
+  }
+
+  uint32_t now = rtcSecondsNow();
+  if (now < g_streakAuto.cachedFirstRtcSec) return;           // RTC ran backwards
+  uint32_t today = (now - g_streakAuto.cachedFirstRtcSec) / STREAK_DAY_SECS;
+
+  if (g_streakAuto.cachedLastDay == today) return;            // already logged today
+  if (++g_streakAuto.pagesToday < STREAK_PAGES_THRESHOLD) return;
+
+  ReadingStreakFile s;
+  if (!readAppDat("streak", &s, sizeof(s)) || s.version != STREAK_SCHEMA) return;
+
+  bool cont = (s.lastLoggedDay != 0xFFFFFFFFu) && (today == s.lastLoggedDay + 1);
+  if (today > s.bitmapHead) {
+    uint32_t d = today - s.bitmapHead;
+    s.bitmap     = (d >= 32) ? 0 : (s.bitmap << d);
+    s.bitmapHead = today;
+  }
+  s.bitmap        |= 1u;
+  s.currentStreak  = cont ? (s.currentStreak + 1) : 1;
+  if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
+  s.lastLoggedDay  = today;
+  s.totalSessions += 1;
+  writeAppDat("streak", &s, sizeof(s));
+
+  g_streakAuto.cachedLastDay = today;
+  g_streakAuto.pagesToday    = 0;
+
+  Toast::show(String("Reading streak: day ") + String(s.currentStreak));
+}
+
+// Flip RUNNING -> NEEDS_NOTIFY exactly once when the timer first expires,
+// and toast at that moment. Subsequent page turns are quiet — the
+// sleep_timer app's own UI is the persistent indicator (and it clears
+// the file back to IDLE on acknowledge).
+void sleepTimerCheckExpired() {
+  SleepTimerFile s;
+  if (!readAppDat("sleep_timer", &s, sizeof(s)) || s.version != SLEEP_TIMER_SCHEMA) return;
+  if (s.status != SLEEP_TIMER_RUNNING) return;
+  if (rtcSecondsNow() < s.endRtcSec)   return;
+
+  s.status = SLEEP_TIMER_NEEDS_NOTIFY;
+  writeAppDat("sleep_timer", &s, sizeof(s));
+  Toast::show(String("Sleep timer up (") + String(s.durationMin) + " min)");
+}
+
+void onReaderPageTurn() {
+  streakAutoLogOnPageTurn();
+  sleepTimerCheckExpired();
+}
+
+// Microseconds until a running sleep timer expires, or 0 if no timer is
+// running / it has already passed. Sleep::enter uses this to arm an RTC
+// wake alarm so the device wakes itself at the timer's end.
+uint64_t sleepTimerWakeUs() {
+  SleepTimerFile s;
+  if (!readAppDat("sleep_timer", &s, sizeof(s))) return 0;
+  if (s.version != SLEEP_TIMER_SCHEMA)           return 0;
+  if (s.status  != SLEEP_TIMER_RUNNING)          return 0;
+  uint32_t now = rtcSecondsNow();
+  if (s.endRtcSec <= now)                        return 0;
+  return (uint64_t)(s.endRtcSec - now) * 1000000ULL;
+}

--- a/Pala_One_2_1/src/ui/reading_hooks.h
+++ b/Pala_One_2_1/src/ui/reading_hooks.h
@@ -1,0 +1,32 @@
+#ifndef PALA_UI_READING_HOOKS_H
+#define PALA_UI_READING_HOOKS_H
+
+// ============================================================================
+//  Reading hooks — firmware-side integration with the reading_streak and
+//  sleep_timer example apps.
+//
+//  Both apps own /apps/<key>.dat files; the firmware reads/writes the same
+//  files so the features keep working when the user is in the book rather
+//  than in the app:
+//
+//    - onReaderPageTurn(): called on every real page turn (next/prev) from
+//      the reader and bookmark-preview screens. Auto-logs the reading streak
+//      after STREAK_PAGES_THRESHOLD page turns on a new day, and flips a
+//      RUNNING sleep timer to NEEDS_NOTIFY when its end-time passes.
+//
+//    - sleepTimerCheckExpired(): called once from setup() so a timer that
+//      expired during deep sleep surfaces its toast on the first render
+//      after wake.
+//
+//    - sleepTimerWakeUs(): returns microseconds until a running timer
+//      expires, or 0 if no timer is running or it has already expired.
+//      Used by Sleep::enter to arm an RTC wake alarm.
+// ============================================================================
+
+#include "src/pure/arduino_compat.h"  // uint32_t, uint64_t
+
+void     onReaderPageTurn();
+void     sleepTimerCheckExpired();
+uint64_t sleepTimerWakeUs();
+
+#endif  // PALA_UI_READING_HOOKS_H

--- a/Pala_One_2_1/src/ui/sleep.cpp
+++ b/Pala_One_2_1/src/ui/sleep.cpp
@@ -11,6 +11,7 @@
 #include "src/hal/display.h"
 #include "src/hal/input.h"          // injectButtonEdgeNow, markUserActivity
 #include "src/ui/pala_one_sleep_black_icon_v4.h"
+#include "src/ui/reading_hooks.h"   // sleepTimerWakeUs — arm RTC alarm if timer running
 #include "src/ui/screen.h"
 
 namespace Sleep {
@@ -88,6 +89,13 @@ void enter() {
   rtc_gpio_pulldown_dis((gpio_num_t)BTN);
   rtc_gpio_pullup_en((gpio_num_t)BTN);
   esp_sleep_enable_ext0_wakeup((gpio_num_t)BTN, 0);
+
+  // If a sleep timer is running, also wake at its end-time so the user
+  // gets the toast even if they put the device down.
+  if (uint64_t deltaUs = sleepTimerWakeUs()) {
+    esp_sleep_enable_timer_wakeup(deltaUs);
+  }
+
   delay(50);
   Serial.printf("[sleep] BTN=%d entering deep sleep\n", digitalRead(BTN));
   Serial.flush();

--- a/examples/build.ps1
+++ b/examples/build.ps1
@@ -1,0 +1,122 @@
+# Pala One app builder for Windows.
+#
+# Builds a single example app without requiring `make` or Git Bash. Uses the
+# xtensa-esp32s3 toolchain installed by Arduino IDE plus the system Python.
+#
+# Usage (from the repo root or anywhere):
+#   .\examples\build.ps1 examples\reading_streak
+#   .\examples\build.ps1 examples\wordle
+#   .\examples\build.ps1 examples\click_counter
+#   .\examples\build.ps1 examples\palagotchi -Clean
+#
+# Equivalent to running `make` against the Makefile, but pure PowerShell.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [string]$AppDir,
+
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Locate toolchain --------------------------------------------------------
+$tcBase = Join-Path $env:LOCALAPPDATA 'Arduino15\packages\esp32\tools\esp-x32'
+if (-not (Test-Path $tcBase)) {
+    throw "ESP32 toolchain not found at $tcBase. Install the ESP32 board package via Arduino IDE first."
+}
+$tcVer = (Get-ChildItem $tcBase -Directory | Sort-Object Name -Descending | Select-Object -First 1).Name
+$bin = Join-Path $tcBase "$tcVer\bin"
+
+$cc      = Join-Path $bin 'xtensa-esp32s3-elf-gcc.exe'
+$objcopy = Join-Path $bin 'xtensa-esp32s3-elf-objcopy.exe'
+$nm      = Join-Path $bin 'xtensa-esp32s3-elf-nm.exe'
+$readelf = Join-Path $bin 'xtensa-esp32s3-elf-readelf.exe'
+
+foreach ($t in @($cc, $objcopy, $nm, $readelf)) {
+    if (-not (Test-Path $t)) { throw "Missing toolchain binary: $t" }
+}
+
+# --- Locate Python -----------------------------------------------------------
+$python = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $python) { $python = Get-Command python3 -ErrorAction SilentlyContinue }
+if (-not $python) { throw "Python 3 not found. Install from python.org and ensure `python` is on PATH." }
+$python = $python.Source
+
+# --- Resolve app paths -------------------------------------------------------
+$AppDir = (Resolve-Path $AppDir).Path
+$appName = Split-Path $AppDir -Leaf
+$src    = Join-Path $AppDir 'app.c'
+$ld     = Join-Path $AppDir 'pala_app.ld'
+$elf    = Join-Path $AppDir "$appName.elf"
+$binOut = Join-Path $AppDir "$appName.bin"
+
+if (-not (Test-Path $src)) { throw "No app.c in $AppDir" }
+if (-not (Test-Path $ld))  { throw "No pala_app.ld in $AppDir" }
+
+if ($Clean) {
+    if (Test-Path $elf)    { Remove-Item $elf -Force }
+    if (Test-Path $binOut) { Remove-Item $binOut -Force }
+    Write-Host "Cleaned $appName."
+    return
+}
+
+# --- Resolve firmware header include path ------------------------------------
+# Script lives in examples/; headers are at <repo>/Pala_One_2_1.
+$headers = (Resolve-Path (Join-Path $PSScriptRoot '..\Pala_One_2_1')).Path
+if (-not (Test-Path (Join-Path $headers 'pala_api.h'))) {
+    throw "Cannot find pala_api.h under $headers"
+}
+
+# --- Compile -----------------------------------------------------------------
+$cflags = @(
+    '-fPIC', '-mlongcalls', '-Os', '-fno-jump-tables',
+    '-nostdlib', '-nodefaultlibs',
+    "-I$headers"
+)
+
+Write-Host "[1/3] Compiling $appName ..."
+& $cc @cflags "-Wl,-T,$ld" '-Wl,-shared' '-o' $elf $src
+if ($LASTEXITCODE -ne 0) { throw "gcc failed (exit $LASTEXITCODE)" }
+
+# --- Strip to raw binary -----------------------------------------------------
+Write-Host "[2/3] Stripping ELF to raw binary ..."
+& $objcopy '-O' binary $elf $binOut
+if ($LASTEXITCODE -ne 0) { throw "objcopy failed (exit $LASTEXITCODE)" }
+
+# --- Find app_main entry offset via nm ---------------------------------------
+$nmLines = & $nm $elf
+if ($LASTEXITCODE -ne 0) { throw "nm failed (exit $LASTEXITCODE)" }
+$entryMatch = $nmLines | Where-Object { $_ -match '^([0-9a-fA-F]+)\s+[Tt]\s+app_main$' } | Select-Object -First 1
+if (-not $entryMatch) { throw "app_main symbol not found in $elf" }
+$entryOff = [Convert]::ToUInt32(($entryMatch -split '\s+')[0], 16)
+
+# --- Patch header (entry offset + relocation table) via Python ---------------
+# Mirrors the Python snippet in the Makefile: read readelf -r, collect
+# R_XTENSA_RELATIVE offsets, append them as a table, and write the three
+# patched header fields (entry_offset @40, reloc_offset @44, reloc_count @48).
+Write-Host "[3/3] Patching header (entry + relocation table) ..."
+$pyScript = @'
+import struct, subprocess, sys
+readelf, elf_in, bin_path, entry_off = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+out = subprocess.check_output([readelf, '-r', elf_in], text=True)
+relocs = [int(ln.split()[0], 16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]
+d = bytearray(open(bin_path, 'rb').read())
+struct.pack_into('<I', d, 40, entry_off)
+reloc_off = len(d) if relocs else 0
+d.extend(struct.pack('<' + 'I' * len(relocs), *relocs))
+struct.pack_into('<I', d, 44, reloc_off)
+struct.pack_into('<I', d, 48, len(relocs))
+open(bin_path, 'wb').write(d)
+print(f'relocations: {len(relocs)} ({relocs})')
+'@
+
+& $python -c $pyScript $readelf $elf $binOut $entryOff
+if ($LASTEXITCODE -ne 0) { throw "Python patch step failed (exit $LASTEXITCODE)" }
+
+$size = (Get-Item $binOut).Length
+Write-Host ""
+Write-Host "Built $binOut" -ForegroundColor Green
+Write-Host ("  size:  {0} bytes" -f $size)
+Write-Host ("  entry: 0x{0:x}" -f $entryOff)

--- a/examples/reading_streak/Makefile
+++ b/examples/reading_streak/Makefile
@@ -1,0 +1,39 @@
+TOOLCHAIN_BASE ?= $(HOME)/.arduino15/packages/esp32/tools/esp-x32
+TOOLCHAIN_VER  ?= $(shell ls $(TOOLCHAIN_BASE) 2>/dev/null | sort -V | tail -1)
+TOOLCHAIN      ?= $(TOOLCHAIN_BASE)/$(TOOLCHAIN_VER)/bin
+
+CC      = $(TOOLCHAIN)/xtensa-esp32s3-elf-gcc
+OBJCOPY = $(TOOLCHAIN)/xtensa-esp32s3-elf-objcopy
+NM      = $(TOOLCHAIN)/xtensa-esp32s3-elf-nm
+READELF = $(TOOLCHAIN)/xtensa-esp32s3-elf-readelf
+
+CFLAGS = -fPIC -mlongcalls -Os -fno-jump-tables -nostdlib -nodefaultlibs \
+         -I../../Pala_One_2_1
+
+all: reading_streak.bin
+
+reading_streak.elf: app.c pala_app.ld
+	$(CC) $(CFLAGS) -Wl,-T,pala_app.ld -Wl,-shared -o $@ app.c
+
+reading_streak.bin: reading_streak.elf
+	$(OBJCOPY) -O binary $< $@
+	$(eval ENTRY_OFF := $(shell $(NM) $< | awk '/^[0-9a-f]+ [Tt] app_main$$/{print $$1}'))
+	@[ -n "$(ENTRY_OFF)" ] || (echo "ERROR: app_main symbol not found"; exit 1)
+	python3 -c " \
+import struct, subprocess; \
+out=subprocess.check_output(['$(READELF)','-r','$<'],text=True); \
+relocs=[int(ln.split()[0],16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]; \
+d=bytearray(open('$@','rb').read()); \
+struct.pack_into('<I',d,40,int('$(ENTRY_OFF)',16)); \
+reloc_off=len(d) if relocs else 0; \
+d.extend(struct.pack('<'+'I'*len(relocs),*relocs)); \
+struct.pack_into('<I',d,44,reloc_off); \
+struct.pack_into('<I',d,48,len(relocs)); \
+open('$@','wb').write(d); \
+print(f'relocations: {relocs}')"
+	@echo "Built $@: $$(wc -c < $@) bytes, entry=0x$(ENTRY_OFF)"
+
+clean:
+	rm -f reading_streak.elf reading_streak.bin
+
+.PHONY: all clean

--- a/examples/reading_streak/app.c
+++ b/examples/reading_streak/app.c
@@ -1,0 +1,183 @@
+#include "../../Pala_One_2_1/pala_app.h"
+#include "../../Pala_One_2_1/pala_api.h"
+
+__attribute__((section(".header")))
+const PalaAppHeader pala_header = {
+    .magic        = PALA_APP_MAGIC,
+    .api_version  = PALA_API_VERSION,
+    .name         = "Reading Streak",
+    .entry_offset = 0,
+    .reloc_offset = 0,
+    .reloc_count  = 0,
+};
+
+#define LONG_PRESS_MS    850u
+#define CONFIRM_SHOW_MS  1500u
+#define DAY_SECS         86400u
+#define HISTORY_CELLS    30
+#define BITMAP_BITS      32
+#define UNSET_DAY        0xFFFFFFFFu
+
+/* Persisted state.  All uint32_t to keep alignment portable across rebuilds. */
+typedef struct {
+    uint32_t version;        /* schema version, currently 1 */
+    uint32_t firstRtcSec;    /* rtcSeconds() the very first time app ran */
+    uint32_t lastLoggedDay;  /* day index of most recent log, UNSET_DAY if never */
+    uint32_t currentStreak;
+    uint32_t longestStreak;
+    uint32_t totalSessions;
+    uint32_t bitmapHead;     /* day index that bit 0 of bitmap refers to */
+    uint32_t bitmap;         /* bit i = "logged on day (bitmapHead - i)" */
+} SavedState;
+
+static void drawStreakBar(const PalaAPI* api, int y, uint32_t bitmap) {
+    /* 30 cells, rightmost = today (bit 0), 8 px per cell, centered. */
+    const int cellW  = 8;
+    const int totalW = HISTORY_CELLS * cellW;
+    const int startX = (250 - totalW) / 2;
+    char buf[2];
+    buf[1] = 0;
+    for (int p = 0; p < HISTORY_CELLS; p++) {
+        int bit  = (HISTORY_CELLS - 1) - p;
+        int bold = (p == HISTORY_CELLS - 1) ? 1 : 0;
+        buf[0] = ((bitmap >> bit) & 1u) ? '#' : '.';
+        api->drawTextAt(startX + p * cellW, y, buf, bold);
+    }
+}
+
+static void drawMain(const PalaAPI* api, const SavedState* s, int loggedToday) {
+    char buf[40];
+
+    api->clearScreen();
+    api->drawHeader("Reading Streak");
+
+    api->snprintf_wrap(buf, sizeof(buf), "Current streak: %u days",
+                       (unsigned)s->currentStreak);
+    api->drawTextAt(6, 34, buf, 1);
+
+    api->snprintf_wrap(buf, sizeof(buf), "Longest: %u",
+                       (unsigned)s->longestStreak);
+    api->drawTextAt(6, 48, buf, 0);
+
+    api->snprintf_wrap(buf, sizeof(buf), "Total: %u sessions",
+                       (unsigned)s->totalSessions);
+    api->drawTextAt(6, 62, buf, 0);
+
+    api->drawTextAt(6, 80, "Last 30 days (today on right):", 0);
+    drawStreakBar(api, 96, s->bitmap);
+
+    if (loggedToday) {
+        api->drawTextAt(6, 118, "Logged today.  Hold = exit", 0);
+    } else {
+        api->drawTextAt(6, 118, "Click = log today   Hold = exit", 1);
+    }
+
+    api->refreshDisplay();
+}
+
+static void drawConfirm(const PalaAPI* api, uint32_t streak) {
+    char buf[16];
+    api->clearScreen();
+    api->drawHeader("Reading Streak");
+    api->drawTextAt(95, 36, "Logged!", 1);
+    api->snprintf_wrap(buf, sizeof(buf), "%u", (unsigned)streak);
+    api->drawCenteredLarge(buf);
+    api->drawTextAt(85, 116, "day streak", 0);
+    api->refreshDisplay();
+}
+
+void app_main(const PalaAPI* api) {
+    SavedState s;
+    int hasSave = (api->storageRead("streak", &s, sizeof(s)) == (int)sizeof(s));
+    uint32_t now = api->rtcSeconds();
+
+    if (!hasSave || s.version != 1) {
+        s.version        = 1;
+        s.firstRtcSec    = now;
+        s.lastLoggedDay  = UNSET_DAY;
+        s.currentStreak  = 0;
+        s.longestStreak  = 0;
+        s.totalSessions  = 0;
+        s.bitmapHead     = 0;
+        s.bitmap         = 0;
+    }
+
+    /* RTC went backwards (battery died, was replaced): reset the day baseline
+       but keep cumulative stats so the user doesn't lose their record. */
+    if (now < s.firstRtcSec) {
+        s.firstRtcSec   = now;
+        s.lastLoggedDay = UNSET_DAY;
+        s.currentStreak = 0;
+        s.bitmapHead    = 0;
+        /* keep bitmap, longestStreak, totalSessions */
+    }
+
+    uint32_t today = (now - s.firstRtcSec) / DAY_SECS;
+
+    /* Slide the bitmap forward so bit 0 represents today. */
+    if (today > s.bitmapHead) {
+        uint32_t delta = today - s.bitmapHead;
+        if (delta >= BITMAP_BITS) s.bitmap = 0;
+        else                      s.bitmap <<= delta;
+        s.bitmapHead = today;
+    }
+
+    /* Streak is broken if there's a gap of more than one day since last log. */
+    if (s.lastLoggedDay != UNSET_DAY && today > s.lastLoggedDay + 1) {
+        s.currentStreak = 0;
+    }
+
+    /* Persist the normalized state so future opens see consistent values. */
+    api->storageWrite("streak", &s, sizeof(s));
+
+    int loggedToday      = (s.lastLoggedDay == today) ? 1 : 0;
+    int needsRedraw      = 1;
+    int showingConfirm   = 0;
+    uint32_t confirmStart = 0;
+    uint32_t pressStart   = 0;
+
+    while (1) {
+        uint32_t mNow = api->millisNow();
+
+        /* Long-press exit, fires while held (same pattern as click_counter). */
+        if (api->buttonPressed()) {
+            if (pressStart == 0) pressStart = mNow;
+            if ((mNow - pressStart) >= LONG_PRESS_MS) {
+                api->storageWrite("streak", &s, sizeof(s));
+                return;
+            }
+        } else {
+            pressStart = 0;
+        }
+
+        /* pendingPresses() bypasses multi-click grouping for a snappy tap. */
+        uint32_t presses = api->pendingPresses();
+        if (presses > 0 && !loggedToday) {
+            int isContinuation = (s.lastLoggedDay != UNSET_DAY) &&
+                                 (today == s.lastLoggedDay + 1);
+            s.bitmap        |= 1u;
+            s.currentStreak  = isContinuation ? (s.currentStreak + 1) : 1;
+            if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
+            s.lastLoggedDay  = today;
+            s.totalSessions += 1;
+            loggedToday      = 1;
+            api->storageWrite("streak", &s, sizeof(s));
+
+            showingConfirm = 1;
+            confirmStart   = mNow;
+            drawConfirm(api, s.currentStreak);
+        }
+
+        if (showingConfirm && (mNow - confirmStart) >= CONFIRM_SHOW_MS) {
+            showingConfirm = 0;
+            needsRedraw    = 1;
+        }
+
+        if (needsRedraw && !showingConfirm) {
+            drawMain(api, &s, loggedToday);
+            needsRedraw = 0;
+        }
+
+        api->delayMs(10);
+    }
+}

--- a/examples/reading_streak/pala_app.ld
+++ b/examples/reading_streak/pala_app.ld
@@ -1,0 +1,8 @@
+ENTRY(app_main)
+SECTIONS {
+    .header   0 : { KEEP(*(.header)) }
+    .literal    : { *(.literal) *(.literal.*) }
+    .text       : { *(.text*) }
+    .rodata     : { *(.rodata*) }
+    .data       : { *(.data*) }
+}

--- a/examples/sleep_timer/Makefile
+++ b/examples/sleep_timer/Makefile
@@ -1,0 +1,39 @@
+TOOLCHAIN_BASE ?= $(HOME)/.arduino15/packages/esp32/tools/esp-x32
+TOOLCHAIN_VER  ?= $(shell ls $(TOOLCHAIN_BASE) 2>/dev/null | sort -V | tail -1)
+TOOLCHAIN      ?= $(TOOLCHAIN_BASE)/$(TOOLCHAIN_VER)/bin
+
+CC      = $(TOOLCHAIN)/xtensa-esp32s3-elf-gcc
+OBJCOPY = $(TOOLCHAIN)/xtensa-esp32s3-elf-objcopy
+NM      = $(TOOLCHAIN)/xtensa-esp32s3-elf-nm
+READELF = $(TOOLCHAIN)/xtensa-esp32s3-elf-readelf
+
+CFLAGS = -fPIC -mlongcalls -Os -fno-jump-tables -nostdlib -nodefaultlibs \
+         -I../../Pala_One_2_1
+
+all: sleep_timer.bin
+
+sleep_timer.elf: app.c pala_app.ld
+	$(CC) $(CFLAGS) -Wl,-T,pala_app.ld -Wl,-shared -o $@ app.c
+
+sleep_timer.bin: sleep_timer.elf
+	$(OBJCOPY) -O binary $< $@
+	$(eval ENTRY_OFF := $(shell $(NM) $< | awk '/^[0-9a-f]+ [Tt] app_main$$/{print $$1}'))
+	@[ -n "$(ENTRY_OFF)" ] || (echo "ERROR: app_main symbol not found"; exit 1)
+	python3 -c " \
+import struct, subprocess; \
+out=subprocess.check_output(['$(READELF)','-r','$<'],text=True); \
+relocs=[int(ln.split()[0],16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]; \
+d=bytearray(open('$@','rb').read()); \
+struct.pack_into('<I',d,40,int('$(ENTRY_OFF)',16)); \
+reloc_off=len(d) if relocs else 0; \
+d.extend(struct.pack('<'+'I'*len(relocs),*relocs)); \
+struct.pack_into('<I',d,44,reloc_off); \
+struct.pack_into('<I',d,48,len(relocs)); \
+open('$@','wb').write(d); \
+print(f'relocations: {relocs}')"
+	@echo "Built $@: $$(wc -c < $@) bytes, entry=0x$(ENTRY_OFF)"
+
+clean:
+	rm -f sleep_timer.elf sleep_timer.bin
+
+.PHONY: all clean

--- a/examples/sleep_timer/app.c
+++ b/examples/sleep_timer/app.c
@@ -1,0 +1,180 @@
+#include "../../Pala_One_2_1/pala_app.h"
+#include "../../Pala_One_2_1/pala_api.h"
+
+__attribute__((section(".header")))
+const PalaAppHeader pala_header = {
+    .magic        = PALA_APP_MAGIC,
+    .api_version  = PALA_API_VERSION,
+    .name         = "Sleep Timer",
+    .entry_offset = 0,
+    .reloc_offset = 0,
+    .reloc_count  = 0,
+};
+
+#define LONG_PRESS_MS  850u
+
+/* Status values are part of the wire format the firmware reads from
+   /apps/sleep_timer.dat. The firmware checks the file after each reader
+   page turn and shows a "time's up" toast when ST_RUNNING has elapsed.
+   Field order in SleepTimerFile is frozen — do not reorder. */
+#define ST_IDLE          0
+#define ST_RUNNING       1
+#define ST_NEEDS_NOTIFY  2
+
+typedef struct {
+    uint32_t version;        /* schema version, currently 1 */
+    uint32_t status;         /* ST_IDLE / ST_RUNNING / ST_NEEDS_NOTIFY */
+    uint32_t endRtcSec;      /* rtcSeconds() value when timer should fire */
+    uint32_t durationMin;    /* original duration; remembered across runs */
+    uint32_t startedRtcSec;  /* rtcSeconds() at start of current run */
+} SleepTimerFile;
+
+static const uint32_t DURATIONS[] = {5, 10, 15, 20, 25, 30, 45, 60};
+#define NUM_DURATIONS         ((int)(sizeof(DURATIONS) / sizeof(DURATIONS[0])))
+#define DEFAULT_DURATION_IDX  4    /* 25 min — common reading session length */
+
+static void drawIdle(const PalaAPI* api, uint32_t durationMin) {
+    char buf[16];
+    api->clearScreen();
+    api->drawHeader("Sleep Timer");
+    api->drawTextAt(78, 34, "Set duration", 0);
+    api->snprintf_wrap(buf, sizeof(buf), "%u min", (unsigned)durationMin);
+    api->drawCenteredLarge(buf);
+    api->drawTextAt(8, 118, "Click=cycle  2x=start  Hold=exit", 0);
+    api->refreshDisplay();
+}
+
+static void drawRunning(const PalaAPI* api, uint32_t remainingSec, uint32_t durationMin) {
+    char buf[24];
+    api->clearScreen();
+    api->drawHeader("Sleep Timer");
+
+    uint32_t mins = remainingSec / 60u;
+    uint32_t secs = remainingSec - (mins * 60u);
+    api->snprintf_wrap(buf, sizeof(buf), "%u:%02u", (unsigned)mins, (unsigned)secs);
+    api->drawCenteredLarge(buf);
+
+    api->snprintf_wrap(buf, sizeof(buf), "%u-min timer", (unsigned)durationMin);
+    api->drawTextAt(82, 108, buf, 0);
+    api->drawTextAt(8, 118, "Click=cancel  Hold=exit (keeps running)", 0);
+    api->refreshDisplay();
+}
+
+static void drawNotify(const PalaAPI* api, uint32_t durationMin) {
+    char buf[24];
+    api->clearScreen();
+    api->drawHeader("Sleep Timer");
+    api->drawCenteredLarge("Time's up!");
+    api->snprintf_wrap(buf, sizeof(buf), "(%u-min timer)", (unsigned)durationMin);
+    api->drawTextAt(82, 108, buf, 0);
+    api->drawTextAt(38, 118, "Click=dismiss   Hold=exit", 0);
+    api->refreshDisplay();
+}
+
+void app_main(const PalaAPI* api) {
+    SleepTimerFile s;
+    int hasSave = (api->storageRead("sleep_timer", &s, sizeof(s)) == (int)sizeof(s));
+    uint32_t now = api->rtcSeconds();
+
+    if (!hasSave || s.version != 1) {
+        s.version       = 1;
+        s.status        = ST_IDLE;
+        s.endRtcSec     = 0;
+        s.durationMin   = DURATIONS[DEFAULT_DURATION_IDX];
+        s.startedRtcSec = 0;
+    }
+
+    /* If a stored timer is running but already past its end, treat as expired. */
+    if (s.status == ST_RUNNING && now >= s.endRtcSec) {
+        s.status = ST_NEEDS_NOTIFY;
+    }
+
+    /* Find current duration index for cycling. Defaults to 25 min if unmatched. */
+    int durIdx = DEFAULT_DURATION_IDX;
+    for (int i = 0; i < NUM_DURATIONS; i++) {
+        if (DURATIONS[i] == s.durationMin) { durIdx = i; break; }
+    }
+
+    api->storageWrite("sleep_timer", &s, sizeof(s));
+
+    int needsRedraw       = 1;
+    uint32_t pressStart   = 0;
+    uint32_t lastDispSec  = 0;
+
+    while (1) {
+        uint32_t mNow = api->millisNow();
+        now = api->rtcSeconds();
+
+        /* Long-press exit. Timer state is preserved on disk; if it's running,
+           the firmware will still show the toast when it expires. */
+        if (api->buttonPressed()) {
+            if (pressStart == 0) pressStart = mNow;
+            if ((mNow - pressStart) >= LONG_PRESS_MS) {
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                return;
+            }
+        } else {
+            pressStart = 0;
+        }
+
+        /* In-app expiration detection (when user is watching the countdown). */
+        if (s.status == ST_RUNNING && now >= s.endRtcSec) {
+            s.status = ST_NEEDS_NOTIFY;
+            api->storageWrite("sleep_timer", &s, sizeof(s));
+            needsRedraw = 1;
+        }
+
+        uint8_t evt = api->pollEvent();
+
+        if (s.status == ST_IDLE) {
+            if (evt == PALA_CLICK) {
+                durIdx += 1;
+                if (durIdx >= NUM_DURATIONS) durIdx = 0;
+                s.durationMin = DURATIONS[durIdx];
+                needsRedraw = 1;
+            } else if (evt == PALA_DOUBLE) {
+                s.status        = ST_RUNNING;
+                s.startedRtcSec = now;
+                s.endRtcSec     = now + (s.durationMin * 60u);
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                needsRedraw = 1;
+            }
+        } else if (s.status == ST_RUNNING) {
+            if (evt == PALA_CLICK) {
+                /* Cancel and return to idle. */
+                s.status        = ST_IDLE;
+                s.endRtcSec     = 0;
+                s.startedRtcSec = 0;
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                needsRedraw = 1;
+            }
+            /* Tick the seconds display once per real second. */
+            if (now != lastDispSec) {
+                lastDispSec = now;
+                needsRedraw = 1;
+            }
+        } else { /* ST_NEEDS_NOTIFY */
+            if (evt != 0) {
+                s.status        = ST_IDLE;
+                s.endRtcSec     = 0;
+                s.startedRtcSec = 0;
+                api->storageWrite("sleep_timer", &s, sizeof(s));
+                needsRedraw = 1;
+            }
+        }
+
+        if (needsRedraw) {
+            if (s.status == ST_IDLE) {
+                drawIdle(api, s.durationMin);
+            } else if (s.status == ST_RUNNING) {
+                uint32_t remaining = (now < s.endRtcSec) ? (s.endRtcSec - now) : 0;
+                drawRunning(api, remaining, s.durationMin);
+            } else {
+                drawNotify(api, s.durationMin);
+            }
+            needsRedraw = 0;
+        }
+
+        api->delayMs(50);
+    }
+}

--- a/examples/sleep_timer/pala_app.ld
+++ b/examples/sleep_timer/pala_app.ld
@@ -1,0 +1,8 @@
+ENTRY(app_main)
+SECTIONS {
+    .header   0 : { KEEP(*(.header)) }
+    .literal    : { *(.literal) *(.literal.*) }
+    .text       : { *(.text*) }
+    .rodata     : { *(.rodata*) }
+    .data       : { *(.data*) }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SUT_SRC
   ${FW_SRC}/pure/bookmarks_codec.cpp
   ${FW_SRC}/pure/list_codec.cpp
   ${FW_SRC}/pure/app_header.cpp
+  ${FW_SRC}/pure/streak_log.cpp
   ${FW_SRC}/storage/book_metadata.cpp
   ${FW_SRC}/storage/list_items.cpp
 )
@@ -40,6 +41,7 @@ set(TEST_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/test_bookmarks_store.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_list_store.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_app_header.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_streak_log.cpp
 )
 
 add_executable(host_tests ${SUT_SRC} ${TEST_SRC})

--- a/test/test_streak_log.cpp
+++ b/test/test_streak_log.cpp
@@ -1,0 +1,102 @@
+// Tests for src/pure/streak_log.cpp.
+//
+// applyStreakLog is the pure half of the reading-streak feature — given a
+// `ReadingStreakFile` (the on-disk wire format) and `today` (a day index),
+// it computes the next state. The bitmap-shift + continuation rules need
+// to match the in-app logic byte for byte so manual taps and the
+// firmware's auto-log produce identical numbers; these tests pin that.
+
+#include "test_framework.h"
+#include "pure/streak_log.h"
+
+static ReadingStreakFile freshState() {
+  ReadingStreakFile s{};
+  s.version       = STREAK_SCHEMA;
+  s.firstRtcSec   = 0;
+  s.lastLoggedDay = STREAK_DAY_UNSET;
+  s.currentStreak = 0;
+  s.longestStreak = 0;
+  s.totalSessions = 0;
+  s.bitmapHead    = 0;
+  s.bitmap        = 0;
+  return s;
+}
+
+TEST_CASE("applyStreakLog starts streak at 1 on first ever log") {
+  ReadingStreakFile s = freshState();
+  StreakLogResult r = applyStreakLog(s, 10);
+  REQUIRE(r.changed);
+  CHECK_EQ(r.next.currentStreak, 1u);
+  CHECK_EQ(r.next.longestStreak, 1u);
+  CHECK_EQ(r.next.totalSessions, 1u);
+  CHECK_EQ(r.next.lastLoggedDay, 10u);
+  CHECK_EQ(r.next.bitmapHead, 10u);
+  CHECK_EQ(r.next.bitmap & 1u, 1u);
+}
+
+TEST_CASE("applyStreakLog continues streak on consecutive days") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, 10).next;
+  s = applyStreakLog(s, 11).next;
+  s = applyStreakLog(s, 12).next;
+  CHECK_EQ(s.currentStreak, 3u);
+  CHECK_EQ(s.longestStreak, 3u);
+  CHECK_EQ(s.totalSessions, 3u);
+  CHECK_EQ(s.lastLoggedDay, 12u);
+}
+
+TEST_CASE("applyStreakLog resets streak after a gap but keeps longest") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, 10).next;
+  s = applyStreakLog(s, 11).next;
+  s = applyStreakLog(s, 12).next;   // streak 3, longest 3
+  s = applyStreakLog(s, 20).next;   // gap of 7 days -> reset to 1
+  CHECK_EQ(s.currentStreak, 1u);
+  CHECK_EQ(s.longestStreak, 3u);
+  CHECK_EQ(s.totalSessions, 4u);
+}
+
+TEST_CASE("applyStreakLog is a no-op when logging the same day twice") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, 10).next;
+  StreakLogResult r = applyStreakLog(s, 10);
+  CHECK(!r.changed);
+  CHECK_EQ(r.next.currentStreak, 1u);
+  CHECK_EQ(r.next.totalSessions, 1u);
+}
+
+TEST_CASE("applyStreakLog bitmap tracks the last 32 days") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, 100).next;
+  s = applyStreakLog(s, 101).next;  // bit 1
+  s = applyStreakLog(s, 103).next;  // bit 3 (gap of 1 day stays in window)
+  // Bitmap: today (bit 0) + bit 2 (day 101) + bit 3 (day 100... wait)
+  // After head=103: shifted by (103-100)=3 from prior head 100.
+  // bitmap before shift: 0b0110 (bits 0,1,2 from 100/101/102? actually
+  // we set bit0 each log). Let's just check the shape:
+  //   day 100 logged -> head=100, bitmap = ...0001
+  //   day 101 logged -> shift by 1 -> ...0010 then |1 -> ...0011, head=101
+  //   day 103 logged -> shift by 2 -> ...1100 then |1 -> ...1101, head=103
+  CHECK_EQ(s.bitmapHead, 103u);
+  CHECK_EQ(s.bitmap, 0b1101u);
+}
+
+TEST_CASE("applyStreakLog clears bitmap when shift >= 32") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, 100).next;
+  s = applyStreakLog(s, 101).next;
+  // Jump > 32 days. The bitmap shift of >=32 in a uint32_t is undefined in
+  // C++ if done with a raw `<<`; applyStreakLog clamps to 0 explicitly so
+  // the result is deterministic.
+  s = applyStreakLog(s, 200).next;
+  CHECK_EQ(s.bitmapHead, 200u);
+  CHECK_EQ(s.bitmap, 1u);  // only today's bit
+}
+
+TEST_CASE("applyStreakLog preserves firstRtcSec and version") {
+  ReadingStreakFile s = freshState();
+  s.firstRtcSec = 0x12345678;
+  StreakLogResult r = applyStreakLog(s, 5);
+  CHECK_EQ(r.next.firstRtcSec, 0x12345678u);
+  CHECK_EQ(r.next.version,     STREAK_SCHEMA);
+}


### PR DESCRIPTION
## Summary

Re-target of #12 against the new `dev` (PlatformIO modular) layout. The original main-targeted patch won't apply after the refactor, so this is a fresh port; on-disk wire format is identical to the original.

Two example apps plus the firmware hooks they need to keep working when the user is in the book rather than the app:

- **`examples/reading_streak/`** — daily check-in with a rolling 32-day bitmap and streak / longest / total stats. Persists `/apps/streak.dat`.
- **`examples/sleep_timer/`** — cycles preset durations (5/10/15/20/25/30/45/60 min) via click; double-click starts, hold exits, click during run cancels. Persists `/apps/sleep_timer.dat`.
- **`examples/build.ps1`** — Windows PowerShell builder for the example apps (no `make` / Git Bash needed). Firmware still builds via PlatformIO; this is only for the app `.bin` builds.

The firmware side splits into two pieces. The deterministic core — bitmap-shift + continuation rules that decide what a "log session for day N" does to the saved state — lives in a pure module so it's host-testable:

**`Pala_One_2_1/src/pure/streak_log.{cpp,h}`**

```
cpp
StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t today);
```

The I/O wrapper (read/write /apps/streak.dat, bootstrap on first call, pages-today threshold gate) lives in Pala_One_2_1/src/ui/reading_hooks.cpp alongside the sleep-timer hooks:

- onReaderPageTurn() is called from advancePage() / retreatPage() in src/ui/reader.cpp. Threshold-gates and then delegates the state transition to applyStreakLog. Bookmark-add doesn't go through advance/retreat, so it correctly stays uncounted.

- sleepTimerCheckExpired() flips a running timer to NEEDS_NOTIFY exactly once when its end-time passes; called from setup() so a timer that expired during deep sleep surfaces its toast on the first render after wake.

- sleepTimerWakeUs() is consulted by Sleep::enter() to arm esp_sleep_enable_timer_wakeup() if a timer is running, so the device wakes itself at the timer's end-time rather than waiting for the next button press.

The struct layout in streak_log.h mirrors the app-side SavedState byte-for-byte, with a schema-version field gating future upgrades.

No .gitignore changes are needed — dev's blanket *.bin / *.elf rules already cover the example apps' build artifacts.

Tests
test/test_streak_log.cpp — 7 cases exercising the pure rules against concrete day indices, no FS / RTC / Toast needed:

- First-ever log starts streak at 1, longest = 1, totalSessions = 1.
- Consecutive days extend streak; longest tracks the peak.
- Gap (today > lastLoggedDay + 1) resets currentStreak to 1, preserves longestStreak.
- Same-day re-log is a no-op (changed=false).
- Bitmap shift within the 32-day window leaves the expected bits set (e.g. days 100 → 101 → 103 = 0b1101 from head 103).
- Bitmap shift ≥ 32 days clears the bitmap — applyStreakLog clamps the shift explicitly so a uint32_t << >=32 (UB in C++) can't manifest.
- firstRtcSec + version pass through unchanged.

Verified locally on the rebased branch (Windows / MSVC 19.50, all 7 cases + 113 pre-existing tests pass, 0 failures):
```

cmake -S test -B test/build
cmake --build test/build
.\test\build\Debug\host_tests.exe
```