### PR TITLE
Dev server for web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Pure modules and KV-backed storage have host-side unit tests under [`test/`](tes
 
 See [test/README.md](test/README.md) for prerequisites (CMake + a C++17 compiler) and per-platform setup / run instructions for Windows, Linux, and macOS.
 
+## Web UI emulator
+
+The [`dev/`](dev/) directory contains a host-side emulator for the captive-portal web UI. It builds a native binary that serves the same route handlers as the firmware, backed by a local filesystem, so you can iterate on the web UI without flashing the device.
+
+See [dev/README.md](dev/README.md) for build and run instructions, the VS Code debug launch config, and the integration test suite.
+
 ## Apps
 
 Pala One supports user-installable apps — self-contained position-independent C binaries that run on top of the firmware and have access to the display, button, RTC, and a per-app key-value store. Apps are uploaded over Wi-Fi through the same web UI used for books, and they appear under the **Apps** entry of the library menu. No firmware rebuild is needed to install one.

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -73,16 +73,17 @@ set(STUB_SRC
   ${STUBS_ROOT}/upload_stub.cpp
 )
 
-add_executable(pala_web_emu
-  ${CMAKE_SOURCE_DIR}/main.cpp
-  ${CMAKE_SOURCE_DIR}/mock_data.cpp
+# ---------------------------------------------------------------------------
+#  Shared library — all non-main sources used by both the emulator and tests
+# ---------------------------------------------------------------------------
+add_library(pala_web_shared STATIC
   ${PURE_SRC}
   ${STORAGE_SRC}
   ${WEB_SRC}
   ${STUB_SRC}
 )
 
-target_include_directories(pala_web_emu PRIVATE
+target_include_directories(pala_web_shared PUBLIC
   # MUST be first — these shadow real Arduino/firmware headers
   ${STUBS_ROOT}/overrides
   # dev/ root — resolves #include "stubs/..." paths from override headers
@@ -95,13 +96,37 @@ target_include_directories(pala_web_emu PRIVATE
   ${TEST_ROOT}
 )
 
-target_link_libraries(pala_web_emu PRIVATE httplib::httplib)
+target_link_libraries(pala_web_shared PUBLIC httplib::httplib)
 
 # PROGMEM is a no-op on the host (it's a flash-storage hint for AVR/Xtensa).
-target_compile_definitions(pala_web_emu PRIVATE PROGMEM=)
+target_compile_definitions(pala_web_shared PUBLIC PROGMEM=)
 
-target_compile_options(pala_web_emu PRIVATE
+target_compile_options(pala_web_shared PUBLIC
   -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
   # Pre-include system headers before arduino_compat.h can define min/max macros.
   -include ${CMAKE_SOURCE_DIR}/stubs/prelude.h
+)
+
+# ---------------------------------------------------------------------------
+#  Emulator executable
+# ---------------------------------------------------------------------------
+add_executable(pala_web_emu
+  ${CMAKE_SOURCE_DIR}/main.cpp
+  ${CMAKE_SOURCE_DIR}/mock_data.cpp
+)
+target_link_libraries(pala_web_emu PRIVATE pala_web_shared)
+
+# ---------------------------------------------------------------------------
+#  Integration test executable
+# ---------------------------------------------------------------------------
+add_executable(pala_web_test
+  ${CMAKE_SOURCE_DIR}/integration_test.cpp
+)
+target_link_libraries(pala_web_test PRIVATE pala_web_shared)
+
+enable_testing()
+add_test(NAME integration COMMAND pala_web_test)
+set_tests_properties(integration PROPERTIES
+  # Run from the repo root so "dev/fs_test" resolves correctly.
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
 )

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 3.16)
+project(pala_web_emu CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+FetchContent_Declare(
+  httplib
+  GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+  GIT_TAG        v0.15.3
+)
+FetchContent_MakeAvailable(httplib)
+
+set(SKETCH_ROOT ${CMAKE_SOURCE_DIR}/../Pala_One_2_1)
+set(FW_SRC      ${SKETCH_ROOT}/src)
+set(TEST_ROOT   ${CMAKE_SOURCE_DIR}/../test)
+set(STUBS_ROOT  ${CMAKE_SOURCE_DIR}/stubs)
+
+# ---------------------------------------------------------------------------
+#  Pure modules — identical to the test build
+# ---------------------------------------------------------------------------
+set(PURE_SRC
+  ${FW_SRC}/pure/paths.cpp
+  ${FW_SRC}/pure/text_util.cpp
+  ${FW_SRC}/pure/find_text.cpp
+  ${FW_SRC}/pure/hashing.cpp
+  ${FW_SRC}/pure/paginator.cpp
+  ${FW_SRC}/pure/library_nav.cpp
+  ${FW_SRC}/pure/bookmark_label.cpp
+  ${FW_SRC}/pure/bookmarks_codec.cpp
+  ${FW_SRC}/pure/list_codec.cpp
+  ${FW_SRC}/pure/app_header.cpp
+)
+
+# ---------------------------------------------------------------------------
+#  Storage modules — pure API compiles; firmware glue (#ifdef ARDUINO) skipped
+# ---------------------------------------------------------------------------
+set(STORAGE_SRC
+  ${FW_SRC}/storage/book_metadata.cpp
+  ${FW_SRC}/storage/list_items.cpp
+  ${FW_SRC}/storage/library.cpp
+  ${FW_SRC}/storage/app_catalog.cpp
+)
+
+# ---------------------------------------------------------------------------
+#  Web handlers — the actual code under development.
+#  upload.cpp / apps_upload.cpp omitted (streaming upload, no GET pages).
+# ---------------------------------------------------------------------------
+set(WEB_SRC
+  ${FW_SRC}/web/web.cpp
+  ${FW_SRC}/web/chrome.cpp
+  ${FW_SRC}/web/files.cpp
+  ${FW_SRC}/web/bookmarks.cpp
+  ${FW_SRC}/web/list.cpp
+  ${FW_SRC}/web/settings.cpp
+  ${FW_SRC}/web/reset.cpp
+)
+
+# ---------------------------------------------------------------------------
+#  Stubs — Arduino / ESP32 API replacements for the host build
+# ---------------------------------------------------------------------------
+set(STUB_SRC
+  ${STUBS_ROOT}/web_server.cpp
+  ${STUBS_ROOT}/fs_stub.cpp
+  ${STUBS_ROOT}/state.cpp
+  ${STUBS_ROOT}/ui_stubs.cpp
+  ${STUBS_ROOT}/text_stubs.cpp
+  ${STUBS_ROOT}/book_metadata_glue.cpp
+  ${STUBS_ROOT}/list_items_glue.cpp
+  ${STUBS_ROOT}/fs_util_stub.cpp
+  ${STUBS_ROOT}/upload_stub.cpp
+)
+
+add_executable(pala_web_emu
+  ${CMAKE_SOURCE_DIR}/main.cpp
+  ${CMAKE_SOURCE_DIR}/mock_data.cpp
+  ${PURE_SRC}
+  ${STORAGE_SRC}
+  ${WEB_SRC}
+  ${STUB_SRC}
+)
+
+target_include_directories(pala_web_emu PRIVATE
+  # MUST be first — these shadow real Arduino/firmware headers
+  ${STUBS_ROOT}/overrides
+  # dev/ root — resolves #include "stubs/..." paths from override headers
+  ${CMAKE_SOURCE_DIR}
+  # Firmware sketch root — resolves #include "src/..." paths
+  ${SKETCH_ROOT}
+  # Firmware src/ root — resolves #include "storage/..." paths (used by map_kv_store.h)
+  ${FW_SRC}
+  # Test utilities — provides map_kv_store.h
+  ${TEST_ROOT}
+)
+
+target_link_libraries(pala_web_emu PRIVATE httplib::httplib)
+
+# PROGMEM is a no-op on the host (it's a flash-storage hint for AVR/Xtensa).
+target_compile_definitions(pala_web_emu PRIVATE PROGMEM=)
+
+target_compile_options(pala_web_emu PRIVATE
+  -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
+  # Pre-include system headers before arduino_compat.h can define min/max macros.
+  -include ${CMAKE_SOURCE_DIR}/stubs/prelude.h
+)

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,63 @@
+# Web UI emulator
+
+The `dev/` directory contains a host-side emulator for the captive-portal web UI. It builds a native binary (`pala_web_emu`) that serves the same route handlers as the firmware, backed by a local filesystem instead of LittleFS. This lets you iterate on the web UI without flashing the device.
+
+It shares a CMake build with the integration tests (`pala_web_test`).
+
+## Requirements
+
+- **CMake 3.14+**
+- A **C++17 compiler** — GCC, Clang, or MSVC
+- Internet access on first build (CMake fetches [cpp-httplib v0.15.3](https://github.com/yhirose/cpp-httplib) via `FetchContent`)
+
+## Run
+
+```bash
+cmake -S dev -B dev/build && cmake --build dev/build
+dev/build/pala_web_emu
+```
+
+Then open `http://localhost:8080` in a browser.
+
+Run from the repo root — the emulator defaults to `dev/fs` as the LittleFS root. The repo ships `dev/fs/` with a short sample book (`books/sample.txt`) so the files page loads populated out of the box. Drop any UTF-8 `.txt` file into `dev/fs/books/` to add more.
+
+To override the filesystem root or port:
+
+```bash
+dev/build/pala_web_emu --port=9090
+```
+
+## Request logging
+
+Every request and its HTTP response status print to stderr:
+
+```
+POST /jumptext body=id=0&query=Bennet
+  -> 302
+GET /files
+  -> 200
+```
+
+This is always on — no flag needed.
+
+## Integration tests
+
+The integration tests (`pala_web_test`) spin up the same server in a thread and make real HTTP requests against it. They live in `dev/integration_test.cpp` and use the same `dev/fs_test/` fixture filesystem.
+
+Run them after building:
+
+```bash
+ctest --test-dir dev/build --output-on-failure
+```
+
+Or as a one-liner from the repo root:
+
+```bash
+cmake -S dev -B dev/build && cmake --build dev/build && ctest --test-dir dev/build --output-on-failure
+```
+
+## Limitations
+
+- **Character widths** use a lookup table approximation for `u8g2_font_helvR12_te`. Line breaks match the device closely but may differ by a word or two for lines containing many narrow or wide characters.
+- **On-disk page cache** (`src/storage/page_cache`) is stubbed and does nothing — page walks are always computed from scratch.
+- **App upload** returns HTTP 501 (not implemented).

--- a/dev/fs/books/sample.txt
+++ b/dev/fs/books/sample.txt
@@ -1,0 +1,102 @@
+The Project Gutenberg eBook of Pride and Prejudice
+
+It is a truth universally acknowledged, that a single man in possession of
+a good fortune, must be in want of a wife.
+
+However little known the feelings or views of such a man may be on his first
+entering a neighbourhood, this truth is so well fixed in the minds of the
+surrounding families, that he is considered as the rightful property of some
+one or other of their daughters.
+
+"My dear Mr. Bennet," said his lady to him one day, "have you heard that
+Netherfield Park is let at last?"
+
+Mr. Bennet replied that he had not.
+
+"But it is," returned she; "for Mrs. Long has just been here, and she told me
+all about it."
+
+Mr. Bennet made no answer.
+
+"Do not you want to know who has taken it?" cried his wife impatiently.
+
+"You want to tell me, and I have no objection to hearing it."
+
+This was invitation enough.
+
+"Why, my dear, you must know, Mrs. Long says that Netherfield is taken by a
+young man of large fortune from the north of England; that he came down on
+Monday in a chaise and four to see the place, and was so much delighted with
+it that he agreed with Mr. Morris immediately; that he is to take possession
+before Michaelmas, and some of his servants are to be in the house by the end
+of next week."
+
+"What is his name?"
+
+"Bingley."
+
+"Is he married or single?"
+
+"Oh! single, my dear, to be sure! A single man of large fortune; four or five
+thousand a year. What a fine thing for our girls!"
+
+"How so? can it affect them?"
+
+"My dear Mr. Bennet," replied his wife, "how can you be so tiresome! You must
+know that I am thinking of his marrying one of them."
+
+"Is that his design in settling here?"
+
+"Design! nonsense, how can you talk so! But it is very likely that he may
+fall in love with one of them, and therefore you must visit him as soon as he
+comes."
+
+"I see no occasion for that. You and the girls may go, or you may send them
+by themselves, which perhaps will be still better, for as you are as handsome
+as any of them, Mr. Bingley might like you the best of the party."
+
+"My dear, you flatter me. I certainly have had my share of beauty, but I do
+not pretend to be any thing extraordinary now. When a woman has five grown-up
+daughters, she ought to give over thinking of her own beauty."
+
+"In such cases, a woman has not often much beauty to think of."
+
+"But, my dear, you must indeed go and see Mr. Bingley when he comes into the
+neighbourhood."
+
+"It is more than I engage for, I assure you."
+
+"But consider your daughters. Only think what an establishment it would be for
+one of them. Sir William and Lady Lucas are determined to go, merely on that
+account, for in general, you know, they visit no new comers. Indeed you must
+go, for it will be impossible for us to visit him, if you do not."
+
+"You are over-scrupulous, surely. I dare say Mr. Bingley will be very glad to
+see you; and I will send a few lines by you to assure him of my hearty
+consent to his marrying which ever he chooses of our girls; though I must
+throw in a good word for my little Lizzy."
+
+"I desire you will do no such thing. Lizzy is not a bit better than the
+others; and I am sure she is not half so handsome as Jane, nor half so
+good-humoured as Lydia. But you are always giving her the preference."
+
+"They have none of them much to recommend them," replied he; "they are all
+silly and ignorant like other girls; but Lizzy has something more of quickness
+than her sisters."
+
+"Mr. Bennet, how can you abuse your own children so? You take delight in
+vexing me. You have no compassion on my poor nerves."
+
+"You mistake me, my dear. I have a high respect for your nerves. They are my
+old friends. I have heard you mention them with consideration these twenty
+years at least."
+
+"Ah, you do not know what I suffer."
+
+"But I hope you will get over it, and live to see many young men of four
+thousand a year come into the neighbourhood."
+
+"It will be no use to us, if twenty such should come, since you will not
+visit them."
+
+"Depend upon it, my dear, that when there are twenty, I will visit them all."

--- a/dev/fs_test/books/hound.txt
+++ b/dev/fs_test/books/hound.txt
@@ -1,0 +1,3 @@
+The detective arrived at dawn.
+A lantern flickered in the fog.
+The butler revealed nothing.

--- a/dev/integration_test.cpp
+++ b/dev/integration_test.cpp
@@ -1,0 +1,241 @@
+// Integration tests for the /jumptext route and surrounding pipeline.
+//
+// Starts the web emulator in a background thread, then drives it with a
+// real HTTP client. Every test is a full round-trip through the actual web
+// handler, storage layer, and stub FS — no mocks are inserted in the path.
+//
+// Run from the repo root (so "dev/fs_test" resolves):
+//   ./dev/build/pala_web_test
+// Or set PALA_EMU_FS_ROOT to point at a different fixture directory.
+
+// httplib must be included before any arduino_compat.h header so the
+// min/max macros it defines don't clobber httplib's use of std::min/max.
+// prelude.h is force-included via -include, so system headers are already
+// parsed before this TU touches anything.
+#include <httplib.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include "test_framework.h"
+
+#include "src/pure/find_text.h"
+#include "src/storage/book_metadata.h"
+#include "src/ui/text.h"
+#include "src/storage/preferences_store.h"
+#include "src/storage/library.h"
+#include "src/storage/app_catalog.h"
+#include "src/state.h"
+#include "stubs/fs_stub.h"
+#include "stubs/web_server.h"
+#include "src/web/web.h"
+
+extern void loadListItems();
+
+static constexpr int kPort = 18080;
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+static httplib::Client* gCli = nullptr;
+
+static std::string locationOf(const httplib::Response& res) {
+  auto it = res.headers.find("Location");
+  return it != res.headers.end() ? it->second : "";
+}
+
+static httplib::Result post(const char* path, httplib::Params params) {
+  return gCli->Post(path, params);
+}
+
+// Read the full contents of a virtual-FS file into a String.
+static String readFile(const char* path) {
+  File f = FS.open(path, "r");
+  String out;
+  if (!f) return out;
+  uint8_t buf[256];
+  size_t n;
+  while ((n = f.read(buf, sizeof(buf))) > 0)
+    out.concat((const char*)buf, (unsigned)n);
+  f.close();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+//  /files page
+// ---------------------------------------------------------------------------
+
+TEST_CASE("/files renders the Find-in-book form") {
+  auto res = gCli->Get("/files");
+  REQUIRE(res);
+  CHECK_EQ(res->status, 200);
+  CHECK(res->body.find("jumptext") != std::string::npos);
+  CHECK(res->body.find("Find in book") != std::string::npos);
+}
+
+TEST_CASE("GET /files?error=not-found renders the warning banner") {
+  auto res = gCli->Get("/files?error=not-found");
+  REQUIRE(res);
+  CHECK_EQ(res->status, 200);
+  CHECK(res->body.find("Text not found in book") != std::string::npos);
+}
+
+TEST_CASE("GET /files without error flag has no warning banner") {
+  auto res = gCli->Get("/files");
+  REQUIRE(res);
+  CHECK_EQ(res->status, 200);
+  CHECK(res->body.find("Text not found in book") == std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+//  /jumptext — validation
+// ---------------------------------------------------------------------------
+
+TEST_CASE("POST /jumptext missing id returns 400") {
+  auto res = post("/jumptext", {{"query", "detective"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+TEST_CASE("POST /jumptext missing query returns 400") {
+  auto res = post("/jumptext", {{"id", "0"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+TEST_CASE("POST /jumptext empty query returns 400") {
+  auto res = post("/jumptext", {{"id", "0"}, {"query", ""}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+TEST_CASE("POST /jumptext out-of-range id returns 400") {
+  auto res = post("/jumptext", {{"id", "999"}, {"query", "detective"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+// ---------------------------------------------------------------------------
+//  /jumptext — happy path and not-found
+// ---------------------------------------------------------------------------
+
+TEST_CASE("POST /jumptext text found redirects to /files") {
+  auto res = post("/jumptext", {{"id", "0"}, {"query", "detective"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 302);
+  CHECK_EQ(locationOf(*res), "/files");
+}
+
+TEST_CASE("POST /jumptext text not found redirects to /files?error=not-found") {
+  auto res = post("/jumptext", {{"id", "0"}, {"query", "elephant"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 302);
+  CHECK_EQ(locationOf(*res), "/files?error=not-found");
+}
+
+// ---------------------------------------------------------------------------
+//  End-to-end: saved offset matches find_text on the raw file
+// ---------------------------------------------------------------------------
+
+// Walk pages in `f` to find the start offset of the page containing `matchOffset`.
+static uint32_t pageStartFor(File& f, uint32_t matchOffset) {
+  uint32_t pageStart = 0;
+  while (true) {
+    uint32_t next = nextPageOffset(f, pageStart);
+    if (next <= pageStart || next > matchOffset) break;
+    pageStart = next;
+  }
+  return pageStart;
+}
+
+TEST_CASE("POST /jumptext saves the correct byte offset") {
+  const String query = "lantern";
+
+  auto res = post("/jumptext", {{"id", "0"}, {"query", query.c_str()}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 302);
+  CHECK_EQ(locationOf(*res), "/files");
+
+  // Expected: start of the page containing the raw match.
+  String content = readFile("/books/hound.txt");
+  REQUIRE(content.length() > 0);
+  uint32_t matchOffset = find_text(content, query);
+  REQUIRE(matchOffset != 0xFFFFFFFFu);
+  File f = FS.open("/books/hound.txt", "r");
+  REQUIRE(f);
+  uint32_t expected = pageStartFor(f, matchOffset);
+  f.close();
+
+  String key = prefKeyForBook(String("/books/hound.txt"));
+  PreferencesStore kv(prefs);
+  CHECK_EQ(loadSavedOffset(kv, key), expected);
+}
+
+TEST_CASE("POST /jumptext not-found does not overwrite a previously saved offset") {
+  const String goodQuery = "butler";
+  auto r1 = post("/jumptext", {{"id", "0"}, {"query", goodQuery.c_str()}});
+  REQUIRE(r1);
+  REQUIRE(r1->status == 302);
+
+  String content = readFile("/books/hound.txt");
+  uint32_t matchOffset = find_text(content, goodQuery);
+  REQUIRE(matchOffset != 0xFFFFFFFFu);
+  File f = FS.open("/books/hound.txt", "r");
+  REQUIRE(f);
+  uint32_t expected = pageStartFor(f, matchOffset);
+  f.close();
+
+  // A failed search must not clobber the stored offset.
+  auto r2 = post("/jumptext", {{"id", "0"}, {"query", "elephant"}});
+  REQUIRE(r2);
+  REQUIRE(r2->status == 302);
+
+  String key = prefKeyForBook(String("/books/hound.txt"));
+  PreferencesStore kv(prefs);
+  CHECK_EQ(loadSavedOffset(kv, key), expected);
+}
+
+// ---------------------------------------------------------------------------
+//  Entry point — starts the server, runs tests, then shuts down cleanly.
+// ---------------------------------------------------------------------------
+
+int main() {
+  const char* env = std::getenv("PALA_EMU_FS_ROOT");
+  std::string fsRoot = (env && env[0]) ? env : "dev/fs_test";
+  LittleFS.setRoot(fsRoot);
+  loadBooks();
+  loadApps();
+  loadListItems();
+  registerWebRoutes();
+
+  std::thread srv([]() { server.run(kPort); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  httplib::Client cli("localhost", kPort);
+  cli.set_follow_location(false);
+  gCli = &cli;
+
+  int passed = 0, failed = 0;
+  for (auto& tc : tf_allTests()) {
+    tf_currentFailures() = 0;
+    std::printf("[ RUN  ] %s\n", tc.name);
+    tc.fn();
+    if (tf_currentFailures() == 0) {
+      std::printf("[  OK  ] %s\n", tc.name);
+      ++passed;
+    } else {
+      std::printf("[ FAIL ] %s (%d failures)\n", tc.name, tf_currentFailures());
+      tf_totalFailures() += tf_currentFailures();
+      ++failed;
+    }
+  }
+  std::printf("\n%zu tests, %d checks, %d passed, %d failed\n",
+              tf_allTests().size(), tf_totalChecks(), passed, failed);
+
+  server.stop();
+  srv.join();
+  return failed == 0 ? 0 : 1;
+}

--- a/dev/main.cpp
+++ b/dev/main.cpp
@@ -1,0 +1,22 @@
+#include <cstdlib>
+#include <cstring>
+#include "stubs/web_server.h"
+#include "src/web/web.h"
+
+extern void loadMockData();
+extern WebServerStub server;
+
+int main(int argc, char* argv[]) {
+  int port = 8080;
+  for (int i = 1; i < argc; i++) {
+    if ((std::strcmp(argv[i], "--port") == 0 || std::strcmp(argv[i], "-p") == 0) && i + 1 < argc) {
+      port = std::atoi(argv[++i]);
+    } else if (std::strncmp(argv[i], "--port=", 7) == 0) {
+      port = std::atoi(argv[i] + 7);
+    }
+  }
+  loadMockData();
+  registerWebRoutes();
+  server.run(port);
+  return 0;
+}

--- a/dev/mock_data.cpp
+++ b/dev/mock_data.cpp
@@ -1,0 +1,23 @@
+#include "src/storage/library.h"
+#include "src/storage/app_catalog.h"
+#include "src/storage/list_items.h"
+#include "stubs/fs_stub.h"
+
+// loadListItems() is declared inside #ifdef ARDUINO in list_items.h;
+// the host implementation lives in stubs/list_items_glue.cpp.
+extern void loadListItems();
+
+void loadMockData() {
+  // Prefer an environment variable override; default to dev/fs relative to CWD.
+  // Run the binary from the repo root: ./dev/build/pala_web_emu
+  const char* env = std::getenv("PALA_EMU_FS_ROOT");
+  std::string root = (env && env[0]) ? env : "dev/fs";
+  std::printf("FS root: %s\n", root.c_str());
+
+  LittleFS.setRoot(root);
+
+  // Scan the real filesystem so book/folder lists reflect what's on disk.
+  loadBooks();
+  loadApps();
+  loadListItems();
+}

--- a/dev/stubs/book_metadata_glue.cpp
+++ b/dev/stubs/book_metadata_glue.cpp
@@ -1,0 +1,55 @@
+// Host implementations of the book_metadata.h firmware-glue functions
+// (normally compiled only under #ifdef ARDUINO). Delegates to the same
+// prefs store that handleJumpPageWeb writes to, so page saves round-trip.
+
+#include "src/storage/book_metadata.h"
+#include "src/storage/preferences_store.h"
+#include "src/pure/hashing.h"
+#include "src/state.h"
+
+static PreferencesStore kv() { return PreferencesStore(prefs); }
+
+uint8_t loadBookmarksForKey(const String& bookKey,
+                            uint16_t outPages[MAX_BOOKMARKS],
+                            uint32_t outOffsets[MAX_BOOKMARKS]) {
+  auto store = kv();
+  Bookmarks bm = loadBookmarks(store, bookKey);
+  for (int i = 0; i < bm.count; i++) {
+    outPages[i]   = bm.pages[i];
+    outOffsets[i] = bm.offsets[i];
+  }
+  return bm.count;
+}
+
+void saveBookmarksForKey(const String& bookKey,
+                         const uint16_t pages[MAX_BOOKMARKS],
+                         const uint32_t offsets[MAX_BOOKMARKS],
+                         uint8_t count) {
+  Bookmarks bm;
+  bm.count = count;
+  for (int i = 0; i < count; i++) {
+    bm.pages[i]   = pages[i];
+    bm.offsets[i] = offsets[i];
+  }
+  auto store = kv();
+  saveBookmarks(store, bookKey, bm);
+}
+
+int savedPageForBookPath(const String& path) {
+  String key = prefKeyForBook(path);
+  auto store = kv();
+  return loadSavedPage(store, key);
+}
+
+void deleteBookMetadata(const String& path) {
+  String key = prefKeyForBook(path);
+  auto store = kv();
+  clearBookMetadata(store, key);
+}
+
+void migrateBookMetadata(const String& oldPath, const String& newPath) {
+  String oldKey = prefKeyForBook(oldPath);
+  String newKey = prefKeyForBook(newPath);
+  auto store = kv();
+  renameBookMetadata(store, oldKey, newKey);
+}

--- a/dev/stubs/fs_stub.cpp
+++ b/dev/stubs/fs_stub.cpp
@@ -1,0 +1,171 @@
+#include "stubs/fs_stub.h"
+
+#include <filesystem>
+#include <cstring>
+#include <sys/statvfs.h>
+
+namespace stdfs = std::filesystem;
+
+LittleFSClass LittleFS;
+
+// ---------------------------------------------------------------------------
+//  LittleFSClass
+// ---------------------------------------------------------------------------
+
+void LittleFSClass::setRoot(const std::string& root) {
+  root_ = root;
+  std::error_code ec;
+  stdfs::create_directories(root_, ec);
+}
+
+std::string LittleFSClass::hostPath(const std::string& virtPath) const {
+  // virtPath is always absolute ("/books/foo.txt"); strip leading slash then join.
+  if (!virtPath.empty() && virtPath[0] == '/') return root_ + virtPath;
+  return root_ + "/" + virtPath;
+}
+
+File LittleFSClass::open(const char* virtPath, const char* mode) {
+  std::string hp = hostPath(virtPath);
+  std::error_code ec;
+
+  if (!stdfs::exists(hp, ec)) return File();
+
+  File f;
+  f.valid_     = true;
+  f.virt_path_ = virtPath;
+  f.is_dir_    = stdfs::is_directory(hp, ec);
+
+  if (f.is_dir_) {
+    for (auto& entry : stdfs::directory_iterator(hp, ec)) {
+      // Build virtual child path.
+      std::string child = f.virt_path_;
+      if (child.back() != '/') child += '/';
+      child += entry.path().filename().string();
+      f.children_.push_back(child);
+    }
+    std::sort(f.children_.begin(), f.children_.end());
+  } else {
+    const char* fmode = (mode && mode[0] == 'w') ? "wb" : "rb";
+    f.fp_ = fopen(hp.c_str(), fmode);
+    if (!f.fp_) f.valid_ = false;
+  }
+  return f;
+}
+
+bool LittleFSClass::exists(const char* virtPath) {
+  std::error_code ec;
+  return stdfs::exists(hostPath(virtPath), ec);
+}
+
+bool LittleFSClass::remove(const char* virtPath) {
+  std::error_code ec;
+  return stdfs::remove(hostPath(virtPath), ec);
+}
+
+bool LittleFSClass::rename(const char* from, const char* to) {
+  std::error_code ec;
+  stdfs::rename(hostPath(from), hostPath(to), ec);
+  return !ec;
+}
+
+bool LittleFSClass::mkdir(const char* virtPath) {
+  std::error_code ec;
+  stdfs::create_directories(hostPath(virtPath), ec);
+  return !ec;
+}
+
+bool LittleFSClass::rmdir(const char* virtPath) {
+  std::error_code ec;
+  stdfs::remove(hostPath(virtPath), ec);
+  return !ec;
+}
+
+size_t LittleFSClass::usedBytes() const {
+  size_t total = 0;
+  std::error_code ec;
+  for (auto& entry : stdfs::recursive_directory_iterator(root_, ec)) {
+    if (!entry.is_directory(ec)) total += entry.file_size(ec);
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+//  File
+// ---------------------------------------------------------------------------
+
+File::File(File&& o) noexcept
+    : valid_(o.valid_), is_dir_(o.is_dir_), virt_path_(std::move(o.virt_path_)),
+      fp_(o.fp_), children_(std::move(o.children_)), child_idx_(o.child_idx_) {
+  o.valid_ = false;
+  o.fp_    = nullptr;
+}
+
+File& File::operator=(File&& o) noexcept {
+  if (this != &o) {
+    close();
+    valid_     = o.valid_;
+    is_dir_    = o.is_dir_;
+    virt_path_ = std::move(o.virt_path_);
+    fp_        = o.fp_;
+    children_  = std::move(o.children_);
+    child_idx_ = o.child_idx_;
+    o.valid_   = false;
+    o.fp_      = nullptr;
+  }
+  return *this;
+}
+
+void File::close() {
+  if (fp_) { fclose(fp_); fp_ = nullptr; }
+  valid_ = false;
+}
+
+size_t File::size() const {
+  if (!fp_) return 0;
+  long cur = ftell(fp_);
+  fseek(fp_, 0, SEEK_END);
+  long end = ftell(fp_);
+  fseek(fp_, cur, SEEK_SET);
+  return (size_t)(end < 0 ? 0 : end);
+}
+
+int File::read() {
+  if (!fp_) return -1;
+  int c = fgetc(fp_);
+  return (c == EOF) ? -1 : c;
+}
+
+size_t File::read(uint8_t* buf, size_t len) {
+  if (!fp_) return 0;
+  return fread(buf, 1, len, fp_);
+}
+
+bool File::seek(uint32_t pos) {
+  if (!fp_) return false;
+  return fseek(fp_, (long)pos, SEEK_SET) == 0;
+}
+
+uint32_t File::position() const {
+  if (!fp_) return 0;
+  long p = ftell(fp_);
+  return (p < 0) ? 0 : (uint32_t)p;
+}
+
+int File::available() const {
+  if (!fp_) return 0;
+  long cur = ftell(fp_);
+  fseek(fp_, 0, SEEK_END);
+  long end = ftell(fp_);
+  fseek(fp_, cur, SEEK_SET);
+  return (int)(end - cur);
+}
+
+size_t File::write(const uint8_t* buf, size_t len) {
+  if (!fp_) return 0;
+  return fwrite(buf, 1, len, fp_);
+}
+
+File File::openNextFile() {
+  if (!is_dir_ || child_idx_ >= children_.size()) return File();
+  return LittleFS.open(children_[child_idx_++].c_str());
+}

--- a/dev/stubs/fs_stub.h
+++ b/dev/stubs/fs_stub.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// Forward declaration for openNextFile() which calls back into LittleFSClass.
+class LittleFSClass;
+extern LittleFSClass LittleFS;
+
+// Mirrors the Arduino File API used by the firmware.
+class File {
+public:
+  File() = default;
+  ~File() { close(); }
+
+  // Non-copyable, movable.
+  File(const File&)            = delete;
+  File& operator=(const File&) = delete;
+  File(File&& o) noexcept;
+  File& operator=(File&& o) noexcept;
+
+  explicit operator bool() const { return valid_; }
+  bool isDirectory() const { return is_dir_; }
+  const char* name() const { return virt_path_.c_str(); }
+  size_t size() const;
+
+  // Reading
+  int      read();
+  size_t   read(uint8_t* buf, size_t len);
+  bool     seek(uint32_t pos);
+  uint32_t position() const;
+  int      available() const;
+
+  // Writing
+  size_t write(const uint8_t* buf, size_t len);
+
+  // Directory iteration
+  File openNextFile();
+
+  void close();
+
+private:
+  friend class LittleFSClass;
+
+  bool        valid_     = false;
+  bool        is_dir_    = false;
+  std::string virt_path_;
+
+  // Regular file
+  FILE*       fp_        = nullptr;
+
+  // Directory: sorted virtual paths of direct children
+  std::vector<std::string> children_;
+  size_t                   child_idx_ = 0;
+};
+
+// Mirrors the subset of the LittleFS API used by the firmware.
+class LittleFSClass {
+public:
+  // Call once at startup before any FS operations.
+  void setRoot(const std::string& root);
+
+  // Convert a virtual device path ("/books/foo.txt") to a host path.
+  std::string hostPath(const std::string& virtPath) const;
+
+  File   open(const char* path, const char* mode = "r");
+  File   open(const std::string& path, const char* mode = "r") { return open(path.c_str(), mode); }
+
+  bool   exists(const char* path);
+  bool   remove(const char* path);
+  bool   rename(const char* from, const char* to);
+  bool   mkdir(const char* path);
+  bool   rmdir(const char* path);
+
+  // String overloads — the firmware calls these with Arduino String objects.
+  // The arduino_compat.h String has an implicit c_str() via operator const char*.
+  // Providing explicit overloads avoids the implicit conversion ambiguity.
+  template<typename S> File open(const S& path, const char* mode = "r")   { return open(path.c_str(), mode); }
+  template<typename S> bool exists(const S& path)                          { return exists(path.c_str()); }
+  template<typename S> bool remove(const S& path)                          { return remove(path.c_str()); }
+  template<typename S> bool rename(const S& from, const S& to)             { return rename(from.c_str(), to.c_str()); }
+  template<typename S> bool mkdir(const S& path)                           { return mkdir(path.c_str()); }
+  template<typename S> bool rmdir(const S& path)                           { return rmdir(path.c_str()); }
+
+  bool   begin(bool /*formatOnFail*/ = false) { return true; }
+  void   end()                                {}
+  bool   format()                             { return true; }
+  size_t totalBytes() const                   { return 4u * 1024u * 1024u; }
+  size_t usedBytes()  const;
+
+private:
+  std::string root_;
+};

--- a/dev/stubs/fs_util_stub.cpp
+++ b/dev/stubs/fs_util_stub.cpp
@@ -1,0 +1,43 @@
+// Host-build stub for src/storage/fs_util.h.
+// Uses the LittleFS stub directly so create/delete operations affect dev/fs/.
+
+#include "src/storage/fs_util.h"
+
+bool fsBegin() { return true; }
+
+size_t fsTotalBytesSafe() { return LittleFS.totalBytes(); }
+size_t fsUsedBytesSafe()  { return LittleFS.usedBytes();  }
+size_t fsFreeBytesSafe()  {
+  size_t t = fsTotalBytesSafe(), u = fsUsedBytesSafe();
+  return (t >= u) ? (t - u) : 0;
+}
+
+void ensureBooksDir() {
+  if (!FS.exists("/books")) FS.mkdir("/books");
+}
+
+bool ensureDirRecursive(const String& path) {
+  if (path.length() == 0 || path == "/") return true;
+  if (FS.exists(path)) return true;
+  int slash = path.lastIndexOf('/');
+  if (slash > 0) {
+    String parent = path.substring(0, slash);
+    if (parent.length() > 0 && !FS.exists(parent)) {
+      if (!ensureDirRecursive(parent)) return false;
+    }
+  }
+  return FS.mkdir(path);
+}
+
+bool isDirEmpty(const String& path) {
+  File dir = FS.open(path);
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+  File f = dir.openNextFile();
+  bool empty = !f;
+  if (f) f.close();
+  dir.close();
+  return empty;
+}

--- a/dev/stubs/list_items_glue.cpp
+++ b/dev/stubs/list_items_glue.cpp
@@ -1,0 +1,46 @@
+// Host implementations of the list_items.h firmware-glue functions
+// (normally compiled only under #ifdef ARDUINO).
+
+#include "src/storage/list_items.h"
+#include "src/pure/list_codec.h"
+#include "map_kv_store.h"
+
+static MapKvStore g_list_kv;
+
+ListState g_list;
+
+void sanitizeListText(String& s) {
+  // Mirror the codec sanitizer: strip leading/trailing whitespace, collapse
+  // internal runs. For the emulator a simple trim is enough.
+  s.trim();
+}
+
+void loadListItems() {
+  ListData data = loadList(g_list_kv);
+  g_list.count = 0;
+  g_list.selectedIndex = 0;
+  for (int i = 0; i < data.count && i < MAX_LIST_ITEMS; i++) {
+    strncpy(g_list.items[i].text, data.items[i].text, MAX_LIST_TEXT);
+    g_list.items[i].text[MAX_LIST_TEXT] = '\0';
+    g_list.items[i].done = data.items[i].done;
+    g_list.count++;
+  }
+}
+
+void saveListItems() {
+  ListData data;
+  data.count = g_list.count;
+  for (int i = 0; i < g_list.count; i++) {
+    strncpy(data.items[i].text, g_list.items[i].text, MAX_LIST_TEXT);
+    data.items[i].text[MAX_LIST_TEXT] = '\0';
+    data.items[i].done = g_list.items[i].done;
+  }
+  saveList(g_list_kv, data);
+}
+
+bool listHasVisibleItems() {
+  for (int i = 0; i < g_list.count; i++) {
+    if (g_list.items[i].text[0] != '\0') return true;
+  }
+  return false;
+}

--- a/dev/stubs/overrides/Preferences.h
+++ b/dev/stubs/overrides/Preferences.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Host-build stub for Arduino's <Preferences.h>.
+// Provides the subset of the Preferences API used by PreferencesStore.
+
+#include <map>
+#include <string>
+#include <vector>
+#include <cstring>
+#include "src/pure/arduino_compat.h"
+
+class Preferences {
+public:
+  int getInt(const char* key, int def = 0) {
+    auto it = bytes_.find(key);
+    if (it == bytes_.end() || it->second.size() != sizeof(int)) return def;
+    int v; std::memcpy(&v, it->second.data(), sizeof(v)); return v;
+  }
+  void putInt(const char* key, int v) {
+    auto& b = bytes_[key]; b.resize(sizeof(v)); std::memcpy(b.data(), &v, sizeof(v));
+  }
+
+  size_t getBytes(const char* key, void* buf, size_t maxLen) {
+    auto it = bytes_.find(key);
+    if (it == bytes_.end()) return 0;
+    size_t n = it->second.size() < maxLen ? it->second.size() : maxLen;
+    std::memcpy(buf, it->second.data(), n);
+    return n;
+  }
+  void putBytes(const char* key, const void* buf, size_t len) {
+    auto& v = bytes_[key];
+    v.assign((const uint8_t*)buf, (const uint8_t*)buf + len);
+  }
+
+  String getString(const char* key, const String& def = String("")) {
+    auto it = strs_.find(key);
+    return (it == strs_.end()) ? def : String(it->second.c_str());
+  }
+  void putString(const char* key, const String& v) { strs_[key] = v.c_str(); }
+
+  void remove(const char* key) { bytes_.erase(key); strs_.erase(key); }
+  void clear()                 { bytes_.clear();     strs_.clear();    }
+
+private:
+  std::map<std::string, std::vector<uint8_t>> bytes_;
+  std::map<std::string, std::string>          strs_;
+};

--- a/dev/stubs/overrides/Preferences.h
+++ b/dev/stubs/overrides/Preferences.h
@@ -7,16 +7,23 @@
 #include <string>
 #include <vector>
 #include <cstring>
+#include <cstdio>
 #include "src/pure/arduino_compat.h"
 
 class Preferences {
 public:
   int getInt(const char* key, int def = 0) {
     auto it = bytes_.find(key);
-    if (it == bytes_.end() || it->second.size() != sizeof(int)) return def;
-    int v; std::memcpy(&v, it->second.data(), sizeof(v)); return v;
+    if (it == bytes_.end() || it->second.size() != sizeof(int)) {
+      std::fprintf(stderr, "  [prefs] getInt  %s -> %d (default)\n", key, def);
+      return def;
+    }
+    int v; std::memcpy(&v, it->second.data(), sizeof(v));
+    std::fprintf(stderr, "  [prefs] getInt  %s -> %d\n", key, v);
+    return v;
   }
   void putInt(const char* key, int v) {
+    std::fprintf(stderr, "  [prefs] putInt  %s = %d\n", key, v);
     auto& b = bytes_[key]; b.resize(sizeof(v)); std::memcpy(b.data(), &v, sizeof(v));
   }
 

--- a/dev/stubs/overrides/src/state.h
+++ b/dev/stubs/overrides/src/state.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Host-build replacement for Pala_One_2_1/src/state.h.
+// Declares the same globals but backed by emulator stubs.
+
+#include "src/config.h"
+#include "stubs/web_server.h"
+#include "stubs/fs_stub.h"
+#include "Preferences.h"
+
+extern WebServerStub server;
+extern Preferences   prefs;
+
+// FS macro mirrors the real state.h convention.
+#define FS LittleFS
+
+// WiFi credential placeholders (some web handlers reference AP_SSID).
+extern char AP_SSID[24];
+extern const char* AP_PASS;
+
+// Arduino built-in stubs.
+inline void delay(unsigned long) {}
+inline unsigned long millis() { return 0; }

--- a/dev/stubs/overrides/src/storage/book_metadata.h
+++ b/dev/stubs/overrides/src/storage/book_metadata.h
@@ -1,0 +1,37 @@
+#pragma once
+// Emulator override: exposes firmware-glue functions without #ifdef ARDUINO.
+// Definitions live in dev/stubs/book_metadata_glue.cpp.
+
+#include "src/storage/kv_store.h"
+#include "src/pure/bookmarks_codec.h"
+#include "src/pure/hashing.h"
+
+// ---------------------------------------------------------------------------
+//  Testable KV-store-backed API (identical to real header)
+// ---------------------------------------------------------------------------
+Bookmarks loadBookmarks(KeyValueStore& kv, const String& bookKey);
+void      saveBookmarks(KeyValueStore& kv, const String& bookKey, const Bookmarks& bm);
+
+int      loadSavedPage(KeyValueStore& kv, const String& bookKey);
+void     saveSavedPage(KeyValueStore& kv, const String& bookKey, int pageIndex);
+uint32_t loadSavedOffset(KeyValueStore& kv, const String& bookKey);
+void     saveSavedOffset(KeyValueStore& kv, const String& bookKey, uint32_t byteOffset);
+
+bool clearBookMetadata(KeyValueStore& kv, const String& bookKey);
+void renameBookMetadata(KeyValueStore& kv, const String& oldKey, const String& newKey);
+
+// ---------------------------------------------------------------------------
+//  Firmware-glue API — exposed unconditionally in the emulator
+// ---------------------------------------------------------------------------
+#include "src/config.h"
+
+uint8_t loadBookmarksForKey(const String& bookKey,
+                            uint16_t outPages[MAX_BOOKMARKS],
+                            uint32_t outOffsets[MAX_BOOKMARKS]);
+void saveBookmarksForKey(const String& bookKey,
+                         const uint16_t pages[MAX_BOOKMARKS],
+                         const uint32_t offsets[MAX_BOOKMARKS],
+                         uint8_t count);
+int  savedPageForBookPath(const String& path);
+void deleteBookMetadata(const String& path);
+void migrateBookMetadata(const String& oldPath, const String& newPath);

--- a/dev/stubs/overrides/src/storage/list_items.h
+++ b/dev/stubs/overrides/src/storage/list_items.h
@@ -1,0 +1,34 @@
+#pragma once
+// Emulator override: exposes firmware-glue types and functions without #ifdef ARDUINO.
+// Definitions live in dev/stubs/list_items_glue.cpp.
+
+#include "src/storage/kv_store.h"
+#include "src/pure/list_codec.h"
+#include "src/config.h"
+
+// ---------------------------------------------------------------------------
+//  Testable KV-store-backed API (identical to real header)
+// ---------------------------------------------------------------------------
+ListData loadList(KeyValueStore& kv);
+void     saveList(KeyValueStore& kv, const ListData& data);
+
+// ---------------------------------------------------------------------------
+//  Firmware-glue runtime state — exposed unconditionally in the emulator
+// ---------------------------------------------------------------------------
+struct ListItem {
+  char    text[MAX_LIST_TEXT + 1];
+  uint8_t done = 0;
+};
+
+struct ListState {
+  ListItem items[MAX_LIST_ITEMS];
+  int count         = 0;
+  int selectedIndex = 0;
+};
+
+extern ListState g_list;
+
+void sanitizeListText(String& s);
+void loadListItems();
+void saveListItems();
+bool listHasVisibleItems();

--- a/dev/stubs/overrides/src/ui/screen.h
+++ b/dev/stubs/overrides/src/ui/screen.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Minimal Screen stub — list.cpp checks g_currentScreen == &g_listScreen
+// after a POST to decide whether to redirect the device display.
+// In the emulator this check always evaluates to false; no navigation occurs.
+
+struct Screen {
+  Screen* nextScreen = nullptr;
+};
+
+extern Screen* g_currentScreen;

--- a/dev/stubs/overrides/src/ui/screens/library_screen.h
+++ b/dev/stubs/overrides/src/ui/screens/library_screen.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "src/ui/screen.h"
+extern Screen g_libraryScreen;
+inline void resetLibraryNav() {}

--- a/dev/stubs/overrides/src/ui/screens/list_screen.h
+++ b/dev/stubs/overrides/src/ui/screens/list_screen.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "src/ui/screen.h"
+extern Screen g_listScreen;

--- a/dev/stubs/overrides/src/ui/toast.h
+++ b/dev/stubs/overrides/src/ui/toast.h
@@ -1,0 +1,5 @@
+#pragma once
+namespace Toast {
+  inline void reset() {}
+  inline void show(const char*) {}
+}

--- a/dev/stubs/prelude.h
+++ b/dev/stubs/prelude.h
@@ -1,0 +1,18 @@
+#pragma once
+// Force-included before every translation unit in the emulator build.
+// System headers must be parsed before arduino_compat.h defines the min/max
+// two-argument macros, otherwise zero-argument calls like numeric_limits<T>::min()
+// are misinterpreted as macro invocations and fail to compile.
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>

--- a/dev/stubs/state.cpp
+++ b/dev/stubs/state.cpp
@@ -1,0 +1,17 @@
+#include "stubs/web_server.h"
+#include "stubs/fs_stub.h"
+#include "Preferences.h"
+#include "src/ui/screen.h"
+#include "src/ui/screens/library_screen.h"
+#include "src/ui/screens/list_screen.h"
+
+WebServerStub server;
+Preferences   prefs;
+
+char        AP_SSID[24] = "PalaOneEmu";
+const char* AP_PASS     = "palaone";
+
+// Screen stubs for list.cpp's post-save navigation check.
+Screen  g_libraryScreen;
+Screen  g_listScreen;
+Screen* g_currentScreen = nullptr;

--- a/dev/stubs/text_stubs.cpp
+++ b/dev/stubs/text_stubs.cpp
@@ -1,36 +1,97 @@
-// Stubs for src/ui/text.h — the paginator/render functions that depend on the
-// u8g2 display library. In the emulator these return simple approximations so
-// the bookmark view and export pages can show *something*.
+// Stubs for src/ui/text.h. The emulator uses the real pure paginator
+// (paginatePage) with a host-side character-width approximation for
+// helvR12_te so page boundaries match the device closely.
 
 #include "src/ui/text.h"
+#include "src/ui/font.h"
+#include "src/pure/find_text.h"
+#include "src/pure/paginator.h"
+#include "src/hal/file_stream.h"
 
-uint32_t drawPageAt(File&, uint32_t startPos) {
-  return startPos + 1000;
-}
-
-// Read up to ~800 bytes of raw text from the file at the given offset.
-// Real firmware would word-wrap at pixel widths; emulator just reads bytes.
-uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
-  if (!f) return startPos;
-  f.seek(startPos);
-  const int kMax = 800;
-  uint8_t buf[kMax];
-  size_t n = f.read(buf, kMax);
-  for (size_t i = 0; i < n; i++) {
-    char c = (char)buf[i];
-    if (c != '\r') out += c;
+// Approximate per-glyph pixel widths for u8g2_font_helvR12_te.
+// Non-ASCII bytes (UTF-8 continuations) return 0; lead bytes return ~7.
+static int hostMeasureWidth(const char* s) {
+  static const uint8_t w[128] = {
+  //  0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // 00
+      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // 10
+      3,  4,  5,  9,  7, 10,  9,  3,  4,  4,  6,  9,  4,  5,  4,  5, // 20  !"#$%&'()*+,-./
+      7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  4,  4,  9,  9,  9,  6, // 30  0-9:;<=>?
+     12,  8,  8,  8,  9,  7,  7,  9,  9,  3,  5,  8,  7, 10,  9,  9, // 40  @A-O
+      7,  9,  8,  7,  7,  9,  8, 11,  8,  7,  8,  4,  5,  4,  9,  7, // 50  P-Z[\]^_
+      5,  7,  7,  6,  7,  7,  4,  7,  7,  3,  3,  7,  3, 10,  7,  7, // 60  `a-o
+      7,  7,  5,  6,  5,  7,  7, 10,  7,  7,  6,  5,  3,  5,  9,  0, // 70  p-z{|}~
+  };
+  int total = 0;
+  while (*s) {
+    unsigned char c = (unsigned char)*s++;
+    if (c < 0x80)       total += w[c];       // ASCII
+    else if (c >= 0xC0) total += 7;          // UTF-8 lead byte — non-ASCII char
+    // continuation bytes (0x80–0xBF) contribute 0
   }
-  return startPos + (uint32_t)n;
+  return total;
 }
 
-uint32_t nextPageOffset(File&, uint32_t startPos) {
-  return startPos + 1000;
+uint32_t drawPageAt(File& f, uint32_t startPos) {
+  FileReadStream stream(f);
+  return paginatePage(stream, startPos, Font::bodyLayout(), hostMeasureWidth, nullptr);
 }
 
-uint32_t pageOffsetForPage(File&, const String&, int page) {
-  return (uint32_t)page * 1000u;
+uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
+  FileReadStream stream(f);
+  auto onLine = [&](const char* buf, size_t len) {
+    const char* p = buf;
+    size_t rem = len;
+    while (rem > 0 && (*p == ' ' || *p == '\t')) { p++; rem--; }
+    out.concat(p, (unsigned int)rem);
+    out.concat('\n');
+  };
+  return paginatePage(stream, startPos, Font::bodyLayout(), hostMeasureWidth, onLine);
 }
 
-uint32_t resolveBookmarkOffset(const String&, uint16_t page, uint32_t storedOffset) {
-  return (storedOffset != 0xFFFFFFFFu) ? storedOffset : (uint32_t)page * 1000u;
+uint32_t nextPageOffset(File& f, uint32_t startPos) {
+  FileReadStream stream(f);
+  return paginatePage(stream, startPos, Font::bodyLayout(), hostMeasureWidth, nullptr);
+}
+
+uint32_t pageOffsetForPage(File& f, const String& /*path*/, int page) {
+  if (page <= 0) return 0;
+  uint32_t off = 0;
+  for (int p = 0; p < page; p++) {
+    uint32_t next = nextPageOffset(f, off);
+    if (next <= off) break;
+    off = next;
+  }
+  return off;
+}
+
+uint32_t resolveBookmarkOffset(const String& path, uint16_t page, uint32_t storedOffset) {
+  File f = FS.open(path, "r");
+  if (!f) return 0;
+  uint32_t off = (storedOffset != 0xFFFFFFFFu) ? storedOffset
+                                                : pageOffsetForPage(f, path, page);
+  f.close();
+  return off;
+}
+
+uint32_t pageOffsetForText(File& f, const String& /*path*/, const String& query,
+                           int* outPageIndex) {
+  if (outPageIndex) *outPageIndex = -1;
+  if (query.length() == 0 || !f) return 0;
+
+  FileReadStream stream(f);
+  uint32_t matchOffset = findByteOffset(stream, query);
+  if (matchOffset == 0xFFFFFFFFu) return 0xFFFFFFFFu;
+
+  uint32_t pageStart = 0;
+  int pageIdx = 0;
+  while (pageStart < matchOffset) {
+    uint32_t next = nextPageOffset(f, pageStart);
+    if (next <= pageStart) break;
+    if (next > matchOffset) break;
+    pageStart = next;
+    pageIdx++;
+  }
+  if (outPageIndex) *outPageIndex = pageIdx;
+  return pageStart;
 }

--- a/dev/stubs/text_stubs.cpp
+++ b/dev/stubs/text_stubs.cpp
@@ -1,0 +1,36 @@
+// Stubs for src/ui/text.h — the paginator/render functions that depend on the
+// u8g2 display library. In the emulator these return simple approximations so
+// the bookmark view and export pages can show *something*.
+
+#include "src/ui/text.h"
+
+uint32_t drawPageAt(File&, uint32_t startPos) {
+  return startPos + 1000;
+}
+
+// Read up to ~800 bytes of raw text from the file at the given offset.
+// Real firmware would word-wrap at pixel widths; emulator just reads bytes.
+uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
+  if (!f) return startPos;
+  f.seek(startPos);
+  const int kMax = 800;
+  uint8_t buf[kMax];
+  size_t n = f.read(buf, kMax);
+  for (size_t i = 0; i < n; i++) {
+    char c = (char)buf[i];
+    if (c != '\r') out += c;
+  }
+  return startPos + (uint32_t)n;
+}
+
+uint32_t nextPageOffset(File&, uint32_t startPos) {
+  return startPos + 1000;
+}
+
+uint32_t pageOffsetForPage(File&, const String&, int page) {
+  return (uint32_t)page * 1000u;
+}
+
+uint32_t resolveBookmarkOffset(const String&, uint16_t page, uint32_t storedOffset) {
+  return (storedOffset != 0xFFFFFFFFu) ? storedOffset : (uint32_t)page * 1000u;
+}

--- a/dev/stubs/ui_stubs.cpp
+++ b/dev/stubs/ui_stubs.cpp
@@ -1,0 +1,58 @@
+// Stubs for the Font:: and Sleep:: namespaces from src/ui/font.h and src/ui/sleep.h.
+// The emulator returns sensible defaults and persists changes in memory only.
+
+#include "src/ui/font.h"
+#include "src/ui/sleep.h"
+#include "src/pure/paginator.h"
+
+// ---------------------------------------------------------------------------
+//  Font
+// ---------------------------------------------------------------------------
+namespace Font {
+
+static int  s_bodySize = 12;
+static int  s_lineGap  = 0;
+
+void useBody()     {}
+void useBold()     {}
+void useUiSmall()  {}
+void useUiTiny()   {}
+void useAppLarge() {}
+void loadSettings() {}
+
+const LayoutMetrics& bodyLayout() {
+  static LayoutMetrics m;
+  m.lineH    = s_bodySize + 2 + s_lineGap;
+  m.maxWidth = 250;
+  m.maxLines = 122 / m.lineH;
+  m.ascent   = s_bodySize;
+  m.descent  = 2;
+  return m;
+}
+
+void setBodySize(int sz) {
+  if (sz == 8 || sz == 10 || sz == 12 || sz == 14) s_bodySize = sz;
+}
+void setLineGap(int gap) {
+  if (gap >= 0 && gap <= 4) s_lineGap = gap;
+}
+int currentBodySize() { return s_bodySize; }
+int currentLineGap()  { return s_lineGap; }
+
+}  // namespace Font
+
+// ---------------------------------------------------------------------------
+//  Sleep
+// ---------------------------------------------------------------------------
+namespace Sleep {
+
+static int s_timeout = 120;
+
+void loadSettings()       {}
+void setIdleTimeout(int s) { if (s >= 10 && s <= 3600) s_timeout = s; }
+int  idleTimeoutSecs()    { return s_timeout; }
+uint32_t idleTimeoutMs()  { return (uint32_t)s_timeout * 1000u; }
+void enter()              {}
+void idleLightSleep(bool) {}
+
+}  // namespace Sleep

--- a/dev/stubs/ui_stubs.cpp
+++ b/dev/stubs/ui_stubs.cpp
@@ -4,6 +4,7 @@
 #include "src/ui/font.h"
 #include "src/ui/sleep.h"
 #include "src/pure/paginator.h"
+#include "src/config.h"
 
 // ---------------------------------------------------------------------------
 //  Font
@@ -22,11 +23,14 @@ void loadSettings() {}
 
 const LayoutMetrics& bodyLayout() {
   static LayoutMetrics m;
-  m.lineH    = s_bodySize + 2 + s_lineGap;
-  m.maxWidth = 250;
-  m.maxLines = 122 / m.lineH;
   m.ascent   = s_bodySize;
   m.descent  = 2;
+  m.lineH    = s_bodySize + m.descent + s_lineGap;
+  m.maxWidth = SCREEN_W - 2 * MARGIN_X;
+  int usableH = SCREEN_H - TOP_PAD - BOT_PAD;
+  if (SHOW_PROGRESS_BAR || SHOW_PAGE_NUMBER) usableH -= STATUS_H;
+  m.maxLines = usableH / m.lineH;
+  if (m.maxLines < 1) m.maxLines = 1;
   return m;
 }
 

--- a/dev/stubs/upload_stub.cpp
+++ b/dev/stubs/upload_stub.cpp
@@ -1,0 +1,8 @@
+// Stub registration functions for upload routes not included in the emulator.
+// web.cpp calls these from registerWebRoutes(); they do nothing here.
+
+#include "src/web/upload.h"
+#include "src/web/apps_upload.h"
+
+void registerUploadRoutes()    {}
+void registerAppUploadRoutes() {}

--- a/dev/stubs/web_server.cpp
+++ b/dev/stubs/web_server.cpp
@@ -1,0 +1,105 @@
+// httplib is only included here — never in web_server.h — so the Arduino
+// min/max macros (defined by arduino_compat.h in other TUs) can't interfere
+// with httplib's use of <random> and other system headers that have zero-arg
+// member functions named min()/max().
+
+#define CPPHTTPLIB_THREAD_POOL_COUNT 1
+#include <httplib.h>
+
+#include "stubs/web_server.h"
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+//  Implementation detail
+// ---------------------------------------------------------------------------
+
+struct WebServerImpl {
+  httplib::Server svr;
+};
+
+// Thread-local request/response context, set for each handler call.
+thread_local static const httplib::Request*                           t_req = nullptr;
+thread_local static httplib::Response*                                t_res = nullptr;
+thread_local static std::vector<std::pair<std::string,std::string>>  t_hdrs;
+
+static void applyHeaders(httplib::Response& res) {
+  for (auto& h : t_hdrs) res.set_header(h.first.c_str(), h.second.c_str());
+  t_hdrs.clear();
+}
+
+static void dispatch(const httplib::Request& req, httplib::Response& res,
+                     const THandlerFunction& handler) {
+  t_req = &req;
+  t_res = &res;
+  t_hdrs.clear();
+  handler();
+  applyHeaders(res);
+  t_req = nullptr;
+  t_res = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+//  WebServerStub
+// ---------------------------------------------------------------------------
+
+WebServerStub::WebServerStub()  : impl_(std::make_unique<WebServerImpl>()) {}
+WebServerStub::~WebServerStub() = default;
+
+void WebServerStub::on(const char* uri, int method, THandlerFunction handler) {
+  if (method == HTTP_GET || method == HTTP_ANY) {
+    impl_->svr.Get(uri, [handler](const httplib::Request& req, httplib::Response& res) {
+      dispatch(req, res, handler);
+    });
+  }
+  if (method == HTTP_POST || method == HTTP_ANY) {
+    impl_->svr.Post(uri, [handler](const httplib::Request& req, httplib::Response& res) {
+      dispatch(req, res, handler);
+    });
+  }
+}
+
+void WebServerStub::on(const char* uri, int /*method*/,
+                       THandlerFunction /*done*/, THandlerFunction /*stream*/) {
+  impl_->svr.Post(uri, [](const httplib::Request&, httplib::Response& res) {
+    res.status = 501;
+    res.set_content("File upload not supported in the web emulator.", "text/plain");
+  });
+}
+
+void WebServerStub::send(int code, const char* contentType, const String& body) {
+  if (!t_res) return;
+  t_res->status = code;
+  applyHeaders(*t_res);
+  t_res->set_content(body.c_str(), contentType);
+}
+
+void WebServerStub::send_P(int code, const char* contentType, const char* progmemStr) {
+  if (!t_res) return;
+  t_res->status = code;
+  applyHeaders(*t_res);
+  t_res->set_content(progmemStr, contentType);
+}
+
+void WebServerStub::sendHeader(const char* name, const String& value) {
+  t_hdrs.push_back({name, value.c_str()});
+}
+
+String WebServerStub::arg(const String& name) {
+  if (!t_req) return String("");
+  if (t_req->has_param(name.c_str()))
+    return String(t_req->get_param_value(name.c_str()).c_str());
+  return String("");
+}
+
+bool WebServerStub::hasArg(const String& name) {
+  return t_req && t_req->has_param(name.c_str());
+}
+
+void WebServerStub::run(int port) {
+  std::cout << "Pala One web emulator: http://localhost:" << port << "\n";
+  std::cout << "Press Ctrl+C to stop.\n";
+  impl_->svr.listen("0.0.0.0", port);
+}

--- a/dev/stubs/web_server.cpp
+++ b/dev/stubs/web_server.cpp
@@ -35,8 +35,25 @@ static void dispatch(const httplib::Request& req, httplib::Response& res,
   t_req = &req;
   t_res = &res;
   t_hdrs.clear();
+
+  std::cerr << req.method << " " << req.path;
+  if (!req.params.empty()) {
+    std::cerr << "?";
+    bool first = true;
+    for (auto& p : req.params) {
+      if (!first) std::cerr << "&";
+      std::cerr << p.first << "=" << p.second;
+      first = false;
+    }
+  }
+  if (!req.body.empty()) std::cerr << " body=" << req.body;
+  std::cerr << "\n";
+
   handler();
   applyHeaders(res);
+
+  std::cerr << "  -> " << res.status << "\n";
+
   t_req = nullptr;
   t_res = nullptr;
 }
@@ -102,4 +119,8 @@ void WebServerStub::run(int port) {
   std::cout << "Pala One web emulator: http://localhost:" << port << "\n";
   std::cout << "Press Ctrl+C to stop.\n";
   impl_->svr.listen("0.0.0.0", port);
+}
+
+void WebServerStub::stop() {
+  impl_->svr.stop();
 }

--- a/dev/stubs/web_server.h
+++ b/dev/stubs/web_server.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "src/pure/arduino_compat.h"
+
+enum HTTPMethod { HTTP_ANY, HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_PATCH, HTTP_DELETE, HTTP_OPTIONS };
+
+using THandlerFunction = std::function<void()>;
+
+// Forward declaration — implementation detail in web_server.cpp.
+struct WebServerImpl;
+
+// Drop-in stub for Arduino's WebServer, backed by cpp-httplib.
+// httplib.h is intentionally NOT included here to avoid macro conflicts.
+class WebServerStub {
+public:
+  WebServerStub();
+  ~WebServerStub();
+
+  // Route registration.
+  void on(const char* uri, int method, THandlerFunction handler);
+  // Streaming-upload variant — returns 501 in the emulator.
+  void on(const char* uri, int method, THandlerFunction done, THandlerFunction stream);
+
+  // Response helpers — callable only from within a handler.
+  void send(int code, const char* contentType, const String& body);
+  void send_P(int code, const char* contentType, const char* progmemStr);
+  void sendHeader(const char* name, const String& value);
+
+  // Request helpers — callable only from within a handler.
+  String arg(const String& name);
+  bool   hasArg(const String& name);
+
+  // No-ops called by firmware during normal startup/loop.
+  void begin() {}
+  void handleClient() {}
+
+  // Start the blocking HTTP server loop.
+  void run(int port = 8080);
+
+private:
+  std::unique_ptr<WebServerImpl> impl_;
+};

--- a/dev/stubs/web_server.h
+++ b/dev/stubs/web_server.h
@@ -41,6 +41,9 @@ public:
   // Start the blocking HTTP server loop.
   void run(int port = 8080);
 
+  // Stop the server (unblocks run()). Safe to call from another thread.
+  void stop();
+
 private:
   std::unique_ptr<WebServerImpl> impl_;
 };


### PR DESCRIPTION
## Summary

- Compiles the real `src/web/` C++ handlers for Linux by stubbing out Arduino-specific dependencies (`WebServer`, `LittleFS`, `Preferences`)
- Uses cpp-httplib v0.15.3 as the HTTP backend, isolated behind a PIMPL boundary to avoid `min`/`max` macro conflicts with the Arduino compat shim
- All six portal pages load: `/`, `/files`, `/bookmarks`, `/list`, `/settings`, `/reset`
- I've tested `/files` the most
- added an integration test stub

## Dev workflow

```bash
# One-time setup
cmake -S dev -B dev/build

# Incremental build (~1–2s with ccache)
cmake --build dev/build
./dev/build/pala_web_emu     # listen on localhost:8080
```

The virtual filesystem is rooted at `dev/fs/` (overridable via `PALA_EMU_FS_ROOT`). A sample book is pre-populated at `dev/fs/books/sample.txt`.

## Test plan

- [x] `cmake -S dev -B dev/build && cmake --build dev/build` compiles clean
- [x] `./dev/build/pala_web_emu` starts and prints listening message
- [x] Smoke test all six pages load in browser at localhost:8080
- [x] `dev/fs/books/sample.txt` appears in the `/files` page
- [x] Edit a string in `src/web/files.cpp`, rebuild, restart — change is visible
- [x] Existing host tests still pass: `cmake -S test -B test/build && cmake --build test/build && ctest --test-dir test/build`
- [x] Integration stub tests pass: `cmake -S dev -B dev/build && cmake --build dev/build && ctest --test-dir dev/build --output-on-failure`

Co-authored by [Claude Code](https://claude.com/claude-code)