### PR TITLE
Lifetime page-turn and button-press counters + Stats example app

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -74,6 +74,7 @@
 #include "src/storage/library.h"
 #include "src/storage/list_items.h"
 #include "src/storage/page_cache.h"
+#include "src/storage/stats.h"
 #include "src/ui/font.h"
 #include "src/ui/pala_api_impl.h"
 #include "src/ui/reader.h"
@@ -152,6 +153,10 @@ void setup() {
   registerWebRoutes();
   markUserActivity();
 
+  // RTC RAM holds the working counters across deep sleep; on a cold boot
+  // they're zeroed, so reload from /apps/stats.dat. No-op on warm wake.
+  statsEnsureLoaded();
+
   if (tryRestoreReadingSession()) {
     renderCurrentPage();      // ~300ms draw — wake-press releases during this
     resetInputFrontend();     // then discard the wake-press only
@@ -176,6 +181,21 @@ void loop() {
 
   ButtonEvent ev = ButtonEvent::fromButtonState(g_btns);
   if (ev.any()) markUserActivity();
+
+  // Stats: peekPressCount is the raw short-press counter — every
+  // press-release pair bumps it (long-holds excluded). Delta against the
+  // last seen value adds those into the lifetime counter. If the apps
+  // API consumed-and-reset between ticks, current < lastSeen — clamp
+  // and continue rather than underflow.
+  {
+    static uint32_t lastSeenPressCount = 0;
+    uint32_t pc = g_btns.peekPressCount();
+    if (pc < lastSeenPressCount) lastSeenPressCount = pc;
+    if (pc != lastSeenPressCount) {
+      statsBumpButtons(pc - lastSeenPressCount);
+      lastSeenPressCount = pc;
+    }
+  }
 
   if (ENABLE_DEEP_SLEEP && g_currentScreen->allowSleep()) {
     if (userIdleMs() > Sleep::idleTimeoutMs()) {

--- a/Pala_One_2_1/src/hal/input.h
+++ b/Pala_One_2_1/src/hal/input.h
@@ -84,6 +84,13 @@ struct ButtonState {
     return n;
   }
 
+  // Read the accumulated raw short-press count without resetting it. Used
+  // by the lifetime-stats counter in `loop()`, which diffs against its
+  // last-seen value each tick. Independent of `consumePressCount` — the
+  // apps API can still consume + reset; stats clamps `lastSeen` to the
+  // current value on the next tick to recover.
+  uint32_t peekPressCount() const { return rawPressCount_; }
+
   bool anyClick() const {
     return shortClick_ || doubleClick_ || tripleClick_ || quadClick_ || longClick_;
   }

--- a/Pala_One_2_1/src/pure/stats_codec.cpp
+++ b/Pala_One_2_1/src/pure/stats_codec.cpp
@@ -1,0 +1,15 @@
+#include "src/pure/stats_codec.h"
+
+#include <cstring>  // memcpy
+
+size_t encodeStats(const StatsFile& s, uint8_t* buf) {
+  std::memcpy(buf, &s, sizeof(s));
+  return sizeof(s);
+}
+
+bool decodeStats(const uint8_t* buf, size_t len, StatsFile& out) {
+  if (len != STATS_ENCODED_SIZE) return false;
+  std::memcpy(&out, buf, sizeof(out));
+  if (out.version != STATS_SCHEMA) return false;
+  return true;
+}

--- a/Pala_One_2_1/src/pure/stats_codec.h
+++ b/Pala_One_2_1/src/pure/stats_codec.h
@@ -1,0 +1,38 @@
+#ifndef PALA_PURE_STATS_CODEC_H
+#define PALA_PURE_STATS_CODEC_H
+
+#include "src/pure/arduino_compat.h"  // uint32_t, uint64_t, size_t
+
+// ============================================================================
+//  Stats wire format + pure encode/decode.
+//
+//  Lives in pure/ so the schema-version check and round-trip are
+//  host-testable independent of LittleFS / RTC RAM. The firmware side
+//  (storage/stats.cpp) owns the RTC-RAM working counters and the flash I/O;
+//  it converts between the in-memory counters and `StatsFile` via the codec.
+//
+//  The struct layout is shared with examples/stats/app.c (schema-version
+//  gated). MUST stay byte-identical to the app-side definition.
+// ============================================================================
+
+static const uint32_t STATS_SCHEMA = 1;
+
+struct StatsFile {
+  uint32_t version;        // == STATS_SCHEMA
+  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
+  uint64_t pagesRead;
+  uint64_t buttonPresses;
+};
+
+static const size_t STATS_ENCODED_SIZE = sizeof(StatsFile);
+
+// Serialise `s` into `buf`. Caller must ensure `buf` has at least
+// STATS_ENCODED_SIZE bytes. Returns the number of bytes written.
+size_t encodeStats(const StatsFile& s, uint8_t* buf);
+
+// Parse `len` bytes from `buf` into `out`. Returns true on a valid record
+// (schema matches, length exact), false otherwise — caller treats false as
+// "reinitialise from zero state".
+bool decodeStats(const uint8_t* buf, size_t len, StatsFile& out);
+
+#endif  // PALA_PURE_STATS_CODEC_H

--- a/Pala_One_2_1/src/storage/stats.cpp
+++ b/Pala_One_2_1/src/storage/stats.cpp
@@ -1,0 +1,83 @@
+#include "src/storage/stats.h"
+
+#include "src/state.h"   // FS (=LittleFS)
+
+// esp_rtc_get_time_us lives in a chip-specific header; forward-declaring it
+// keeps this file building across chip variants. Same pattern as
+// src/ui/pala_api_impl.cpp.
+extern "C" uint64_t esp_rtc_get_time_us(void);
+
+// ============================================================================
+//  Wire format — MUST stay byte-identical to StatsFile in examples/stats/app.c.
+// ============================================================================
+struct StatsFile {
+  uint32_t version;        // == STATS_SCHEMA
+  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
+  uint64_t pagesRead;
+  uint64_t buttonPresses;
+};
+
+static const uint32_t STATS_SCHEMA             = 1;
+static const uint32_t STATS_FLUSH_EVERY_EVENTS = 100;
+
+// Working counters live in RTC RAM. Preserved across deep sleep; lost on
+// cold boot, which `statsEnsureLoaded` repairs from /apps/stats.dat.
+RTC_DATA_ATTR static uint64_t s_pagesRead          = 0;
+RTC_DATA_ATTR static uint64_t s_buttonPresses      = 0;
+RTC_DATA_ATTR static uint32_t s_firstRtcSec        = 0;
+RTC_DATA_ATTR static uint32_t s_eventsSinceFlush   = 0;
+RTC_DATA_ATTR static bool     s_rtcInitialised     = false;
+
+static uint32_t rtcSecondsNow() {
+  return (uint32_t)(esp_rtc_get_time_us() / 1000000ULL);
+}
+
+void statsFlushToFile() {
+  StatsFile s;
+  s.version       = STATS_SCHEMA;
+  s.firstRtcSec   = s_firstRtcSec;
+  s.pagesRead     = s_pagesRead;
+  s.buttonPresses = s_buttonPresses;
+
+  File f = FS.open("/apps/stats.dat", "w");
+  if (!f) return;
+  f.write((const uint8_t*)&s, sizeof(s));
+  f.close();
+
+  s_eventsSinceFlush = 0;
+}
+
+void statsEnsureLoaded() {
+  if (s_rtcInitialised) return;
+
+  StatsFile s;
+  File f = FS.open("/apps/stats.dat", "r");
+  if (f && f.read((uint8_t*)&s, sizeof(s)) == sizeof(s) && s.version == STATS_SCHEMA) {
+    s_pagesRead     = s.pagesRead;
+    s_buttonPresses = s.buttonPresses;
+    s_firstRtcSec   = s.firstRtcSec;
+  } else {
+    s_pagesRead     = 0;
+    s_buttonPresses = 0;
+    s_firstRtcSec   = rtcSecondsNow();
+  }
+  if (f) f.close();
+
+  s_eventsSinceFlush = 0;
+  s_rtcInitialised   = true;
+}
+
+static inline void bumpEventsAndMaybeFlush() {
+  if (++s_eventsSinceFlush >= STATS_FLUSH_EVERY_EVENTS) statsFlushToFile();
+}
+
+void statsBumpPages() {
+  s_pagesRead++;
+  bumpEventsAndMaybeFlush();
+}
+
+void statsBumpButtons(uint32_t delta) {
+  if (delta == 0) return;
+  s_buttonPresses += delta;
+  bumpEventsAndMaybeFlush();
+}

--- a/Pala_One_2_1/src/storage/stats.cpp
+++ b/Pala_One_2_1/src/storage/stats.cpp
@@ -1,23 +1,13 @@
 #include "src/storage/stats.h"
 
-#include "src/state.h"   // FS (=LittleFS)
+#include "src/pure/stats_codec.h"  // StatsFile + encodeStats / decodeStats
+#include "src/state.h"             // FS (=LittleFS)
 
 // esp_rtc_get_time_us lives in a chip-specific header; forward-declaring it
 // keeps this file building across chip variants. Same pattern as
 // src/ui/pala_api_impl.cpp.
 extern "C" uint64_t esp_rtc_get_time_us(void);
 
-// ============================================================================
-//  Wire format — MUST stay byte-identical to StatsFile in examples/stats/app.c.
-// ============================================================================
-struct StatsFile {
-  uint32_t version;        // == STATS_SCHEMA
-  uint32_t firstRtcSec;    // rtcSeconds() at first ever write
-  uint64_t pagesRead;
-  uint64_t buttonPresses;
-};
-
-static const uint32_t STATS_SCHEMA             = 1;
 static const uint32_t STATS_FLUSH_EVERY_EVENTS = 100;
 
 // Working counters live in RTC RAM. Preserved across deep sleep; lost on
@@ -39,9 +29,12 @@ void statsFlushToFile() {
   s.pagesRead     = s_pagesRead;
   s.buttonPresses = s_buttonPresses;
 
+  uint8_t buf[STATS_ENCODED_SIZE];
+  size_t n = encodeStats(s, buf);
+
   File f = FS.open("/apps/stats.dat", "w");
   if (!f) return;
-  f.write((const uint8_t*)&s, sizeof(s));
+  f.write(buf, n);
   f.close();
 
   s_eventsSinceFlush = 0;
@@ -50,9 +43,16 @@ void statsFlushToFile() {
 void statsEnsureLoaded() {
   if (s_rtcInitialised) return;
 
-  StatsFile s;
+  uint8_t buf[STATS_ENCODED_SIZE];
+  size_t  got = 0;
   File f = FS.open("/apps/stats.dat", "r");
-  if (f && f.read((uint8_t*)&s, sizeof(s)) == sizeof(s) && s.version == STATS_SCHEMA) {
+  if (f) {
+    got = f.read(buf, sizeof(buf));
+    f.close();
+  }
+
+  StatsFile s;
+  if (decodeStats(buf, got, s)) {
     s_pagesRead     = s.pagesRead;
     s_buttonPresses = s.buttonPresses;
     s_firstRtcSec   = s.firstRtcSec;
@@ -61,7 +61,6 @@ void statsEnsureLoaded() {
     s_buttonPresses = 0;
     s_firstRtcSec   = rtcSecondsNow();
   }
-  if (f) f.close();
 
   s_eventsSinceFlush = 0;
   s_rtcInitialised   = true;

--- a/Pala_One_2_1/src/storage/stats.h
+++ b/Pala_One_2_1/src/storage/stats.h
@@ -1,0 +1,34 @@
+#ifndef PALA_STORAGE_STATS_H
+#define PALA_STORAGE_STATS_H
+
+#include "src/pure/arduino_compat.h"  // uint32_t
+
+// ============================================================================
+//  Stats — lifetime page-turn and button-press counters.
+//
+//  Working counters live in RTC RAM (survive deep sleep, unlimited writes).
+//  Flash flush happens at sleep-entry and every STATS_FLUSH_EVERY_EVENTS
+//  bumps as a safety net. Cold-boot reload comes from /apps/stats.dat, which
+//  the Stats example app reads to display the totals.
+//
+//  The wire-format struct lives in stats.cpp and MUST stay byte-identical
+//  to the StatsFile in examples/stats/app.c.
+// ============================================================================
+
+// Cold-boot reload from /apps/stats.dat. No-op if RTC RAM was preserved
+// across a deep-sleep cycle. Call once early in setup().
+void statsEnsureLoaded();
+
+// Bump the lifetime page-turn counter by one. Auto-flushes to flash every
+// STATS_FLUSH_EVERY_EVENTS bumps.
+void statsBumpPages();
+
+// Bump the lifetime button-press counter by `delta`. No-op if delta == 0.
+// Auto-flushes alongside page bumps.
+void statsBumpButtons(uint32_t delta);
+
+// Force a flush of RTC RAM counters to /apps/stats.dat. Called at deep-sleep
+// entry so any in-flight deltas land before power-down.
+void statsFlushToFile();
+
+#endif  // PALA_STORAGE_STATS_H

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -6,6 +6,7 @@
 #include "src/storage/library.h"   // g_library — openBookByIndex reads it
 #include "src/storage/page_cache.h"
 #include "src/storage/preferences_store.h"
+#include "src/storage/stats.h"              // statsBumpPages — lifetime page-turn counter
 
 #include "src/ui/font.h"                    // currentBodySize/currentLineGap for cache stamping
 #include "src/ui/screens/library_screen.h"  // navigateToLibraryRoot — fallback on error
@@ -312,6 +313,7 @@ bool advancePage() {
   if (targetPage >= g_bookview.pages.count) return false;
   g_bookview.cursor.pageIndex = targetPage;
   g_bookview.cursor.pageTurnsSinceFull++;
+  statsBumpPages();
   return true;
 }
 
@@ -319,6 +321,7 @@ bool retreatPage() {
   if (g_bookview.cursor.pageIndex <= 0) return false;
   g_bookview.cursor.pageIndex--;
   g_bookview.cursor.pageTurnsSinceFull++;
+  statsBumpPages();
   return true;
 }
 

--- a/Pala_One_2_1/src/ui/sleep.cpp
+++ b/Pala_One_2_1/src/ui/sleep.cpp
@@ -10,6 +10,7 @@
 #include "src/state.h"
 #include "src/hal/display.h"
 #include "src/hal/input.h"          // injectButtonEdgeNow, markUserActivity
+#include "src/storage/stats.h"      // statsFlushToFile — drain RTC counters to flash
 #include "src/ui/pala_one_sleep_black_icon_v4.h"
 #include "src/ui/screen.h"
 
@@ -88,6 +89,9 @@ void enter() {
   rtc_gpio_pulldown_dis((gpio_num_t)BTN);
   rtc_gpio_pullup_en((gpio_num_t)BTN);
   esp_sleep_enable_ext0_wakeup((gpio_num_t)BTN, 0);
+
+  statsFlushToFile();
+
   delay(50);
   Serial.printf("[sleep] BTN=%d entering deep sleep\n", digitalRead(BTN));
   Serial.flush();

--- a/examples/stats/Makefile
+++ b/examples/stats/Makefile
@@ -1,0 +1,42 @@
+# Locate the ESP32-S3 toolchain installed by Arduino IDE / arduino-cli.
+# The toolchain ships under esp-x32/<version>/bin on Linux.
+# Override TOOLCHAIN on the command line if it lives elsewhere.
+TOOLCHAIN_BASE ?= $(HOME)/.arduino15/packages/esp32/tools/esp-x32
+TOOLCHAIN_VER  ?= $(shell ls $(TOOLCHAIN_BASE) 2>/dev/null | sort -V | tail -1)
+TOOLCHAIN      ?= $(TOOLCHAIN_BASE)/$(TOOLCHAIN_VER)/bin
+
+CC      = $(TOOLCHAIN)/xtensa-esp32s3-elf-gcc
+OBJCOPY = $(TOOLCHAIN)/xtensa-esp32s3-elf-objcopy
+NM      = $(TOOLCHAIN)/xtensa-esp32s3-elf-nm
+READELF = $(TOOLCHAIN)/xtensa-esp32s3-elf-readelf
+
+CFLAGS = -fPIC -mlongcalls -Os -nostdlib -nodefaultlibs \
+         -I../../Pala_One_2_1
+
+all: stats.bin
+
+stats.elf: app.c pala_app.ld
+	$(CC) $(CFLAGS) -Wl,-T,pala_app.ld -Wl,-shared -o $@ app.c
+
+stats.bin: stats.elf
+	$(OBJCOPY) -O binary $< $@
+	$(eval ENTRY_OFF := $(shell $(NM) $< | awk '/^[0-9a-f]+ [Tt] app_main$$/{print $$1}'))
+	@[ -n "$(ENTRY_OFF)" ] || (echo "ERROR: app_main symbol not found"; exit 1)
+	python3 -c " \
+import struct, subprocess; \
+out=subprocess.check_output(['$(READELF)','-r','$<'],text=True); \
+relocs=[int(ln.split()[0],16) for ln in out.splitlines() if 'R_XTENSA_RELATIVE' in ln]; \
+d=bytearray(open('$@','rb').read()); \
+struct.pack_into('<I',d,40,int('$(ENTRY_OFF)',16)); \
+reloc_off=len(d) if relocs else 0; \
+d.extend(struct.pack('<'+'I'*len(relocs),*relocs)); \
+struct.pack_into('<I',d,44,reloc_off); \
+struct.pack_into('<I',d,48,len(relocs)); \
+open('$@','wb').write(d); \
+print(f'relocations: {relocs}')"
+	@echo "Built $@: $$(wc -c < $@) bytes, entry=0x$(ENTRY_OFF)"
+
+clean:
+	rm -f stats.elf stats.bin
+
+.PHONY: all clean

--- a/examples/stats/app.c
+++ b/examples/stats/app.c
@@ -1,0 +1,79 @@
+#include "../../Pala_One_2_1/pala_app.h"
+#include "../../Pala_One_2_1/pala_api.h"
+
+__attribute__((section(".header")))
+const PalaAppHeader pala_header = {
+    .magic        = PALA_APP_MAGIC,
+    .api_version  = PALA_API_VERSION,
+    .name         = "Stats",
+    .entry_offset = 0,  // patched by Makefile
+    .reloc_offset = 0,  // patched by Makefile
+    .reloc_count  = 0,  // patched by Makefile
+};
+
+#define LONG_PRESS_MS 850
+#define STATS_SCHEMA  1u
+
+// Must match StatsFile in Pala_One_2_1.ino byte-for-byte.
+typedef struct {
+    uint32_t version;
+    uint32_t firstRtcSec;
+    uint64_t pagesRead;
+    uint64_t buttonPresses;
+} StatsFile;
+
+// snprintf in the app runtime may not advertise %llu support; render
+// values >= 2^32 as a two-segment decimal to avoid relying on it.
+static void formatU64(const PalaAPI* api, char* buf, int len, uint64_t v) {
+    if (v <= 0xFFFFFFFFu) {
+        api->snprintf_wrap(buf, len, "%lu", (unsigned long)v);
+        return;
+    }
+    unsigned long hi = (unsigned long)(v / 1000000000ULL);
+    unsigned long lo = (unsigned long)(v % 1000000000ULL);
+    api->snprintf_wrap(buf, len, "%lu%09lu", hi, lo);
+}
+
+static void drawPage(const PalaAPI* api) {
+    StatsFile s;
+    int n = api->storageRead("stats", &s, (int)sizeof(s));
+    int valid = (n == (int)sizeof(s) && s.version == STATS_SCHEMA);
+
+    api->clearScreen();
+    api->drawHeader("Stats");
+
+    char num[32];
+
+    api->drawTextAt(6, 36, "Pages read", 1);
+    if (valid) formatU64(api, num, sizeof(num), s.pagesRead);
+    else       api->snprintf_wrap(num, sizeof(num), "--");
+    api->drawTextAt(6, 50, num, 0);
+
+    api->drawTextAt(6, 70, "Button presses", 1);
+    if (valid) formatU64(api, num, sizeof(num), s.buttonPresses);
+    else       api->snprintf_wrap(num, sizeof(num), "--");
+    api->drawTextAt(6, 84, num, 0);
+
+    api->drawTextAt(6, 116, "hold to exit", 0);
+    api->refreshDisplay();
+}
+
+void app_main(const PalaAPI* api) {
+    uint32_t pressStart = 0;
+
+    drawPage(api);
+
+    while (1) {
+        // Drive the input frontend so btns.poll() ticks.
+        (void)api->pendingPresses();
+
+        if (api->buttonPressed()) {
+            if (pressStart == 0) pressStart = api->millisNow();
+            if ((api->millisNow() - pressStart) >= LONG_PRESS_MS) return;
+        } else {
+            pressStart = 0;
+        }
+
+        api->delayMs(10);
+    }
+}

--- a/examples/stats/pala_app.ld
+++ b/examples/stats/pala_app.ld
@@ -1,0 +1,8 @@
+ENTRY(app_main)
+SECTIONS {
+    .header   0 : { KEEP(*(.header)) }
+    .literal    : { *(.literal) *(.literal.*) }
+    .text       : { *(.text*) }
+    .rodata     : { *(.rodata*) }
+    .data       : { *(.data*) }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SUT_SRC
   ${FW_SRC}/pure/bookmarks_codec.cpp
   ${FW_SRC}/pure/list_codec.cpp
   ${FW_SRC}/pure/app_header.cpp
+  ${FW_SRC}/pure/stats_codec.cpp
   ${FW_SRC}/storage/book_metadata.cpp
   ${FW_SRC}/storage/list_items.cpp
 )
@@ -40,6 +41,7 @@ set(TEST_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/test_bookmarks_store.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_list_store.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_app_header.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_stats_codec.cpp
 )
 
 add_executable(host_tests ${SUT_SRC} ${TEST_SRC})

--- a/test/test_stats_codec.cpp
+++ b/test/test_stats_codec.cpp
@@ -1,0 +1,74 @@
+// Tests for src/pure/stats_codec.cpp.
+//
+// The stats wire format is shared between the firmware (storage/stats.cpp)
+// and the Stats example app (examples/stats/app.c). The codec is what
+// gates a cold-boot reload — if a future schema change ships, decodeStats
+// must reject the old version so the firmware reinitialises from zero
+// rather than reading garbage. These tests pin that.
+
+#include <cstring>
+
+#include "test_framework.h"
+#include "pure/stats_codec.h"
+
+static StatsFile sample() {
+  StatsFile s{};
+  s.version       = STATS_SCHEMA;
+  s.firstRtcSec   = 0xDEADBEEF;
+  s.pagesRead     = 12345;
+  s.buttonPresses = 67890;
+  return s;
+}
+
+TEST_CASE("encode + decode round-trips StatsFile exactly") {
+  StatsFile s = sample();
+  uint8_t buf[STATS_ENCODED_SIZE];
+  size_t n = encodeStats(s, buf);
+  CHECK_EQ(n, STATS_ENCODED_SIZE);
+
+  StatsFile out{};
+  REQUIRE(decodeStats(buf, n, out));
+  CHECK_EQ(out.version,       s.version);
+  CHECK_EQ(out.firstRtcSec,   s.firstRtcSec);
+  CHECK_EQ(out.pagesRead,     s.pagesRead);
+  CHECK_EQ(out.buttonPresses, s.buttonPresses);
+}
+
+TEST_CASE("decodeStats rejects a wrong schema version") {
+  StatsFile s = sample();
+  s.version = 99;
+  uint8_t buf[STATS_ENCODED_SIZE];
+  encodeStats(s, buf);
+
+  StatsFile out{};
+  CHECK(!decodeStats(buf, STATS_ENCODED_SIZE, out));
+}
+
+TEST_CASE("decodeStats rejects a short buffer") {
+  StatsFile s = sample();
+  uint8_t buf[STATS_ENCODED_SIZE];
+  encodeStats(s, buf);
+
+  StatsFile out{};
+  CHECK(!decodeStats(buf, STATS_ENCODED_SIZE - 1, out));
+  CHECK(!decodeStats(buf, 0, out));
+}
+
+TEST_CASE("decodeStats rejects an oversized buffer") {
+  // A longer-than-expected blob would mean the on-disk format grew; the
+  // firmware should treat it as foreign and reinitialise, not slice off
+  // the first STATS_ENCODED_SIZE bytes and hope they're still valid.
+  StatsFile s = sample();
+  uint8_t buf[STATS_ENCODED_SIZE + 16];
+  std::memset(buf, 0, sizeof(buf));
+  encodeStats(s, buf);
+
+  StatsFile out{};
+  CHECK(!decodeStats(buf, STATS_ENCODED_SIZE + 16, out));
+}
+
+TEST_CASE("STATS_ENCODED_SIZE matches the struct size") {
+  // The example app reads/writes sizeof(StatsFile) directly. If this ever
+  // drifts (added padding, layout change), the wire format breaks silently.
+  CHECK_EQ(STATS_ENCODED_SIZE, sizeof(StatsFile));
+}


### PR DESCRIPTION
## Summary

Re-target of #17 against the new `dev` (PlatformIO modular) layout. Same wire format and behaviour as the main-targeted PR.

A lifetime-counter subsystem so apps can read totals without the firmware hammering flash on every event, plus a Stats example app that displays them.

**`Pala_One_2_1/src/storage/stats.{cpp,h}`** owns the working counters in RTC RAM (survive deep sleep with zero flash writes) and the flash I/O. The wire-format struct + schema-version check live in a pure helper so they're host-testable:

**`Pala_One_2_1/src/pure/stats_codec.{cpp,h}`**

```cpp
struct StatsFile { uint32_t version; uint32_t firstRtcSec; uint64_t pagesRead; uint64_t buttonPresses; };
size_t encodeStats(const StatsFile& s, uint8_t* buf);
bool   decodeStats(const uint8_t* buf, size_t len, StatsFile& out);
```

Public API on the storage side:

- `statsBumpPages()` — called from `advancePage()` / `retreatPage()` in `src/ui/reader.cpp` so only real cursor moves count.
- `statsBumpButtons(delta)` — called from `loop()` against a diff of `g_btns.peekPressCount()`.
- `statsFlushToFile()` — called from `Sleep::enter()` so any in-flight deltas land before power-down. Also auto-flushes every `STATS_FLUSH_EVERY_EVENTS` (= 100) bumps as a safety net. A heavy 500-turn/day reader is ~5 flash writes/day.

`src/hal/input.h` gains a `peekPressCount() const` accessor alongside the existing `consumePressCount()`. Stats reads via peek (doesn't disturb the apps-API consumer); if the apps API consumed between ticks (current < lastSeen), stats clamps and continues without underflow.

**`examples/stats/`** reads `/apps/stats.dat` and shows total pages + total button presses. Long-press to exit. Values are snapshotted at app entry — the firmware `loop()` is paused while the app runs, so any clicks made while reading the screen don't update the on-screen numbers until you re-open the app.

`StatsFile` in `stats_codec.h` must stay byte-identical to the struct in `examples/stats/app.c`.

## Tests

`test/test_stats_codec.cpp` — **5 cases**:

- Round-trip through `encodeStats` + `decodeStats` preserves every field.
- Wrong `version` is rejected (a future schema bump must reinitialise from zero, not return stale fields).
- Short buffer is rejected.
- Oversized buffer is rejected — a future format growth must not silently slice off the first `STATS_ENCODED_SIZE` bytes and call it valid.
- `STATS_ENCODED_SIZE == sizeof(StatsFile)` — guards against accidental padding drift.

Verified locally on the rebased branch (Windows / MSVC 19.50, all 5 cases + 115 pre-existing tests pass, 0 failures):

```powershell
cmake -S test -B test/build
cmake --build test/build
.\test\build\Debug\host_tests.exe
```

## Scope / history

Two commits — the original feature commit plus the pure-codec extract + tests. Rebased on current `dev` (post-PR #20 language selection); auto-merge clean. No public API changes outside the additive `peekPressCount` and the new `stats.h` / `stats_codec.h` modules.

If the sleep-streak-hooks PR merges first, conflicts in `src/ui/reader.cpp`, `src/ui/sleep.cpp`, `Pala_One_2_1/Pala_One_2_1.ino`, and `test/CMakeLists.txt`. Resolution is "keep both calls" — the features are independent.