### PR TITLE
Find-in-Book web feature

### DIFF
--- a/Pala_One_2_1/src/pure/arduino_compat.h
+++ b/Pala_One_2_1/src/pure/arduino_compat.h
@@ -57,6 +57,10 @@ public:
   String& operator+=(int n)           { s_ += String(n).s_; return *this; }
   String& operator+=(unsigned long n) { s_ += String(n).s_; return *this; }
 
+  bool concat(const char* buf, unsigned int len) { s_.append(buf, len); return true; }
+  bool concat(const String& o)                   { s_ += o.s_; return true; }
+  bool concat(char c)                            { s_ += c; return true; }
+
   String operator+(const String& o) const { String r(*this); r += o; return r; }
   String operator+(const char* o) const   { String r(*this); r += o; return r; }
   String operator+(char c) const          { String r(*this); r += c; return r; }

--- a/Pala_One_2_1/src/pure/find_text.cpp
+++ b/Pala_One_2_1/src/pure/find_text.cpp
@@ -1,0 +1,99 @@
+#include "find_text.h"
+
+uint32_t find_text(const String& text, const String& pattern) {
+  const unsigned text_len = text.length();
+  const unsigned pattern_len = pattern.length();
+
+  // Edge cases: empty pattern matches at the start; pattern longer than text can't match.
+  if (pattern_len == 0) {
+    return 0;
+  }
+  if (pattern_len > text_len) {
+    return 0xFFFFFFFFu;
+  }
+
+  const char* text_data = text.c_str();
+  const char* pattern_data = pattern.c_str();
+
+  // Table of how far to skip ahead when a mismatch occurs on a given byte.
+  unsigned shift[256];
+
+  // Initialize all shifts to the pattern length (the max)
+  for (unsigned i = 0; i < sizeof(shift) / sizeof(shift[0]); ++i) {
+    shift[i] = pattern_len;
+  }
+
+  // For each pattern byte except the last, record how far we can skip
+  // when that byte appears as the mismatch character.
+  for (unsigned i = 0; i + 1 < pattern_len; ++i) {
+    shift[static_cast<unsigned char>(pattern_data[i])] = pattern_len - 1 - i;
+  }
+
+  unsigned index = 0;
+  while (index <= text_len - pattern_len) {
+    // Compare from the end of the pattern backwards.
+    unsigned pos = pattern_len - 1;
+    while (pos < pattern_len && pattern_data[pos] == text_data[index + pos]) {
+      if (pos == 0) {
+        return static_cast<uint32_t>(index);
+      }
+      --pos;
+    }
+    index += shift[static_cast<unsigned char>(text_data[index + pattern_len - 1])];
+  }
+
+  return 0xFFFFFFFFu;
+}
+
+static String asciiLower(const String& s) {
+  String out;
+  const char* p = s.c_str();
+  while (*p) {
+    char c = *p++;
+    if (c >= 'A' && c <= 'Z') c += 32;
+    out += c;
+  }
+  return out;
+}
+
+uint32_t findByteOffset(IReadStream& in, const String& pattern, size_t chunkSize) {
+  const unsigned patLen = pattern.length();
+  if (patLen == 0) return 0;
+  const unsigned overlap = patLen - 1;
+
+  // Normalise once; search windows are lowercased per chunk below.
+  const String lowerPat = asciiLower(pattern);
+
+  in.seek(0);
+  String tail;       // original bytes — preserves correct byte offsets
+  String lowerTail;  // lowercased mirror of tail
+
+  while (in.available()) {
+    uint32_t chunkStart = in.position();
+    String newBytes;
+    for (size_t i = 0; i < chunkSize && in.available(); ++i) {
+      int b = in.read();
+      if (b < 0) break;
+      newBytes += (char)(uint8_t)b;
+    }
+    if (newBytes.length() == 0) break;
+
+    // searchStr[0] is at absolute byte searchBase.
+    uint32_t searchBase = chunkStart - (uint32_t)tail.length();
+    String searchStr   = tail;       searchStr   += newBytes;
+    String lowerSearch = lowerTail;  lowerSearch += asciiLower(newBytes);
+
+    uint32_t pos = find_text(lowerSearch, lowerPat);
+    if (pos != 0xFFFFFFFFu) return searchBase + pos;
+
+    if (overlap > 0 && searchStr.length() > overlap) {
+      tail      = searchStr  .substring(searchStr  .length() - overlap);
+      lowerTail = lowerSearch.substring(lowerSearch.length() - overlap);
+    } else {
+      tail      = searchStr;
+      lowerTail = lowerSearch;
+    }
+  }
+
+  return 0xFFFFFFFFu;
+}

--- a/Pala_One_2_1/src/pure/find_text.h
+++ b/Pala_One_2_1/src/pure/find_text.h
@@ -1,0 +1,20 @@
+#ifndef PALA_PURE_FIND_TEXT_H
+#define PALA_PURE_FIND_TEXT_H
+
+#include "arduino_compat.h"
+#include "stream.h"
+
+// Search for the first occurrence of `pattern` inside `text`.
+// Uses the Boyer-Moore-Horspool variant to skip ahead by the
+// last-character shift when possible.
+// Returns the zero-based byte index of the match, or 0xFFFFFFFFu if not found.
+uint32_t find_text(const String& text, const String& pattern);
+
+// Stream `in` in `chunkSize`-byte windows, keeping the last (patLen-1) bytes
+// of each window as overlap for the next so matches that straddle a chunk
+// boundary are not missed. Returns the absolute byte offset of the first
+// occurrence of `pattern`, or 0xFFFFFFFFu if not found.
+uint32_t findByteOffset(IReadStream& in, const String& pattern,
+                        size_t chunkSize = 512);
+
+#endif // PALA_PURE_FIND_TEXT_H

--- a/Pala_One_2_1/src/ui/text.cpp
+++ b/Pala_One_2_1/src/ui/text.cpp
@@ -2,6 +2,7 @@
 
 #include "src/hal/display.h"            // u8g2
 #include "src/pure/bookmarks_codec.h"   // kOffsetUnset
+#include "src/pure/find_text.h"
 #include "src/storage/page_cache.h"     // on-disk page-offset cache
 #include "src/ui/font.h"                // Font::useBody / bodyLayout / current{BodySize,LineGap}
 
@@ -78,6 +79,60 @@ uint32_t pageOffsetForPage(File& f, const String& path, int page) {
     off = next;
   }
   return off;
+}
+
+uint32_t pageOffsetForText(File& f, const String& path, const String& query,
+                           int* outPageIndex) {
+  if (query.length() == 0) return 0;
+
+  FileReadStream stream(f);
+  uint32_t matchOffset = findByteOffset(stream, query);
+  if (matchOffset == 0xFFFFFFFFu) return 0xFFFFFFFFu;
+
+  // Load any existing page cache so we can skip re-pagination of pages the
+  // reader already computed, and so we don't discard that work when we save.
+  // Static to keep 40 KB off the stack; re-initialised on every call.
+  static PageOffsetTable table;
+  table.count = 1;
+  table.offsets[0] = 0;
+  table.eofReached = false;
+  loadPageOffsetCacheForBook(path, f.size(),
+                             Font::currentBodySize(), Font::currentLineGap(), table);
+
+  // Find the highest cached page whose byte offset is at or before the match
+  // so we can resume from there instead of walking from page 0.
+  int pageIdx = 0;
+  for (int i = table.count - 1; i >= 0; i--) {
+    if (table.offsets[i] <= matchOffset) { pageIdx = i; break; }
+  }
+
+  Font::useBody();
+  uint32_t pageStart = table.offsets[pageIdx];
+
+  // Walk forward, using cached entries when available and computing new ones
+  // otherwise. New entries are appended to the table as we go.
+  while (pageStart < matchOffset && pageIdx + 1 < MAX_PAGES) {
+    uint32_t next;
+    if (pageIdx + 1 < table.count) {
+      next = table.offsets[pageIdx + 1];   // already known — free
+    } else {
+      next = nextPageOffset(f, pageStart);
+      if (next <= pageStart) break;        // EOF or no progress
+      table.offsets[pageIdx + 1] = next;
+      table.count = pageIdx + 2;
+    }
+    if (next > matchOffset) break;
+    pageStart = next;
+    pageIdx++;
+  }
+
+  // Persist everything we know. The reader and future lookups start from the
+  // highest page recorded here rather than paginating from scratch.
+  savePageOffsetCacheForBook(path, f.size(),
+                             Font::currentBodySize(), Font::currentLineGap(), table);
+
+  if (outPageIndex) *outPageIndex = pageIdx;
+  return pageStart;
 }
 
 uint32_t resolveBookmarkOffset(const String& path, uint16_t page, uint32_t storedOffset) {

--- a/Pala_One_2_1/src/ui/text.h
+++ b/Pala_One_2_1/src/ui/text.h
@@ -39,6 +39,13 @@ uint32_t nextPageOffset(File& f, uint32_t startPos);
 // `nextPageOffset` if the requested page is past the cached portion.
 uint32_t pageOffsetForPage(File& f, const String& path, int page);
 
+// Find the byte offset of the first page that contains `query`. Searches
+// raw file bytes, then walks pages to the page boundary. Returns
+// 0xFFFFFFFFu if the pattern is not found. If `outPageIndex` is non-null
+// it receives the zero-based page index of the matched page.
+uint32_t pageOffsetForText(File& f, const String& path, const String& query,
+                           int* outPageIndex = nullptr);
+
 // Returns `storedOffset` if it's a usable cached value for this book; falls
 // back to `pageOffsetForPage` otherwise. Owns the file handle internally.
 uint32_t resolveBookmarkOffset(const String& path, uint16_t page, uint32_t storedOffset);

--- a/Pala_One_2_1/src/web/files.cpp
+++ b/Pala_One_2_1/src/web/files.cpp
@@ -9,7 +9,7 @@
 #include "src/storage/app_catalog.h"
 #include "src/storage/library.h"
 #include "src/storage/preferences_store.h"
-#include "src/ui/text.h"            // pageOffsetForPage
+#include "src/ui/text.h" // pageOffsetForPage, pageOffsetForText
 #include "src/web/chrome.h"
 
 // ============================================================================
@@ -19,10 +19,12 @@
 //  /mkdir       — POST: create folder
 //  /rmdir       — POST: delete (empty) folder
 //  /move        — POST: move book to a different folder
-//  /jumppage    — POST: set the page that opens next on device
+//  /jumppage    — POST: jump to page N on next device open
+//  /jumptext    — POST: jump to first page containing a search string
 // ============================================================================
 
-static void handleRoot() {
+static void handleRoot()
+{
   String subtitle = "Firmware ";
   subtitle += FW_BUILD;
   subtitle += " &middot; ";
@@ -33,32 +35,32 @@ static void handleRoot() {
   subtitle += humanBytes(fsTotalBytesSafe());
 
   String out = webPageStart(
-    "Pala One",
-    subtitle,
-    "<a href='/files'>Files</a><a href='/bookmarks'>Bookmarks</a><a href='/list'>List</a><a href='/settings'>Settings</a><a href='/reset'>Factory reset</a>"
-  );
+      "Pala One",
+      subtitle,
+      "<a href='/files'>Files</a><a href='/bookmarks'>Bookmarks</a><a href='/list'>List</a><a href='/settings'>Settings</a><a href='/reset'>Factory reset</a>");
 
   out += storageCardHtml();
 
-  if (fsTotalBytesSafe() == 0 || fsFreeBytesSafe() < 8192) {
+  if (fsTotalBytesSafe() == 0 || fsFreeBytesSafe() < 8192)
+  {
     out += "<div class='banner-warn'>&#9888; Storage is not available or almost full. If uploads fail, delete books or use Factory reset from this web UI.</div>";
   }
 
   out +=
-    "<div class='card'><h2>Upload book</h2>"
-    "<p class='muted'>Send UTF-8 plain text files to <b>/books</b> on the device, then sort them into folders from the Files page.</p>"
-    "<form method='POST' action='/upload' enctype='multipart/form-data' accept-charset='UTF-8' style='margin-top:14px'>"
-    "<input type='file' name='file' accept='.txt,text/plain' required>"
-    "<div class='actions'><button type='submit'>Upload</button><a class='btn secondary' href='/files'>Manage files</a></div>"
-    "</form></div>";
+      "<div class='card'><h2>Upload book</h2>"
+      "<p class='muted'>Send UTF-8 plain text files to <b>/books</b> on the device, then sort them into folders from the Files page.</p>"
+      "<form method='POST' action='/upload' enctype='multipart/form-data' accept-charset='UTF-8' style='margin-top:14px'>"
+      "<input type='file' name='file' accept='.txt,text/plain' required>"
+      "<div class='actions'><button type='submit'>Upload</button><a class='btn secondary' href='/files'>Manage files</a></div>"
+      "</form></div>";
 
   out +=
-    "<div class='card'><h2>Install app</h2>"
-    "<p class='muted'>Upload a Pala app binary (<b>.bin</b>) to <b>/apps</b>. The header is validated before commit; only files with the correct magic and API version are accepted. Open <b>Apps</b> from the library to launch.</p>"
-    "<form method='POST' action='/upload-app' enctype='multipart/form-data' style='margin-top:14px'>"
-    "<input type='file' name='file' accept='.bin' required>"
-    "<div class='actions'><button type='submit'>Install app</button></div>"
-    "</form></div>";
+      "<div class='card'><h2>Install app</h2>"
+      "<p class='muted'>Upload a Pala app binary (<b>.bin</b>) to <b>/apps</b>. The header is validated before commit; only files with the correct magic and API version are accepted. Open <b>Apps</b> from the library to launch.</p>"
+      "<form method='POST' action='/upload-app' enctype='multipart/form-data' style='margin-top:14px'>"
+      "<input type='file' name='file' accept='.bin' required>"
+      "<div class='actions'><button type='submit'>Install app</button></div>"
+      "</form></div>";
 
   out += "<div class='card'><h2>Notes</h2><p class='muted'>Uploaded books are normalized and compacted before saving, so a source TXT can be larger than the final stored file. The reader is optimized for UTF-8 plain text and Latin-based languages.</p></div>";
 
@@ -66,27 +68,35 @@ static void handleRoot() {
   server.send(200, "text/html; charset=utf-8", out);
 }
 
-static void handleFiles() {
+static void handleFiles()
+{
   String out = webPageStart(
-    "Files",
-    "Manage books, folders and library structure for Pala One.",
-    "<a href='/'>Home</a><a href='/bookmarks'>Bookmarks</a><a href='/settings'>Settings</a>",
-    true
-  );
+      "Files",
+      "Manage books, folders and library structure for Pala One.",
+      "<a href='/'>Home</a><a href='/bookmarks'>Bookmarks</a><a href='/settings'>Settings</a>",
+      true);
+
+  if (server.hasArg("error") && server.arg("error") == "not-found") {
+    out += "<div class='banner-warn'>&#9888; Text not found in book.</div>";
+  }
 
   out +=
-    "<div class='card'><h2>Create folder</h2>"
-    "<form method='POST' action='/mkdir' class='stack' accept-charset='UTF-8' style='margin-top:12px'>"
-    "<input type='text' name='folder' placeholder='books or classics/english' maxlength='64'>"
-    "<div class='actions'><button type='submit'>Create folder</button><span class='muted'>Folders live inside /books.</span></div>"
-    "</form></div>";
+      "<div class='card'><h2>Create folder</h2>"
+      "<form method='POST' action='/mkdir' class='stack' accept-charset='UTF-8' style='margin-top:12px'>"
+      "<input type='text' name='folder' placeholder='books or classics/english' maxlength='64'>"
+      "<div class='actions'><button type='submit'>Create folder</button><span class='muted'>Folders live inside /books.</span></div>"
+      "</form></div>";
 
   out += "<div class='card'><h2>Folders</h2>";
-  if (g_library.folderCount == 0) {
+  if (g_library.folderCount == 0)
+  {
     out += "<p class='muted'>No folders yet. Books currently live in the root of /books.</p>";
-  } else {
+  }
+  else
+  {
     out += "<ul class='list'>";
-    for (int i = 0; i < g_library.folderCount; i++) {
+    for (int i = 0; i < g_library.folderCount; i++)
+    {
       out += "<li><div class='row'><div><span class='pill'>";
       out += htmlEscape(prettyRelativeLabel(String(g_library.folders[i])));
       out += "</span></div><div><form method='POST' action='/rmdir' style='display:inline'>";
@@ -99,18 +109,25 @@ static void handleFiles() {
   out += "</div>";
 
   out += "<div class='card'><h2>Library files</h2>";
-  if (g_library.bookCount   >= MAX_BOOKS)   out += "<p style='color:#b91c1c;font-weight:600'>&#9888; Library full (80 books max). Delete books to make room.</p>";
-  if (g_library.folderCount >= MAX_FOLDERS) out += "<p style='color:#b91c1c;font-weight:600'>&#9888; Folder limit reached (32 max).</p>";
+  if (g_library.bookCount >= MAX_BOOKS)
+    out += "<p style='color:#b91c1c;font-weight:600'>&#9888; Library full (80 books max). Delete books to make room.</p>";
+  if (g_library.folderCount >= MAX_FOLDERS)
+    out += "<p style='color:#b91c1c;font-weight:600'>&#9888; Folder limit reached (32 max).</p>";
 
-  if (g_library.bookCount == 0) {
+  if (g_library.bookCount == 0)
+  {
     out += "<p class='muted'>No books uploaded yet.</p>";
-  } else {
+  }
+  else
+  {
     out += "<ul class='list'>";
-    for (int i = 0; i < g_library.bookCount; i++) {
+    for (int i = 0; i < g_library.bookCount; i++)
+    {
       String bookPath = String(g_library.books[i].path);
       String folderLabel = g_library.books[i].folder[0] ? prettyRelativeLabel(g_library.books[i].folder) : String("Root");
       int savedPage = savedPageForBookPath(bookPath) + 1;
-      if (savedPage < 1) savedPage = 1;
+      if (savedPage < 1)
+        savedPage = 1;
 
       out += "<li><div class='row'><div><h3>";
       out += htmlEscape(String(g_library.books[i].name));
@@ -125,7 +142,13 @@ static void handleFiles() {
       out += "<form method='POST' action='/jumppage' class='stack small' accept-charset='UTF-8' style='margin-top:10px'>";
       out += "<input type='hidden' name='id' value='" + String(i) + "'>";
       out += "<div class='row' style='align-items:end;gap:10px'><div style='flex:1'><input type='text' name='page' value='" + String(savedPage) + "' inputmode='numeric' placeholder='Page'></div><div><button type='submit'>Jump</button></div></div>";
-      out += "<div class='muted'>Set the page that should open next on the device.<br><span class='muted'>The first open may take a moment.</span></div></form>";
+      out += "</form>";
+
+      out += "<form method='POST' action='/jumptext' class='stack small' accept-charset='UTF-8' style='margin-top:10px'>";
+      out += "<input type='hidden' name='id' value='" + String(i) + "'>";
+      out += "<div class='row' style='align-items:end;gap:10px'><div style='flex:1'><input type='text' name='query' value='' placeholder='Find in book'></div><div><button type='submit'>Find</button></div></div>";
+      out += "</form>";
+      out += "<div class='muted'>Enter a page number to jump to, or text to search for (case-insensitive). Search scans the whole file &mdash; may take a few seconds for large books.</div>";
 
       out += "<form method='POST' action='/move' class='stack small' accept-charset='UTF-8' style='margin-top:10px'>";
       out += "<input type='hidden' name='id' value='" + String(i) + "'>";
@@ -140,16 +163,24 @@ static void handleFiles() {
   out += "</div>";
 
   out += "<div class='card'><h2>Apps</h2>";
-  if (g_apps.count == 0) {
+  if (g_apps.count == 0)
+  {
     out += "<p class='muted'>No apps installed.</p>";
-  } else {
+  }
+  else
+  {
     out += "<ul class='list'>";
-    for (int i = 0; i < g_apps.count; i++) {
-      const char* absPath = g_apps.entries[i].path;
+    for (int i = 0; i < g_apps.count; i++)
+    {
+      const char *absPath = g_apps.entries[i].path;
       String fileName = lastPathComponent(String(absPath));
       size_t sz = 0;
       File af = FS.open(absPath, "r");
-      if (af) { sz = af.size(); af.close(); }
+      if (af)
+      {
+        sz = af.size();
+        af.close();
+      }
 
       out += "<li><div class='row'><div><h3>";
       out += htmlEscape(String(g_apps.entries[i].name));
@@ -170,95 +201,113 @@ static void handleFiles() {
   server.send(200, "text/html; charset=utf-8", out);
 }
 
-static void handleDelete() {
-  if (!server.hasArg("id")) {
+static void handleDelete()
+{
+  if (!server.hasArg("id"))
+  {
     server.send(400, "text/plain; charset=utf-8", "missing id");
     return;
   }
 
   int id = server.arg("id").toInt();
-  if (id < 0 || id >= g_library.bookCount) {
+  if (id < 0 || id >= g_library.bookCount)
+  {
     server.send(400, "text/plain; charset=utf-8", "bad id");
     return;
   }
 
   // Library entry already cleared g_bookview; no book is "current" here.
   String path = String(g_library.books[id].path);
-  if (FS.exists(path)) FS.remove(path);
+  if (FS.exists(path))
+    FS.remove(path);
   deleteBookMetadata(path);
-  loadBooks();   // refresh catalog so the next read sees the deletion
+  loadBooks(); // refresh catalog so the next read sees the deletion
 
   server.sendHeader("Location", "/files");
   server.send(302, "text/plain", "");
 }
 
-static void handleCreateFolder() {
+static void handleCreateFolder()
+{
   ensureBooksDir();
-  if (!server.hasArg("folder")) {
+  if (!server.hasArg("folder"))
+  {
     server.send(400, "text/plain; charset=utf-8", "missing folder");
     return;
   }
 
   String folder = sanitizeFolderInput(server.arg("folder"));
-  if (folder.length() == 0) {
+  if (folder.length() == 0)
+  {
     server.send(400, "text/plain; charset=utf-8", "bad folder");
     return;
   }
-  if (g_library.folderCount >= MAX_FOLDERS) {
+  if (g_library.folderCount >= MAX_FOLDERS)
+  {
     server.send(409, "text/plain; charset=utf-8", "folder limit reached");
     return;
   }
 
   String fullPath = "/books/" + folder;
-  if (!ensureDirRecursive(fullPath)) {
+  if (!ensureDirRecursive(fullPath))
+  {
     server.send(500, "text/plain; charset=utf-8", "mkdir failed");
     return;
   }
-  loadBooks();   // refresh catalog so the new folder appears
+  loadBooks(); // refresh catalog so the new folder appears
 
   server.sendHeader("Location", "/files");
   server.send(302, "text/plain", "");
 }
 
-static void handleDeleteFolder() {
-  if (!server.hasArg("folder")) {
+static void handleDeleteFolder()
+{
+  if (!server.hasArg("folder"))
+  {
     server.send(400, "text/plain; charset=utf-8", "missing folder");
     return;
   }
 
   String folder = sanitizeFolderInput(server.arg("folder"));
-  if (folder.length() == 0) {
+  if (folder.length() == 0)
+  {
     server.send(400, "text/plain; charset=utf-8", "bad folder");
     return;
   }
 
   String fullPath = "/books/" + folder;
-  if (!FS.exists(fullPath)) {
+  if (!FS.exists(fullPath))
+  {
     server.send(404, "text/plain; charset=utf-8", "folder not found");
     return;
   }
-  if (!isDirEmpty(fullPath)) {
+  if (!isDirEmpty(fullPath))
+  {
     server.send(409, "text/plain; charset=utf-8", "folder not empty");
     return;
   }
-  if (!FS.rmdir(fullPath)) {
+  if (!FS.rmdir(fullPath))
+  {
     server.send(500, "text/plain; charset=utf-8", "delete failed");
     return;
   }
-  loadBooks();   // refresh catalog so the folder disappears
+  loadBooks(); // refresh catalog so the folder disappears
 
   server.sendHeader("Location", "/files");
   server.send(302, "text/plain", "");
 }
 
-static void handleMoveBook() {
-  if (!server.hasArg("id")) {
+static void handleMoveBook()
+{
+  if (!server.hasArg("id"))
+  {
     server.send(400, "text/plain; charset=utf-8", "missing id");
     return;
   }
 
   int id = server.arg("id").toInt();
-  if (id < 0 || id >= g_library.bookCount) {
+  if (id < 0 || id >= g_library.bookCount)
+  {
     server.send(400, "text/plain; charset=utf-8", "bad id");
     return;
   }
@@ -267,49 +316,57 @@ static void handleMoveBook() {
   String folder = sanitizeFolderInput(server.arg("folder"));
   String destDir = (folder.length() == 0) ? String("/books") : String("/books/") + folder;
 
-  if (!ensureDirRecursive(destDir)) {
+  if (!ensureDirRecursive(destDir))
+  {
     server.send(500, "text/plain; charset=utf-8", "folder create failed");
     return;
   }
 
   String newPath = destDir + "/" + lastPathComponent(oldPath);
-  if (newPath == oldPath) {
+  if (newPath == oldPath)
+  {
     server.sendHeader("Location", "/files");
     server.send(302, "text/plain", "");
     return;
   }
-  if (FS.exists(newPath)) {
+  if (FS.exists(newPath))
+  {
     server.send(409, "text/plain; charset=utf-8", "destination exists");
     return;
   }
 
   // Library entry already cleared g_bookview; no book is "current" here.
-  if (!FS.rename(oldPath, newPath)) {
+  if (!FS.rename(oldPath, newPath))
+  {
     server.send(500, "text/plain; charset=utf-8", "move failed");
     return;
   }
 
-  migrateBookMetadata(oldPath, newPath);   // NVS keys + page-cache file
-  loadBooks();   // refresh catalog so the moved book shows in its new folder
+  migrateBookMetadata(oldPath, newPath); // NVS keys + page-cache file
+  loadBooks();                           // refresh catalog so the moved book shows in its new folder
 
   server.sendHeader("Location", "/files");
   server.send(302, "text/plain", "");
 }
 
-static void handleJumpPageWeb() {
-  if (!server.hasArg("id") || !server.hasArg("page")) {
+static void handleJumpPageWeb()
+{
+  if (!server.hasArg("id") || !server.hasArg("page"))
+  {
     server.send(400, "text/plain; charset=utf-8", "missing id/page");
     return;
   }
 
   int id = server.arg("id").toInt();
-  if (id < 0 || id >= g_library.bookCount) {
+  if (id < 0 || id >= g_library.bookCount)
+  {
     server.send(400, "text/plain; charset=utf-8", "bad id");
     return;
   }
 
   int page = server.arg("page").toInt();
-  if (page < 1) page = 1;
+  if (page < 1)
+    page = 1;
   int zeroBasedPage = page - 1;
 
   // Library entry already cleared g_bookview. We write both the page number
@@ -323,7 +380,8 @@ static void handleJumpPageWeb() {
   saveSavedPage(kv, key, zeroBasedPage);
 
   File f = FS.open(path, "r");
-  if (f) {
+  if (f)
+  {
     uint32_t offset = pageOffsetForPage(f, path, zeroBasedPage);
     f.close();
     saveSavedOffset(kv, key, offset);
@@ -333,12 +391,65 @@ static void handleJumpPageWeb() {
   server.send(302, "text/plain", "");
 }
 
-void registerFilesRoutes() {
-  server.on("/",         HTTP_GET,  handleRoot);
-  server.on("/files",    HTTP_GET,  handleFiles);
-  server.on("/del",      HTTP_POST, handleDelete);          // POST: prevents accidental deletion via browser prefetch
-  server.on("/mkdir",    HTTP_POST, handleCreateFolder);
-  server.on("/rmdir",    HTTP_POST, handleDeleteFolder);    // POST: destructive
-  server.on("/move",     HTTP_POST, handleMoveBook);
+static void handleJumpTextWeb()
+{
+  if (!server.hasArg("id") || !server.hasArg("query"))
+  {
+    server.send(400, "text/plain; charset=utf-8", "missing id/query");
+    return;
+  }
+
+  int id = server.arg("id").toInt();
+  if (id < 0 || id >= g_library.bookCount)
+  {
+    server.send(400, "text/plain; charset=utf-8", "bad id");
+    return;
+  }
+
+  String query = server.arg("query");
+  if (query.length() == 0)
+  {
+    server.send(400, "text/plain; charset=utf-8", "empty query");
+    return;
+  }
+
+  String path = String(g_library.books[id].path);
+  File f = FS.open(path, "r");
+  if (!f)
+  {
+    server.send(500, "text/plain; charset=utf-8", "open failed");
+    return;
+  }
+
+  int pageIdx = -1;
+  uint32_t offset = pageOffsetForText(f, path, query, &pageIdx);
+  f.close();
+
+  if (offset == 0xFFFFFFFFu)
+  {
+    server.sendHeader("Location", "/files?error=not-found");
+    server.send(302, "text/plain", "");
+    return;
+  }
+
+  String key = prefKeyForBook(path);
+  PreferencesStore kv(prefs);
+  saveSavedOffset(kv, key, offset);
+  if (pageIdx >= 0)
+    saveSavedPage(kv, key, pageIdx);
+
+  server.sendHeader("Location", "/files");
+  server.send(302, "text/plain", "");
+}
+
+void registerFilesRoutes()
+{
+  server.on("/", HTTP_GET, handleRoot);
+  server.on("/files", HTTP_GET, handleFiles);
+  server.on("/del", HTTP_POST, handleDelete); // POST: prevents accidental deletion via browser prefetch
+  server.on("/mkdir", HTTP_POST, handleCreateFolder);
+  server.on("/rmdir", HTTP_POST, handleDeleteFolder); // POST: destructive
+  server.on("/move", HTTP_POST, handleMoveBook);
   server.on("/jumppage", HTTP_POST, handleJumpPageWeb);
+  server.on("/jumptext", HTTP_POST, handleJumpTextWeb);
 }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Pure modules and KV-backed storage have host-side unit tests under [`test/`](tes
 
 See [test/README.md](test/README.md) for prerequisites (CMake + a C++17 compiler) and per-platform setup / run instructions for Windows, Linux, and macOS.
 
+## Web UI emulator
+
+The [`dev/`](dev/) directory contains a host-side emulator for the captive-portal web UI. It builds a native binary that serves the same route handlers as the firmware, backed by a local filesystem, so you can iterate on the web UI without flashing the device.
+
+See [dev/README.md](dev/README.md) for build and run instructions, the VS Code debug launch config, and the integration test suite.
+
 ## Apps
 
 Pala One supports user-installable apps — self-contained position-independent C binaries that run on top of the firmware and have access to the display, button, RTC, and a per-app key-value store. Apps are uploaded over Wi-Fi through the same web UI used for books, and they appear under the **Apps** entry of the library menu. No firmware rebuild is needed to install one.

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -73,16 +73,17 @@ set(STUB_SRC
   ${STUBS_ROOT}/upload_stub.cpp
 )
 
-add_executable(pala_web_emu
-  ${CMAKE_SOURCE_DIR}/main.cpp
-  ${CMAKE_SOURCE_DIR}/mock_data.cpp
+# ---------------------------------------------------------------------------
+#  Shared library — all non-main sources used by both the emulator and tests
+# ---------------------------------------------------------------------------
+add_library(pala_web_shared STATIC
   ${PURE_SRC}
   ${STORAGE_SRC}
   ${WEB_SRC}
   ${STUB_SRC}
 )
 
-target_include_directories(pala_web_emu PRIVATE
+target_include_directories(pala_web_shared PUBLIC
   # MUST be first — these shadow real Arduino/firmware headers
   ${STUBS_ROOT}/overrides
   # dev/ root — resolves #include "stubs/..." paths from override headers
@@ -95,13 +96,37 @@ target_include_directories(pala_web_emu PRIVATE
   ${TEST_ROOT}
 )
 
-target_link_libraries(pala_web_emu PRIVATE httplib::httplib)
+target_link_libraries(pala_web_shared PUBLIC httplib::httplib)
 
 # PROGMEM is a no-op on the host (it's a flash-storage hint for AVR/Xtensa).
-target_compile_definitions(pala_web_emu PRIVATE PROGMEM=)
+target_compile_definitions(pala_web_shared PUBLIC PROGMEM=)
 
-target_compile_options(pala_web_emu PRIVATE
+target_compile_options(pala_web_shared PUBLIC
   -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
   # Pre-include system headers before arduino_compat.h can define min/max macros.
   -include ${CMAKE_SOURCE_DIR}/stubs/prelude.h
+)
+
+# ---------------------------------------------------------------------------
+#  Emulator executable
+# ---------------------------------------------------------------------------
+add_executable(pala_web_emu
+  ${CMAKE_SOURCE_DIR}/main.cpp
+  ${CMAKE_SOURCE_DIR}/mock_data.cpp
+)
+target_link_libraries(pala_web_emu PRIVATE pala_web_shared)
+
+# ---------------------------------------------------------------------------
+#  Integration test executable
+# ---------------------------------------------------------------------------
+add_executable(pala_web_test
+  ${CMAKE_SOURCE_DIR}/integration_test.cpp
+)
+target_link_libraries(pala_web_test PRIVATE pala_web_shared)
+
+enable_testing()
+add_test(NAME integration COMMAND pala_web_test)
+set_tests_properties(integration PROPERTIES
+  # Run from the repo root so "dev/fs_test" resolves correctly.
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
 )

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 3.16)
+project(pala_web_emu CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+FetchContent_Declare(
+  httplib
+  GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+  GIT_TAG        v0.15.3
+)
+FetchContent_MakeAvailable(httplib)
+
+set(SKETCH_ROOT ${CMAKE_SOURCE_DIR}/../Pala_One_2_1)
+set(FW_SRC      ${SKETCH_ROOT}/src)
+set(TEST_ROOT   ${CMAKE_SOURCE_DIR}/../test)
+set(STUBS_ROOT  ${CMAKE_SOURCE_DIR}/stubs)
+
+# ---------------------------------------------------------------------------
+#  Pure modules — identical to the test build
+# ---------------------------------------------------------------------------
+set(PURE_SRC
+  ${FW_SRC}/pure/paths.cpp
+  ${FW_SRC}/pure/text_util.cpp
+  ${FW_SRC}/pure/find_text.cpp
+  ${FW_SRC}/pure/hashing.cpp
+  ${FW_SRC}/pure/paginator.cpp
+  ${FW_SRC}/pure/library_nav.cpp
+  ${FW_SRC}/pure/bookmark_label.cpp
+  ${FW_SRC}/pure/bookmarks_codec.cpp
+  ${FW_SRC}/pure/list_codec.cpp
+  ${FW_SRC}/pure/app_header.cpp
+)
+
+# ---------------------------------------------------------------------------
+#  Storage modules — pure API compiles; firmware glue (#ifdef ARDUINO) skipped
+# ---------------------------------------------------------------------------
+set(STORAGE_SRC
+  ${FW_SRC}/storage/book_metadata.cpp
+  ${FW_SRC}/storage/list_items.cpp
+  ${FW_SRC}/storage/library.cpp
+  ${FW_SRC}/storage/app_catalog.cpp
+)
+
+# ---------------------------------------------------------------------------
+#  Web handlers — the actual code under development.
+#  upload.cpp / apps_upload.cpp omitted (streaming upload, no GET pages).
+# ---------------------------------------------------------------------------
+set(WEB_SRC
+  ${FW_SRC}/web/web.cpp
+  ${FW_SRC}/web/chrome.cpp
+  ${FW_SRC}/web/files.cpp
+  ${FW_SRC}/web/bookmarks.cpp
+  ${FW_SRC}/web/list.cpp
+  ${FW_SRC}/web/settings.cpp
+  ${FW_SRC}/web/reset.cpp
+)
+
+# ---------------------------------------------------------------------------
+#  Stubs — Arduino / ESP32 API replacements for the host build
+# ---------------------------------------------------------------------------
+set(STUB_SRC
+  ${STUBS_ROOT}/web_server.cpp
+  ${STUBS_ROOT}/fs_stub.cpp
+  ${STUBS_ROOT}/state.cpp
+  ${STUBS_ROOT}/ui_stubs.cpp
+  ${STUBS_ROOT}/text_stubs.cpp
+  ${STUBS_ROOT}/book_metadata_glue.cpp
+  ${STUBS_ROOT}/list_items_glue.cpp
+  ${STUBS_ROOT}/fs_util_stub.cpp
+  ${STUBS_ROOT}/upload_stub.cpp
+)
+
+add_executable(pala_web_emu
+  ${CMAKE_SOURCE_DIR}/main.cpp
+  ${CMAKE_SOURCE_DIR}/mock_data.cpp
+  ${PURE_SRC}
+  ${STORAGE_SRC}
+  ${WEB_SRC}
+  ${STUB_SRC}
+)
+
+target_include_directories(pala_web_emu PRIVATE
+  # MUST be first — these shadow real Arduino/firmware headers
+  ${STUBS_ROOT}/overrides
+  # dev/ root — resolves #include "stubs/..." paths from override headers
+  ${CMAKE_SOURCE_DIR}
+  # Firmware sketch root — resolves #include "src/..." paths
+  ${SKETCH_ROOT}
+  # Firmware src/ root — resolves #include "storage/..." paths (used by map_kv_store.h)
+  ${FW_SRC}
+  # Test utilities — provides map_kv_store.h
+  ${TEST_ROOT}
+)
+
+target_link_libraries(pala_web_emu PRIVATE httplib::httplib)
+
+# PROGMEM is a no-op on the host (it's a flash-storage hint for AVR/Xtensa).
+target_compile_definitions(pala_web_emu PRIVATE PROGMEM=)
+
+target_compile_options(pala_web_emu PRIVATE
+  -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
+  # Pre-include system headers before arduino_compat.h can define min/max macros.
+  -include ${CMAKE_SOURCE_DIR}/stubs/prelude.h
+)

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,63 @@
+# Web UI emulator
+
+The `dev/` directory contains a host-side emulator for the captive-portal web UI. It builds a native binary (`pala_web_emu`) that serves the same route handlers as the firmware, backed by a local filesystem instead of LittleFS. This lets you iterate on the web UI without flashing the device.
+
+It shares a CMake build with the integration tests (`pala_web_test`).
+
+## Requirements
+
+- **CMake 3.14+**
+- A **C++17 compiler** — GCC, Clang, or MSVC
+- Internet access on first build (CMake fetches [cpp-httplib v0.15.3](https://github.com/yhirose/cpp-httplib) via `FetchContent`)
+
+## Run
+
+```bash
+cmake -S dev -B dev/build && cmake --build dev/build
+dev/build/pala_web_emu
+```
+
+Then open `http://localhost:8080` in a browser.
+
+Run from the repo root — the emulator defaults to `dev/fs` as the LittleFS root. The repo ships `dev/fs/` with a short sample book (`books/sample.txt`) so the files page loads populated out of the box. Drop any UTF-8 `.txt` file into `dev/fs/books/` to add more.
+
+To override the filesystem root or port:
+
+```bash
+dev/build/pala_web_emu --port=9090
+```
+
+## Request logging
+
+Every request and its HTTP response status print to stderr:
+
+```
+POST /jumptext body=id=0&query=Bennet
+  -> 302
+GET /files
+  -> 200
+```
+
+This is always on — no flag needed.
+
+## Integration tests
+
+The integration tests (`pala_web_test`) spin up the same server in a thread and make real HTTP requests against it. They live in `dev/integration_test.cpp` and use the same `dev/fs_test/` fixture filesystem.
+
+Run them after building:
+
+```bash
+ctest --test-dir dev/build --output-on-failure
+```
+
+Or as a one-liner from the repo root:
+
+```bash
+cmake -S dev -B dev/build && cmake --build dev/build && ctest --test-dir dev/build --output-on-failure
+```
+
+## Limitations
+
+- **Character widths** use a lookup table approximation for `u8g2_font_helvR12_te`. Line breaks match the device closely but may differ by a word or two for lines containing many narrow or wide characters.
+- **On-disk page cache** (`src/storage/page_cache`) is stubbed and does nothing — page walks are always computed from scratch.
+- **App upload** returns HTTP 501 (not implemented).

--- a/dev/fs/books/sample.txt
+++ b/dev/fs/books/sample.txt
@@ -1,0 +1,102 @@
+The Project Gutenberg eBook of Pride and Prejudice
+
+It is a truth universally acknowledged, that a single man in possession of
+a good fortune, must be in want of a wife.
+
+However little known the feelings or views of such a man may be on his first
+entering a neighbourhood, this truth is so well fixed in the minds of the
+surrounding families, that he is considered as the rightful property of some
+one or other of their daughters.
+
+"My dear Mr. Bennet," said his lady to him one day, "have you heard that
+Netherfield Park is let at last?"
+
+Mr. Bennet replied that he had not.
+
+"But it is," returned she; "for Mrs. Long has just been here, and she told me
+all about it."
+
+Mr. Bennet made no answer.
+
+"Do not you want to know who has taken it?" cried his wife impatiently.
+
+"You want to tell me, and I have no objection to hearing it."
+
+This was invitation enough.
+
+"Why, my dear, you must know, Mrs. Long says that Netherfield is taken by a
+young man of large fortune from the north of England; that he came down on
+Monday in a chaise and four to see the place, and was so much delighted with
+it that he agreed with Mr. Morris immediately; that he is to take possession
+before Michaelmas, and some of his servants are to be in the house by the end
+of next week."
+
+"What is his name?"
+
+"Bingley."
+
+"Is he married or single?"
+
+"Oh! single, my dear, to be sure! A single man of large fortune; four or five
+thousand a year. What a fine thing for our girls!"
+
+"How so? can it affect them?"
+
+"My dear Mr. Bennet," replied his wife, "how can you be so tiresome! You must
+know that I am thinking of his marrying one of them."
+
+"Is that his design in settling here?"
+
+"Design! nonsense, how can you talk so! But it is very likely that he may
+fall in love with one of them, and therefore you must visit him as soon as he
+comes."
+
+"I see no occasion for that. You and the girls may go, or you may send them
+by themselves, which perhaps will be still better, for as you are as handsome
+as any of them, Mr. Bingley might like you the best of the party."
+
+"My dear, you flatter me. I certainly have had my share of beauty, but I do
+not pretend to be any thing extraordinary now. When a woman has five grown-up
+daughters, she ought to give over thinking of her own beauty."
+
+"In such cases, a woman has not often much beauty to think of."
+
+"But, my dear, you must indeed go and see Mr. Bingley when he comes into the
+neighbourhood."
+
+"It is more than I engage for, I assure you."
+
+"But consider your daughters. Only think what an establishment it would be for
+one of them. Sir William and Lady Lucas are determined to go, merely on that
+account, for in general, you know, they visit no new comers. Indeed you must
+go, for it will be impossible for us to visit him, if you do not."
+
+"You are over-scrupulous, surely. I dare say Mr. Bingley will be very glad to
+see you; and I will send a few lines by you to assure him of my hearty
+consent to his marrying which ever he chooses of our girls; though I must
+throw in a good word for my little Lizzy."
+
+"I desire you will do no such thing. Lizzy is not a bit better than the
+others; and I am sure she is not half so handsome as Jane, nor half so
+good-humoured as Lydia. But you are always giving her the preference."
+
+"They have none of them much to recommend them," replied he; "they are all
+silly and ignorant like other girls; but Lizzy has something more of quickness
+than her sisters."
+
+"Mr. Bennet, how can you abuse your own children so? You take delight in
+vexing me. You have no compassion on my poor nerves."
+
+"You mistake me, my dear. I have a high respect for your nerves. They are my
+old friends. I have heard you mention them with consideration these twenty
+years at least."
+
+"Ah, you do not know what I suffer."
+
+"But I hope you will get over it, and live to see many young men of four
+thousand a year come into the neighbourhood."
+
+"It will be no use to us, if twenty such should come, since you will not
+visit them."
+
+"Depend upon it, my dear, that when there are twenty, I will visit them all."

--- a/dev/fs_test/books/hound.txt
+++ b/dev/fs_test/books/hound.txt
@@ -1,0 +1,3 @@
+The detective arrived at dawn.
+A lantern flickered in the fog.
+The butler revealed nothing.

--- a/dev/integration_test.cpp
+++ b/dev/integration_test.cpp
@@ -76,6 +76,128 @@ TEST_CASE("/files renders the Find-in-book form") {
   CHECK(res->body.find("Find in book") != std::string::npos);
 }
 
+TEST_CASE("GET /files?error=not-found renders the warning banner") {
+  auto res = gCli->Get("/files?error=not-found");
+  REQUIRE(res);
+  CHECK_EQ(res->status, 200);
+  CHECK(res->body.find("Text not found in book") != std::string::npos);
+}
+
+TEST_CASE("GET /files without error flag has no warning banner") {
+  auto res = gCli->Get("/files");
+  REQUIRE(res);
+  CHECK_EQ(res->status, 200);
+  CHECK(res->body.find("Text not found in book") == std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+//  /jumptext — validation
+// ---------------------------------------------------------------------------
+
+TEST_CASE("POST /jumptext missing id returns 400") {
+  auto res = post("/jumptext", {{"query", "detective"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+TEST_CASE("POST /jumptext missing query returns 400") {
+  auto res = post("/jumptext", {{"id", "0"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+TEST_CASE("POST /jumptext empty query returns 400") {
+  auto res = post("/jumptext", {{"id", "0"}, {"query", ""}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+TEST_CASE("POST /jumptext out-of-range id returns 400") {
+  auto res = post("/jumptext", {{"id", "999"}, {"query", "detective"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 400);
+}
+
+// ---------------------------------------------------------------------------
+//  /jumptext — happy path and not-found
+// ---------------------------------------------------------------------------
+
+TEST_CASE("POST /jumptext text found redirects to /files") {
+  auto res = post("/jumptext", {{"id", "0"}, {"query", "detective"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 302);
+  CHECK_EQ(locationOf(*res), "/files");
+}
+
+TEST_CASE("POST /jumptext text not found redirects to /files?error=not-found") {
+  auto res = post("/jumptext", {{"id", "0"}, {"query", "elephant"}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 302);
+  CHECK_EQ(locationOf(*res), "/files?error=not-found");
+}
+
+// ---------------------------------------------------------------------------
+//  End-to-end: saved offset matches find_text on the raw file
+// ---------------------------------------------------------------------------
+
+// Walk pages in `f` to find the start offset of the page containing `matchOffset`.
+static uint32_t pageStartFor(File& f, uint32_t matchOffset) {
+  uint32_t pageStart = 0;
+  while (true) {
+    uint32_t next = nextPageOffset(f, pageStart);
+    if (next <= pageStart || next > matchOffset) break;
+    pageStart = next;
+  }
+  return pageStart;
+}
+
+TEST_CASE("POST /jumptext saves the correct byte offset") {
+  const String query = "lantern";
+
+  auto res = post("/jumptext", {{"id", "0"}, {"query", query.c_str()}});
+  REQUIRE(res);
+  CHECK_EQ(res->status, 302);
+  CHECK_EQ(locationOf(*res), "/files");
+
+  // Expected: start of the page containing the raw match.
+  String content = readFile("/books/hound.txt");
+  REQUIRE(content.length() > 0);
+  uint32_t matchOffset = find_text(content, query);
+  REQUIRE(matchOffset != 0xFFFFFFFFu);
+  File f = FS.open("/books/hound.txt", "r");
+  REQUIRE(f);
+  uint32_t expected = pageStartFor(f, matchOffset);
+  f.close();
+
+  String key = prefKeyForBook(String("/books/hound.txt"));
+  PreferencesStore kv(prefs);
+  CHECK_EQ(loadSavedOffset(kv, key), expected);
+}
+
+TEST_CASE("POST /jumptext not-found does not overwrite a previously saved offset") {
+  const String goodQuery = "butler";
+  auto r1 = post("/jumptext", {{"id", "0"}, {"query", goodQuery.c_str()}});
+  REQUIRE(r1);
+  REQUIRE(r1->status == 302);
+
+  String content = readFile("/books/hound.txt");
+  uint32_t matchOffset = find_text(content, goodQuery);
+  REQUIRE(matchOffset != 0xFFFFFFFFu);
+  File f = FS.open("/books/hound.txt", "r");
+  REQUIRE(f);
+  uint32_t expected = pageStartFor(f, matchOffset);
+  f.close();
+
+  // A failed search must not clobber the stored offset.
+  auto r2 = post("/jumptext", {{"id", "0"}, {"query", "elephant"}});
+  REQUIRE(r2);
+  REQUIRE(r2->status == 302);
+
+  String key = prefKeyForBook(String("/books/hound.txt"));
+  PreferencesStore kv(prefs);
+  CHECK_EQ(loadSavedOffset(kv, key), expected);
+}
+
 // ---------------------------------------------------------------------------
 //  Entry point — starts the server, runs tests, then shuts down cleanly.
 // ---------------------------------------------------------------------------

--- a/dev/integration_test.cpp
+++ b/dev/integration_test.cpp
@@ -1,0 +1,119 @@
+// Integration tests for the /jumptext route and surrounding pipeline.
+//
+// Starts the web emulator in a background thread, then drives it with a
+// real HTTP client. Every test is a full round-trip through the actual web
+// handler, storage layer, and stub FS — no mocks are inserted in the path.
+//
+// Run from the repo root (so "dev/fs_test" resolves):
+//   ./dev/build/pala_web_test
+// Or set PALA_EMU_FS_ROOT to point at a different fixture directory.
+
+// httplib must be included before any arduino_compat.h header so the
+// min/max macros it defines don't clobber httplib's use of std::min/max.
+// prelude.h is force-included via -include, so system headers are already
+// parsed before this TU touches anything.
+#include <httplib.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include "test_framework.h"
+
+#include "src/pure/find_text.h"
+#include "src/storage/book_metadata.h"
+#include "src/ui/text.h"
+#include "src/storage/preferences_store.h"
+#include "src/storage/library.h"
+#include "src/storage/app_catalog.h"
+#include "src/state.h"
+#include "stubs/fs_stub.h"
+#include "stubs/web_server.h"
+#include "src/web/web.h"
+
+extern void loadListItems();
+
+static constexpr int kPort = 18080;
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+static httplib::Client* gCli = nullptr;
+
+static std::string locationOf(const httplib::Response& res) {
+  auto it = res.headers.find("Location");
+  return it != res.headers.end() ? it->second : "";
+}
+
+static httplib::Result post(const char* path, httplib::Params params) {
+  return gCli->Post(path, params);
+}
+
+// Read the full contents of a virtual-FS file into a String.
+static String readFile(const char* path) {
+  File f = FS.open(path, "r");
+  String out;
+  if (!f) return out;
+  uint8_t buf[256];
+  size_t n;
+  while ((n = f.read(buf, sizeof(buf))) > 0)
+    out.concat((const char*)buf, (unsigned)n);
+  f.close();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+//  /files page
+// ---------------------------------------------------------------------------
+
+TEST_CASE("/files renders the Find-in-book form") {
+  auto res = gCli->Get("/files");
+  REQUIRE(res);
+  CHECK_EQ(res->status, 200);
+  CHECK(res->body.find("jumptext") != std::string::npos);
+  CHECK(res->body.find("Find in book") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+//  Entry point — starts the server, runs tests, then shuts down cleanly.
+// ---------------------------------------------------------------------------
+
+int main() {
+  const char* env = std::getenv("PALA_EMU_FS_ROOT");
+  std::string fsRoot = (env && env[0]) ? env : "dev/fs_test";
+  LittleFS.setRoot(fsRoot);
+  loadBooks();
+  loadApps();
+  loadListItems();
+  registerWebRoutes();
+
+  std::thread srv([]() { server.run(kPort); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  httplib::Client cli("localhost", kPort);
+  cli.set_follow_location(false);
+  gCli = &cli;
+
+  int passed = 0, failed = 0;
+  for (auto& tc : tf_allTests()) {
+    tf_currentFailures() = 0;
+    std::printf("[ RUN  ] %s\n", tc.name);
+    tc.fn();
+    if (tf_currentFailures() == 0) {
+      std::printf("[  OK  ] %s\n", tc.name);
+      ++passed;
+    } else {
+      std::printf("[ FAIL ] %s (%d failures)\n", tc.name, tf_currentFailures());
+      tf_totalFailures() += tf_currentFailures();
+      ++failed;
+    }
+  }
+  std::printf("\n%zu tests, %d checks, %d passed, %d failed\n",
+              tf_allTests().size(), tf_totalChecks(), passed, failed);
+
+  server.stop();
+  srv.join();
+  return failed == 0 ? 0 : 1;
+}

--- a/dev/main.cpp
+++ b/dev/main.cpp
@@ -1,0 +1,22 @@
+#include <cstdlib>
+#include <cstring>
+#include "stubs/web_server.h"
+#include "src/web/web.h"
+
+extern void loadMockData();
+extern WebServerStub server;
+
+int main(int argc, char* argv[]) {
+  int port = 8080;
+  for (int i = 1; i < argc; i++) {
+    if ((std::strcmp(argv[i], "--port") == 0 || std::strcmp(argv[i], "-p") == 0) && i + 1 < argc) {
+      port = std::atoi(argv[++i]);
+    } else if (std::strncmp(argv[i], "--port=", 7) == 0) {
+      port = std::atoi(argv[i] + 7);
+    }
+  }
+  loadMockData();
+  registerWebRoutes();
+  server.run(port);
+  return 0;
+}

--- a/dev/mock_data.cpp
+++ b/dev/mock_data.cpp
@@ -1,0 +1,23 @@
+#include "src/storage/library.h"
+#include "src/storage/app_catalog.h"
+#include "src/storage/list_items.h"
+#include "stubs/fs_stub.h"
+
+// loadListItems() is declared inside #ifdef ARDUINO in list_items.h;
+// the host implementation lives in stubs/list_items_glue.cpp.
+extern void loadListItems();
+
+void loadMockData() {
+  // Prefer an environment variable override; default to dev/fs relative to CWD.
+  // Run the binary from the repo root: ./dev/build/pala_web_emu
+  const char* env = std::getenv("PALA_EMU_FS_ROOT");
+  std::string root = (env && env[0]) ? env : "dev/fs";
+  std::printf("FS root: %s\n", root.c_str());
+
+  LittleFS.setRoot(root);
+
+  // Scan the real filesystem so book/folder lists reflect what's on disk.
+  loadBooks();
+  loadApps();
+  loadListItems();
+}

--- a/dev/stubs/book_metadata_glue.cpp
+++ b/dev/stubs/book_metadata_glue.cpp
@@ -1,0 +1,55 @@
+// Host implementations of the book_metadata.h firmware-glue functions
+// (normally compiled only under #ifdef ARDUINO). Delegates to the same
+// prefs store that handleJumpPageWeb writes to, so page saves round-trip.
+
+#include "src/storage/book_metadata.h"
+#include "src/storage/preferences_store.h"
+#include "src/pure/hashing.h"
+#include "src/state.h"
+
+static PreferencesStore kv() { return PreferencesStore(prefs); }
+
+uint8_t loadBookmarksForKey(const String& bookKey,
+                            uint16_t outPages[MAX_BOOKMARKS],
+                            uint32_t outOffsets[MAX_BOOKMARKS]) {
+  auto store = kv();
+  Bookmarks bm = loadBookmarks(store, bookKey);
+  for (int i = 0; i < bm.count; i++) {
+    outPages[i]   = bm.pages[i];
+    outOffsets[i] = bm.offsets[i];
+  }
+  return bm.count;
+}
+
+void saveBookmarksForKey(const String& bookKey,
+                         const uint16_t pages[MAX_BOOKMARKS],
+                         const uint32_t offsets[MAX_BOOKMARKS],
+                         uint8_t count) {
+  Bookmarks bm;
+  bm.count = count;
+  for (int i = 0; i < count; i++) {
+    bm.pages[i]   = pages[i];
+    bm.offsets[i] = offsets[i];
+  }
+  auto store = kv();
+  saveBookmarks(store, bookKey, bm);
+}
+
+int savedPageForBookPath(const String& path) {
+  String key = prefKeyForBook(path);
+  auto store = kv();
+  return loadSavedPage(store, key);
+}
+
+void deleteBookMetadata(const String& path) {
+  String key = prefKeyForBook(path);
+  auto store = kv();
+  clearBookMetadata(store, key);
+}
+
+void migrateBookMetadata(const String& oldPath, const String& newPath) {
+  String oldKey = prefKeyForBook(oldPath);
+  String newKey = prefKeyForBook(newPath);
+  auto store = kv();
+  renameBookMetadata(store, oldKey, newKey);
+}

--- a/dev/stubs/fs_stub.cpp
+++ b/dev/stubs/fs_stub.cpp
@@ -1,0 +1,171 @@
+#include "stubs/fs_stub.h"
+
+#include <filesystem>
+#include <cstring>
+#include <sys/statvfs.h>
+
+namespace stdfs = std::filesystem;
+
+LittleFSClass LittleFS;
+
+// ---------------------------------------------------------------------------
+//  LittleFSClass
+// ---------------------------------------------------------------------------
+
+void LittleFSClass::setRoot(const std::string& root) {
+  root_ = root;
+  std::error_code ec;
+  stdfs::create_directories(root_, ec);
+}
+
+std::string LittleFSClass::hostPath(const std::string& virtPath) const {
+  // virtPath is always absolute ("/books/foo.txt"); strip leading slash then join.
+  if (!virtPath.empty() && virtPath[0] == '/') return root_ + virtPath;
+  return root_ + "/" + virtPath;
+}
+
+File LittleFSClass::open(const char* virtPath, const char* mode) {
+  std::string hp = hostPath(virtPath);
+  std::error_code ec;
+
+  if (!stdfs::exists(hp, ec)) return File();
+
+  File f;
+  f.valid_     = true;
+  f.virt_path_ = virtPath;
+  f.is_dir_    = stdfs::is_directory(hp, ec);
+
+  if (f.is_dir_) {
+    for (auto& entry : stdfs::directory_iterator(hp, ec)) {
+      // Build virtual child path.
+      std::string child = f.virt_path_;
+      if (child.back() != '/') child += '/';
+      child += entry.path().filename().string();
+      f.children_.push_back(child);
+    }
+    std::sort(f.children_.begin(), f.children_.end());
+  } else {
+    const char* fmode = (mode && mode[0] == 'w') ? "wb" : "rb";
+    f.fp_ = fopen(hp.c_str(), fmode);
+    if (!f.fp_) f.valid_ = false;
+  }
+  return f;
+}
+
+bool LittleFSClass::exists(const char* virtPath) {
+  std::error_code ec;
+  return stdfs::exists(hostPath(virtPath), ec);
+}
+
+bool LittleFSClass::remove(const char* virtPath) {
+  std::error_code ec;
+  return stdfs::remove(hostPath(virtPath), ec);
+}
+
+bool LittleFSClass::rename(const char* from, const char* to) {
+  std::error_code ec;
+  stdfs::rename(hostPath(from), hostPath(to), ec);
+  return !ec;
+}
+
+bool LittleFSClass::mkdir(const char* virtPath) {
+  std::error_code ec;
+  stdfs::create_directories(hostPath(virtPath), ec);
+  return !ec;
+}
+
+bool LittleFSClass::rmdir(const char* virtPath) {
+  std::error_code ec;
+  stdfs::remove(hostPath(virtPath), ec);
+  return !ec;
+}
+
+size_t LittleFSClass::usedBytes() const {
+  size_t total = 0;
+  std::error_code ec;
+  for (auto& entry : stdfs::recursive_directory_iterator(root_, ec)) {
+    if (!entry.is_directory(ec)) total += entry.file_size(ec);
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+//  File
+// ---------------------------------------------------------------------------
+
+File::File(File&& o) noexcept
+    : valid_(o.valid_), is_dir_(o.is_dir_), virt_path_(std::move(o.virt_path_)),
+      fp_(o.fp_), children_(std::move(o.children_)), child_idx_(o.child_idx_) {
+  o.valid_ = false;
+  o.fp_    = nullptr;
+}
+
+File& File::operator=(File&& o) noexcept {
+  if (this != &o) {
+    close();
+    valid_     = o.valid_;
+    is_dir_    = o.is_dir_;
+    virt_path_ = std::move(o.virt_path_);
+    fp_        = o.fp_;
+    children_  = std::move(o.children_);
+    child_idx_ = o.child_idx_;
+    o.valid_   = false;
+    o.fp_      = nullptr;
+  }
+  return *this;
+}
+
+void File::close() {
+  if (fp_) { fclose(fp_); fp_ = nullptr; }
+  valid_ = false;
+}
+
+size_t File::size() const {
+  if (!fp_) return 0;
+  long cur = ftell(fp_);
+  fseek(fp_, 0, SEEK_END);
+  long end = ftell(fp_);
+  fseek(fp_, cur, SEEK_SET);
+  return (size_t)(end < 0 ? 0 : end);
+}
+
+int File::read() {
+  if (!fp_) return -1;
+  int c = fgetc(fp_);
+  return (c == EOF) ? -1 : c;
+}
+
+size_t File::read(uint8_t* buf, size_t len) {
+  if (!fp_) return 0;
+  return fread(buf, 1, len, fp_);
+}
+
+bool File::seek(uint32_t pos) {
+  if (!fp_) return false;
+  return fseek(fp_, (long)pos, SEEK_SET) == 0;
+}
+
+uint32_t File::position() const {
+  if (!fp_) return 0;
+  long p = ftell(fp_);
+  return (p < 0) ? 0 : (uint32_t)p;
+}
+
+int File::available() const {
+  if (!fp_) return 0;
+  long cur = ftell(fp_);
+  fseek(fp_, 0, SEEK_END);
+  long end = ftell(fp_);
+  fseek(fp_, cur, SEEK_SET);
+  return (int)(end - cur);
+}
+
+size_t File::write(const uint8_t* buf, size_t len) {
+  if (!fp_) return 0;
+  return fwrite(buf, 1, len, fp_);
+}
+
+File File::openNextFile() {
+  if (!is_dir_ || child_idx_ >= children_.size()) return File();
+  return LittleFS.open(children_[child_idx_++].c_str());
+}

--- a/dev/stubs/fs_stub.h
+++ b/dev/stubs/fs_stub.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// Forward declaration for openNextFile() which calls back into LittleFSClass.
+class LittleFSClass;
+extern LittleFSClass LittleFS;
+
+// Mirrors the Arduino File API used by the firmware.
+class File {
+public:
+  File() = default;
+  ~File() { close(); }
+
+  // Non-copyable, movable.
+  File(const File&)            = delete;
+  File& operator=(const File&) = delete;
+  File(File&& o) noexcept;
+  File& operator=(File&& o) noexcept;
+
+  explicit operator bool() const { return valid_; }
+  bool isDirectory() const { return is_dir_; }
+  const char* name() const { return virt_path_.c_str(); }
+  size_t size() const;
+
+  // Reading
+  int      read();
+  size_t   read(uint8_t* buf, size_t len);
+  bool     seek(uint32_t pos);
+  uint32_t position() const;
+  int      available() const;
+
+  // Writing
+  size_t write(const uint8_t* buf, size_t len);
+
+  // Directory iteration
+  File openNextFile();
+
+  void close();
+
+private:
+  friend class LittleFSClass;
+
+  bool        valid_     = false;
+  bool        is_dir_    = false;
+  std::string virt_path_;
+
+  // Regular file
+  FILE*       fp_        = nullptr;
+
+  // Directory: sorted virtual paths of direct children
+  std::vector<std::string> children_;
+  size_t                   child_idx_ = 0;
+};
+
+// Mirrors the subset of the LittleFS API used by the firmware.
+class LittleFSClass {
+public:
+  // Call once at startup before any FS operations.
+  void setRoot(const std::string& root);
+
+  // Convert a virtual device path ("/books/foo.txt") to a host path.
+  std::string hostPath(const std::string& virtPath) const;
+
+  File   open(const char* path, const char* mode = "r");
+  File   open(const std::string& path, const char* mode = "r") { return open(path.c_str(), mode); }
+
+  bool   exists(const char* path);
+  bool   remove(const char* path);
+  bool   rename(const char* from, const char* to);
+  bool   mkdir(const char* path);
+  bool   rmdir(const char* path);
+
+  // String overloads — the firmware calls these with Arduino String objects.
+  // The arduino_compat.h String has an implicit c_str() via operator const char*.
+  // Providing explicit overloads avoids the implicit conversion ambiguity.
+  template<typename S> File open(const S& path, const char* mode = "r")   { return open(path.c_str(), mode); }
+  template<typename S> bool exists(const S& path)                          { return exists(path.c_str()); }
+  template<typename S> bool remove(const S& path)                          { return remove(path.c_str()); }
+  template<typename S> bool rename(const S& from, const S& to)             { return rename(from.c_str(), to.c_str()); }
+  template<typename S> bool mkdir(const S& path)                           { return mkdir(path.c_str()); }
+  template<typename S> bool rmdir(const S& path)                           { return rmdir(path.c_str()); }
+
+  bool   begin(bool /*formatOnFail*/ = false) { return true; }
+  void   end()                                {}
+  bool   format()                             { return true; }
+  size_t totalBytes() const                   { return 4u * 1024u * 1024u; }
+  size_t usedBytes()  const;
+
+private:
+  std::string root_;
+};

--- a/dev/stubs/fs_util_stub.cpp
+++ b/dev/stubs/fs_util_stub.cpp
@@ -1,0 +1,43 @@
+// Host-build stub for src/storage/fs_util.h.
+// Uses the LittleFS stub directly so create/delete operations affect dev/fs/.
+
+#include "src/storage/fs_util.h"
+
+bool fsBegin() { return true; }
+
+size_t fsTotalBytesSafe() { return LittleFS.totalBytes(); }
+size_t fsUsedBytesSafe()  { return LittleFS.usedBytes();  }
+size_t fsFreeBytesSafe()  {
+  size_t t = fsTotalBytesSafe(), u = fsUsedBytesSafe();
+  return (t >= u) ? (t - u) : 0;
+}
+
+void ensureBooksDir() {
+  if (!FS.exists("/books")) FS.mkdir("/books");
+}
+
+bool ensureDirRecursive(const String& path) {
+  if (path.length() == 0 || path == "/") return true;
+  if (FS.exists(path)) return true;
+  int slash = path.lastIndexOf('/');
+  if (slash > 0) {
+    String parent = path.substring(0, slash);
+    if (parent.length() > 0 && !FS.exists(parent)) {
+      if (!ensureDirRecursive(parent)) return false;
+    }
+  }
+  return FS.mkdir(path);
+}
+
+bool isDirEmpty(const String& path) {
+  File dir = FS.open(path);
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+  File f = dir.openNextFile();
+  bool empty = !f;
+  if (f) f.close();
+  dir.close();
+  return empty;
+}

--- a/dev/stubs/list_items_glue.cpp
+++ b/dev/stubs/list_items_glue.cpp
@@ -1,0 +1,46 @@
+// Host implementations of the list_items.h firmware-glue functions
+// (normally compiled only under #ifdef ARDUINO).
+
+#include "src/storage/list_items.h"
+#include "src/pure/list_codec.h"
+#include "map_kv_store.h"
+
+static MapKvStore g_list_kv;
+
+ListState g_list;
+
+void sanitizeListText(String& s) {
+  // Mirror the codec sanitizer: strip leading/trailing whitespace, collapse
+  // internal runs. For the emulator a simple trim is enough.
+  s.trim();
+}
+
+void loadListItems() {
+  ListData data = loadList(g_list_kv);
+  g_list.count = 0;
+  g_list.selectedIndex = 0;
+  for (int i = 0; i < data.count && i < MAX_LIST_ITEMS; i++) {
+    strncpy(g_list.items[i].text, data.items[i].text, MAX_LIST_TEXT);
+    g_list.items[i].text[MAX_LIST_TEXT] = '\0';
+    g_list.items[i].done = data.items[i].done;
+    g_list.count++;
+  }
+}
+
+void saveListItems() {
+  ListData data;
+  data.count = g_list.count;
+  for (int i = 0; i < g_list.count; i++) {
+    strncpy(data.items[i].text, g_list.items[i].text, MAX_LIST_TEXT);
+    data.items[i].text[MAX_LIST_TEXT] = '\0';
+    data.items[i].done = g_list.items[i].done;
+  }
+  saveList(g_list_kv, data);
+}
+
+bool listHasVisibleItems() {
+  for (int i = 0; i < g_list.count; i++) {
+    if (g_list.items[i].text[0] != '\0') return true;
+  }
+  return false;
+}

--- a/dev/stubs/overrides/Preferences.h
+++ b/dev/stubs/overrides/Preferences.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Host-build stub for Arduino's <Preferences.h>.
+// Provides the subset of the Preferences API used by PreferencesStore.
+
+#include <map>
+#include <string>
+#include <vector>
+#include <cstring>
+#include "src/pure/arduino_compat.h"
+
+class Preferences {
+public:
+  int getInt(const char* key, int def = 0) {
+    auto it = bytes_.find(key);
+    if (it == bytes_.end() || it->second.size() != sizeof(int)) return def;
+    int v; std::memcpy(&v, it->second.data(), sizeof(v)); return v;
+  }
+  void putInt(const char* key, int v) {
+    auto& b = bytes_[key]; b.resize(sizeof(v)); std::memcpy(b.data(), &v, sizeof(v));
+  }
+
+  size_t getBytes(const char* key, void* buf, size_t maxLen) {
+    auto it = bytes_.find(key);
+    if (it == bytes_.end()) return 0;
+    size_t n = it->second.size() < maxLen ? it->second.size() : maxLen;
+    std::memcpy(buf, it->second.data(), n);
+    return n;
+  }
+  void putBytes(const char* key, const void* buf, size_t len) {
+    auto& v = bytes_[key];
+    v.assign((const uint8_t*)buf, (const uint8_t*)buf + len);
+  }
+
+  String getString(const char* key, const String& def = String("")) {
+    auto it = strs_.find(key);
+    return (it == strs_.end()) ? def : String(it->second.c_str());
+  }
+  void putString(const char* key, const String& v) { strs_[key] = v.c_str(); }
+
+  void remove(const char* key) { bytes_.erase(key); strs_.erase(key); }
+  void clear()                 { bytes_.clear();     strs_.clear();    }
+
+private:
+  std::map<std::string, std::vector<uint8_t>> bytes_;
+  std::map<std::string, std::string>          strs_;
+};

--- a/dev/stubs/overrides/Preferences.h
+++ b/dev/stubs/overrides/Preferences.h
@@ -7,16 +7,23 @@
 #include <string>
 #include <vector>
 #include <cstring>
+#include <cstdio>
 #include "src/pure/arduino_compat.h"
 
 class Preferences {
 public:
   int getInt(const char* key, int def = 0) {
     auto it = bytes_.find(key);
-    if (it == bytes_.end() || it->second.size() != sizeof(int)) return def;
-    int v; std::memcpy(&v, it->second.data(), sizeof(v)); return v;
+    if (it == bytes_.end() || it->second.size() != sizeof(int)) {
+      std::fprintf(stderr, "  [prefs] getInt  %s -> %d (default)\n", key, def);
+      return def;
+    }
+    int v; std::memcpy(&v, it->second.data(), sizeof(v));
+    std::fprintf(stderr, "  [prefs] getInt  %s -> %d\n", key, v);
+    return v;
   }
   void putInt(const char* key, int v) {
+    std::fprintf(stderr, "  [prefs] putInt  %s = %d\n", key, v);
     auto& b = bytes_[key]; b.resize(sizeof(v)); std::memcpy(b.data(), &v, sizeof(v));
   }
 

--- a/dev/stubs/overrides/src/state.h
+++ b/dev/stubs/overrides/src/state.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Host-build replacement for Pala_One_2_1/src/state.h.
+// Declares the same globals but backed by emulator stubs.
+
+#include "src/config.h"
+#include "stubs/web_server.h"
+#include "stubs/fs_stub.h"
+#include "Preferences.h"
+
+extern WebServerStub server;
+extern Preferences   prefs;
+
+// FS macro mirrors the real state.h convention.
+#define FS LittleFS
+
+// WiFi credential placeholders (some web handlers reference AP_SSID).
+extern char AP_SSID[24];
+extern const char* AP_PASS;
+
+// Arduino built-in stubs.
+inline void delay(unsigned long) {}
+inline unsigned long millis() { return 0; }

--- a/dev/stubs/overrides/src/storage/book_metadata.h
+++ b/dev/stubs/overrides/src/storage/book_metadata.h
@@ -1,0 +1,37 @@
+#pragma once
+// Emulator override: exposes firmware-glue functions without #ifdef ARDUINO.
+// Definitions live in dev/stubs/book_metadata_glue.cpp.
+
+#include "src/storage/kv_store.h"
+#include "src/pure/bookmarks_codec.h"
+#include "src/pure/hashing.h"
+
+// ---------------------------------------------------------------------------
+//  Testable KV-store-backed API (identical to real header)
+// ---------------------------------------------------------------------------
+Bookmarks loadBookmarks(KeyValueStore& kv, const String& bookKey);
+void      saveBookmarks(KeyValueStore& kv, const String& bookKey, const Bookmarks& bm);
+
+int      loadSavedPage(KeyValueStore& kv, const String& bookKey);
+void     saveSavedPage(KeyValueStore& kv, const String& bookKey, int pageIndex);
+uint32_t loadSavedOffset(KeyValueStore& kv, const String& bookKey);
+void     saveSavedOffset(KeyValueStore& kv, const String& bookKey, uint32_t byteOffset);
+
+bool clearBookMetadata(KeyValueStore& kv, const String& bookKey);
+void renameBookMetadata(KeyValueStore& kv, const String& oldKey, const String& newKey);
+
+// ---------------------------------------------------------------------------
+//  Firmware-glue API — exposed unconditionally in the emulator
+// ---------------------------------------------------------------------------
+#include "src/config.h"
+
+uint8_t loadBookmarksForKey(const String& bookKey,
+                            uint16_t outPages[MAX_BOOKMARKS],
+                            uint32_t outOffsets[MAX_BOOKMARKS]);
+void saveBookmarksForKey(const String& bookKey,
+                         const uint16_t pages[MAX_BOOKMARKS],
+                         const uint32_t offsets[MAX_BOOKMARKS],
+                         uint8_t count);
+int  savedPageForBookPath(const String& path);
+void deleteBookMetadata(const String& path);
+void migrateBookMetadata(const String& oldPath, const String& newPath);

--- a/dev/stubs/overrides/src/storage/list_items.h
+++ b/dev/stubs/overrides/src/storage/list_items.h
@@ -1,0 +1,34 @@
+#pragma once
+// Emulator override: exposes firmware-glue types and functions without #ifdef ARDUINO.
+// Definitions live in dev/stubs/list_items_glue.cpp.
+
+#include "src/storage/kv_store.h"
+#include "src/pure/list_codec.h"
+#include "src/config.h"
+
+// ---------------------------------------------------------------------------
+//  Testable KV-store-backed API (identical to real header)
+// ---------------------------------------------------------------------------
+ListData loadList(KeyValueStore& kv);
+void     saveList(KeyValueStore& kv, const ListData& data);
+
+// ---------------------------------------------------------------------------
+//  Firmware-glue runtime state — exposed unconditionally in the emulator
+// ---------------------------------------------------------------------------
+struct ListItem {
+  char    text[MAX_LIST_TEXT + 1];
+  uint8_t done = 0;
+};
+
+struct ListState {
+  ListItem items[MAX_LIST_ITEMS];
+  int count         = 0;
+  int selectedIndex = 0;
+};
+
+extern ListState g_list;
+
+void sanitizeListText(String& s);
+void loadListItems();
+void saveListItems();
+bool listHasVisibleItems();

--- a/dev/stubs/overrides/src/ui/screen.h
+++ b/dev/stubs/overrides/src/ui/screen.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Minimal Screen stub — list.cpp checks g_currentScreen == &g_listScreen
+// after a POST to decide whether to redirect the device display.
+// In the emulator this check always evaluates to false; no navigation occurs.
+
+struct Screen {
+  Screen* nextScreen = nullptr;
+};
+
+extern Screen* g_currentScreen;

--- a/dev/stubs/overrides/src/ui/screens/library_screen.h
+++ b/dev/stubs/overrides/src/ui/screens/library_screen.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "src/ui/screen.h"
+extern Screen g_libraryScreen;
+inline void resetLibraryNav() {}

--- a/dev/stubs/overrides/src/ui/screens/list_screen.h
+++ b/dev/stubs/overrides/src/ui/screens/list_screen.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "src/ui/screen.h"
+extern Screen g_listScreen;

--- a/dev/stubs/overrides/src/ui/toast.h
+++ b/dev/stubs/overrides/src/ui/toast.h
@@ -1,0 +1,5 @@
+#pragma once
+namespace Toast {
+  inline void reset() {}
+  inline void show(const char*) {}
+}

--- a/dev/stubs/prelude.h
+++ b/dev/stubs/prelude.h
@@ -1,0 +1,18 @@
+#pragma once
+// Force-included before every translation unit in the emulator build.
+// System headers must be parsed before arduino_compat.h defines the min/max
+// two-argument macros, otherwise zero-argument calls like numeric_limits<T>::min()
+// are misinterpreted as macro invocations and fail to compile.
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>

--- a/dev/stubs/state.cpp
+++ b/dev/stubs/state.cpp
@@ -1,0 +1,17 @@
+#include "stubs/web_server.h"
+#include "stubs/fs_stub.h"
+#include "Preferences.h"
+#include "src/ui/screen.h"
+#include "src/ui/screens/library_screen.h"
+#include "src/ui/screens/list_screen.h"
+
+WebServerStub server;
+Preferences   prefs;
+
+char        AP_SSID[24] = "PalaOneEmu";
+const char* AP_PASS     = "palaone";
+
+// Screen stubs for list.cpp's post-save navigation check.
+Screen  g_libraryScreen;
+Screen  g_listScreen;
+Screen* g_currentScreen = nullptr;

--- a/dev/stubs/text_stubs.cpp
+++ b/dev/stubs/text_stubs.cpp
@@ -1,36 +1,97 @@
-// Stubs for src/ui/text.h — the paginator/render functions that depend on the
-// u8g2 display library. In the emulator these return simple approximations so
-// the bookmark view and export pages can show *something*.
+// Stubs for src/ui/text.h. The emulator uses the real pure paginator
+// (paginatePage) with a host-side character-width approximation for
+// helvR12_te so page boundaries match the device closely.
 
 #include "src/ui/text.h"
+#include "src/ui/font.h"
+#include "src/pure/find_text.h"
+#include "src/pure/paginator.h"
+#include "src/hal/file_stream.h"
 
-uint32_t drawPageAt(File&, uint32_t startPos) {
-  return startPos + 1000;
-}
-
-// Read up to ~800 bytes of raw text from the file at the given offset.
-// Real firmware would word-wrap at pixel widths; emulator just reads bytes.
-uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
-  if (!f) return startPos;
-  f.seek(startPos);
-  const int kMax = 800;
-  uint8_t buf[kMax];
-  size_t n = f.read(buf, kMax);
-  for (size_t i = 0; i < n; i++) {
-    char c = (char)buf[i];
-    if (c != '\r') out += c;
+// Approximate per-glyph pixel widths for u8g2_font_helvR12_te.
+// Non-ASCII bytes (UTF-8 continuations) return 0; lead bytes return ~7.
+static int hostMeasureWidth(const char* s) {
+  static const uint8_t w[128] = {
+  //  0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // 00
+      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // 10
+      3,  4,  5,  9,  7, 10,  9,  3,  4,  4,  6,  9,  4,  5,  4,  5, // 20  !"#$%&'()*+,-./
+      7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  4,  4,  9,  9,  9,  6, // 30  0-9:;<=>?
+     12,  8,  8,  8,  9,  7,  7,  9,  9,  3,  5,  8,  7, 10,  9,  9, // 40  @A-O
+      7,  9,  8,  7,  7,  9,  8, 11,  8,  7,  8,  4,  5,  4,  9,  7, // 50  P-Z[\]^_
+      5,  7,  7,  6,  7,  7,  4,  7,  7,  3,  3,  7,  3, 10,  7,  7, // 60  `a-o
+      7,  7,  5,  6,  5,  7,  7, 10,  7,  7,  6,  5,  3,  5,  9,  0, // 70  p-z{|}~
+  };
+  int total = 0;
+  while (*s) {
+    unsigned char c = (unsigned char)*s++;
+    if (c < 0x80)       total += w[c];       // ASCII
+    else if (c >= 0xC0) total += 7;          // UTF-8 lead byte — non-ASCII char
+    // continuation bytes (0x80–0xBF) contribute 0
   }
-  return startPos + (uint32_t)n;
+  return total;
 }
 
-uint32_t nextPageOffset(File&, uint32_t startPos) {
-  return startPos + 1000;
+uint32_t drawPageAt(File& f, uint32_t startPos) {
+  FileReadStream stream(f);
+  return paginatePage(stream, startPos, Font::bodyLayout(), hostMeasureWidth, nullptr);
 }
 
-uint32_t pageOffsetForPage(File&, const String&, int page) {
-  return (uint32_t)page * 1000u;
+uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
+  FileReadStream stream(f);
+  auto onLine = [&](const char* buf, size_t len) {
+    const char* p = buf;
+    size_t rem = len;
+    while (rem > 0 && (*p == ' ' || *p == '\t')) { p++; rem--; }
+    out.concat(p, (unsigned int)rem);
+    out.concat('\n');
+  };
+  return paginatePage(stream, startPos, Font::bodyLayout(), hostMeasureWidth, onLine);
 }
 
-uint32_t resolveBookmarkOffset(const String&, uint16_t page, uint32_t storedOffset) {
-  return (storedOffset != 0xFFFFFFFFu) ? storedOffset : (uint32_t)page * 1000u;
+uint32_t nextPageOffset(File& f, uint32_t startPos) {
+  FileReadStream stream(f);
+  return paginatePage(stream, startPos, Font::bodyLayout(), hostMeasureWidth, nullptr);
+}
+
+uint32_t pageOffsetForPage(File& f, const String& /*path*/, int page) {
+  if (page <= 0) return 0;
+  uint32_t off = 0;
+  for (int p = 0; p < page; p++) {
+    uint32_t next = nextPageOffset(f, off);
+    if (next <= off) break;
+    off = next;
+  }
+  return off;
+}
+
+uint32_t resolveBookmarkOffset(const String& path, uint16_t page, uint32_t storedOffset) {
+  File f = FS.open(path, "r");
+  if (!f) return 0;
+  uint32_t off = (storedOffset != 0xFFFFFFFFu) ? storedOffset
+                                                : pageOffsetForPage(f, path, page);
+  f.close();
+  return off;
+}
+
+uint32_t pageOffsetForText(File& f, const String& /*path*/, const String& query,
+                           int* outPageIndex) {
+  if (outPageIndex) *outPageIndex = -1;
+  if (query.length() == 0 || !f) return 0;
+
+  FileReadStream stream(f);
+  uint32_t matchOffset = findByteOffset(stream, query);
+  if (matchOffset == 0xFFFFFFFFu) return 0xFFFFFFFFu;
+
+  uint32_t pageStart = 0;
+  int pageIdx = 0;
+  while (pageStart < matchOffset) {
+    uint32_t next = nextPageOffset(f, pageStart);
+    if (next <= pageStart) break;
+    if (next > matchOffset) break;
+    pageStart = next;
+    pageIdx++;
+  }
+  if (outPageIndex) *outPageIndex = pageIdx;
+  return pageStart;
 }

--- a/dev/stubs/text_stubs.cpp
+++ b/dev/stubs/text_stubs.cpp
@@ -1,0 +1,36 @@
+// Stubs for src/ui/text.h — the paginator/render functions that depend on the
+// u8g2 display library. In the emulator these return simple approximations so
+// the bookmark view and export pages can show *something*.
+
+#include "src/ui/text.h"
+
+uint32_t drawPageAt(File&, uint32_t startPos) {
+  return startPos + 1000;
+}
+
+// Read up to ~800 bytes of raw text from the file at the given offset.
+// Real firmware would word-wrap at pixel widths; emulator just reads bytes.
+uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
+  if (!f) return startPos;
+  f.seek(startPos);
+  const int kMax = 800;
+  uint8_t buf[kMax];
+  size_t n = f.read(buf, kMax);
+  for (size_t i = 0; i < n; i++) {
+    char c = (char)buf[i];
+    if (c != '\r') out += c;
+  }
+  return startPos + (uint32_t)n;
+}
+
+uint32_t nextPageOffset(File&, uint32_t startPos) {
+  return startPos + 1000;
+}
+
+uint32_t pageOffsetForPage(File&, const String&, int page) {
+  return (uint32_t)page * 1000u;
+}
+
+uint32_t resolveBookmarkOffset(const String&, uint16_t page, uint32_t storedOffset) {
+  return (storedOffset != 0xFFFFFFFFu) ? storedOffset : (uint32_t)page * 1000u;
+}

--- a/dev/stubs/ui_stubs.cpp
+++ b/dev/stubs/ui_stubs.cpp
@@ -1,0 +1,58 @@
+// Stubs for the Font:: and Sleep:: namespaces from src/ui/font.h and src/ui/sleep.h.
+// The emulator returns sensible defaults and persists changes in memory only.
+
+#include "src/ui/font.h"
+#include "src/ui/sleep.h"
+#include "src/pure/paginator.h"
+
+// ---------------------------------------------------------------------------
+//  Font
+// ---------------------------------------------------------------------------
+namespace Font {
+
+static int  s_bodySize = 12;
+static int  s_lineGap  = 0;
+
+void useBody()     {}
+void useBold()     {}
+void useUiSmall()  {}
+void useUiTiny()   {}
+void useAppLarge() {}
+void loadSettings() {}
+
+const LayoutMetrics& bodyLayout() {
+  static LayoutMetrics m;
+  m.lineH    = s_bodySize + 2 + s_lineGap;
+  m.maxWidth = 250;
+  m.maxLines = 122 / m.lineH;
+  m.ascent   = s_bodySize;
+  m.descent  = 2;
+  return m;
+}
+
+void setBodySize(int sz) {
+  if (sz == 8 || sz == 10 || sz == 12 || sz == 14) s_bodySize = sz;
+}
+void setLineGap(int gap) {
+  if (gap >= 0 && gap <= 4) s_lineGap = gap;
+}
+int currentBodySize() { return s_bodySize; }
+int currentLineGap()  { return s_lineGap; }
+
+}  // namespace Font
+
+// ---------------------------------------------------------------------------
+//  Sleep
+// ---------------------------------------------------------------------------
+namespace Sleep {
+
+static int s_timeout = 120;
+
+void loadSettings()       {}
+void setIdleTimeout(int s) { if (s >= 10 && s <= 3600) s_timeout = s; }
+int  idleTimeoutSecs()    { return s_timeout; }
+uint32_t idleTimeoutMs()  { return (uint32_t)s_timeout * 1000u; }
+void enter()              {}
+void idleLightSleep(bool) {}
+
+}  // namespace Sleep

--- a/dev/stubs/ui_stubs.cpp
+++ b/dev/stubs/ui_stubs.cpp
@@ -4,6 +4,7 @@
 #include "src/ui/font.h"
 #include "src/ui/sleep.h"
 #include "src/pure/paginator.h"
+#include "src/config.h"
 
 // ---------------------------------------------------------------------------
 //  Font
@@ -22,11 +23,14 @@ void loadSettings() {}
 
 const LayoutMetrics& bodyLayout() {
   static LayoutMetrics m;
-  m.lineH    = s_bodySize + 2 + s_lineGap;
-  m.maxWidth = 250;
-  m.maxLines = 122 / m.lineH;
   m.ascent   = s_bodySize;
   m.descent  = 2;
+  m.lineH    = s_bodySize + m.descent + s_lineGap;
+  m.maxWidth = SCREEN_W - 2 * MARGIN_X;
+  int usableH = SCREEN_H - TOP_PAD - BOT_PAD;
+  if (SHOW_PROGRESS_BAR || SHOW_PAGE_NUMBER) usableH -= STATUS_H;
+  m.maxLines = usableH / m.lineH;
+  if (m.maxLines < 1) m.maxLines = 1;
   return m;
 }
 

--- a/dev/stubs/upload_stub.cpp
+++ b/dev/stubs/upload_stub.cpp
@@ -1,0 +1,8 @@
+// Stub registration functions for upload routes not included in the emulator.
+// web.cpp calls these from registerWebRoutes(); they do nothing here.
+
+#include "src/web/upload.h"
+#include "src/web/apps_upload.h"
+
+void registerUploadRoutes()    {}
+void registerAppUploadRoutes() {}

--- a/dev/stubs/web_server.cpp
+++ b/dev/stubs/web_server.cpp
@@ -1,0 +1,105 @@
+// httplib is only included here — never in web_server.h — so the Arduino
+// min/max macros (defined by arduino_compat.h in other TUs) can't interfere
+// with httplib's use of <random> and other system headers that have zero-arg
+// member functions named min()/max().
+
+#define CPPHTTPLIB_THREAD_POOL_COUNT 1
+#include <httplib.h>
+
+#include "stubs/web_server.h"
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+//  Implementation detail
+// ---------------------------------------------------------------------------
+
+struct WebServerImpl {
+  httplib::Server svr;
+};
+
+// Thread-local request/response context, set for each handler call.
+thread_local static const httplib::Request*                           t_req = nullptr;
+thread_local static httplib::Response*                                t_res = nullptr;
+thread_local static std::vector<std::pair<std::string,std::string>>  t_hdrs;
+
+static void applyHeaders(httplib::Response& res) {
+  for (auto& h : t_hdrs) res.set_header(h.first.c_str(), h.second.c_str());
+  t_hdrs.clear();
+}
+
+static void dispatch(const httplib::Request& req, httplib::Response& res,
+                     const THandlerFunction& handler) {
+  t_req = &req;
+  t_res = &res;
+  t_hdrs.clear();
+  handler();
+  applyHeaders(res);
+  t_req = nullptr;
+  t_res = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+//  WebServerStub
+// ---------------------------------------------------------------------------
+
+WebServerStub::WebServerStub()  : impl_(std::make_unique<WebServerImpl>()) {}
+WebServerStub::~WebServerStub() = default;
+
+void WebServerStub::on(const char* uri, int method, THandlerFunction handler) {
+  if (method == HTTP_GET || method == HTTP_ANY) {
+    impl_->svr.Get(uri, [handler](const httplib::Request& req, httplib::Response& res) {
+      dispatch(req, res, handler);
+    });
+  }
+  if (method == HTTP_POST || method == HTTP_ANY) {
+    impl_->svr.Post(uri, [handler](const httplib::Request& req, httplib::Response& res) {
+      dispatch(req, res, handler);
+    });
+  }
+}
+
+void WebServerStub::on(const char* uri, int /*method*/,
+                       THandlerFunction /*done*/, THandlerFunction /*stream*/) {
+  impl_->svr.Post(uri, [](const httplib::Request&, httplib::Response& res) {
+    res.status = 501;
+    res.set_content("File upload not supported in the web emulator.", "text/plain");
+  });
+}
+
+void WebServerStub::send(int code, const char* contentType, const String& body) {
+  if (!t_res) return;
+  t_res->status = code;
+  applyHeaders(*t_res);
+  t_res->set_content(body.c_str(), contentType);
+}
+
+void WebServerStub::send_P(int code, const char* contentType, const char* progmemStr) {
+  if (!t_res) return;
+  t_res->status = code;
+  applyHeaders(*t_res);
+  t_res->set_content(progmemStr, contentType);
+}
+
+void WebServerStub::sendHeader(const char* name, const String& value) {
+  t_hdrs.push_back({name, value.c_str()});
+}
+
+String WebServerStub::arg(const String& name) {
+  if (!t_req) return String("");
+  if (t_req->has_param(name.c_str()))
+    return String(t_req->get_param_value(name.c_str()).c_str());
+  return String("");
+}
+
+bool WebServerStub::hasArg(const String& name) {
+  return t_req && t_req->has_param(name.c_str());
+}
+
+void WebServerStub::run(int port) {
+  std::cout << "Pala One web emulator: http://localhost:" << port << "\n";
+  std::cout << "Press Ctrl+C to stop.\n";
+  impl_->svr.listen("0.0.0.0", port);
+}

--- a/dev/stubs/web_server.cpp
+++ b/dev/stubs/web_server.cpp
@@ -35,8 +35,25 @@ static void dispatch(const httplib::Request& req, httplib::Response& res,
   t_req = &req;
   t_res = &res;
   t_hdrs.clear();
+
+  std::cerr << req.method << " " << req.path;
+  if (!req.params.empty()) {
+    std::cerr << "?";
+    bool first = true;
+    for (auto& p : req.params) {
+      if (!first) std::cerr << "&";
+      std::cerr << p.first << "=" << p.second;
+      first = false;
+    }
+  }
+  if (!req.body.empty()) std::cerr << " body=" << req.body;
+  std::cerr << "\n";
+
   handler();
   applyHeaders(res);
+
+  std::cerr << "  -> " << res.status << "\n";
+
   t_req = nullptr;
   t_res = nullptr;
 }
@@ -102,4 +119,8 @@ void WebServerStub::run(int port) {
   std::cout << "Pala One web emulator: http://localhost:" << port << "\n";
   std::cout << "Press Ctrl+C to stop.\n";
   impl_->svr.listen("0.0.0.0", port);
+}
+
+void WebServerStub::stop() {
+  impl_->svr.stop();
 }

--- a/dev/stubs/web_server.h
+++ b/dev/stubs/web_server.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "src/pure/arduino_compat.h"
+
+enum HTTPMethod { HTTP_ANY, HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_PATCH, HTTP_DELETE, HTTP_OPTIONS };
+
+using THandlerFunction = std::function<void()>;
+
+// Forward declaration — implementation detail in web_server.cpp.
+struct WebServerImpl;
+
+// Drop-in stub for Arduino's WebServer, backed by cpp-httplib.
+// httplib.h is intentionally NOT included here to avoid macro conflicts.
+class WebServerStub {
+public:
+  WebServerStub();
+  ~WebServerStub();
+
+  // Route registration.
+  void on(const char* uri, int method, THandlerFunction handler);
+  // Streaming-upload variant — returns 501 in the emulator.
+  void on(const char* uri, int method, THandlerFunction done, THandlerFunction stream);
+
+  // Response helpers — callable only from within a handler.
+  void send(int code, const char* contentType, const String& body);
+  void send_P(int code, const char* contentType, const char* progmemStr);
+  void sendHeader(const char* name, const String& value);
+
+  // Request helpers — callable only from within a handler.
+  String arg(const String& name);
+  bool   hasArg(const String& name);
+
+  // No-ops called by firmware during normal startup/loop.
+  void begin() {}
+  void handleClient() {}
+
+  // Start the blocking HTTP server loop.
+  void run(int port = 8080);
+
+private:
+  std::unique_ptr<WebServerImpl> impl_;
+};

--- a/dev/stubs/web_server.h
+++ b/dev/stubs/web_server.h
@@ -41,6 +41,9 @@ public:
   // Start the blocking HTTP server loop.
   void run(int port = 8080);
 
+  // Stop the server (unblocks run()). Safe to call from another thread.
+  void stop();
+
 private:
   std::unique_ptr<WebServerImpl> impl_;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(FW_SRC ${CMAKE_SOURCE_DIR}/../Pala_One_2_1/src)
 set(SUT_SRC
   ${FW_SRC}/pure/paths.cpp
   ${FW_SRC}/pure/text_util.cpp
+  ${FW_SRC}/pure/find_text.cpp
   ${FW_SRC}/pure/hashing.cpp
   ${FW_SRC}/pure/paginator.cpp
   ${FW_SRC}/pure/library_nav.cpp

--- a/test/test_text_util.cpp
+++ b/test/test_text_util.cpp
@@ -1,5 +1,6 @@
 #include "test_framework.h"
 #include "pure/text_util.h"
+#include "pure/find_text.h"
 
 TEST_CASE("utf8CharLenFromLead recognizes ASCII and multibyte leads") {
   CHECK_EQ(utf8CharLenFromLead('a'), 1);
@@ -91,4 +92,86 @@ TEST_CASE("compactText trims trailing whitespace and newlines") {
 
 TEST_CASE("compactText drops trailing spaces before newline") {
   CHECK_EQ(compactText("a   \nb"), String("a\nb"));
+}
+
+TEST_CASE("find_text locates patterns with Boyer-Moore-Horspool") {
+  CHECK_EQ(find_text("hello world", "world"), 6u);
+  CHECK_EQ(find_text("hello world", "hello"), 0u);
+  CHECK_EQ(find_text("hello world", "o w"), 4u);
+  CHECK_EQ(find_text("hello world", ""), 0u);
+  CHECK_EQ(find_text("hello world", "missing"), 0xFFFFFFFFu);
+}
+
+TEST_CASE("find_text handles repeated partial pattern matches and skip arithmetic") {
+  // Text contains several prefixes of the pattern before the actual match.
+  CHECK_EQ(find_text("abcxabcdabxabcdabcdabcy", "abcdabcy"), 15u);
+  CHECK_EQ(find_text("aaaaaaab", "aaab"), 4u);
+  CHECK_EQ(find_text("ababababaabababc", "abababc"), 9u);
+}
+
+// ============================================================================
+//  findByteOffset — chunked streaming search
+//
+//  All cases use chunkSize=3 so the fixture strings force boundary crossings
+//  without needing large buffers.
+// ============================================================================
+
+TEST_CASE("findByteOffset finds pattern entirely within the first chunk") {
+  StringReadStream s("abcdef");
+  CHECK_EQ(findByteOffset(s, String("ab"), 3), 0u);
+  CHECK_EQ(findByteOffset(s, String("bc"), 3), 1u);
+}
+
+TEST_CASE("findByteOffset finds pattern that spans a chunk boundary") {
+  // "cd" straddles the boundary between chunk "abc" and chunk "def".
+  StringReadStream s("abcdef");
+  CHECK_EQ(findByteOffset(s, String("cd"), 3), 2u);
+}
+
+TEST_CASE("findByteOffset finds pattern entirely in a later chunk") {
+  StringReadStream s("abcdef");
+  CHECK_EQ(findByteOffset(s, String("de"), 3), 3u);
+  CHECK_EQ(findByteOffset(s, String("ef"), 3), 4u);
+}
+
+TEST_CASE("findByteOffset handles pattern longer than chunkSize") {
+  // "cdefg" spans three chunks ("abc","def","ghi") with chunkSize=3.
+  StringReadStream s("abcdefghi");
+  CHECK_EQ(findByteOffset(s, String("cdefg"), 3), 2u);
+}
+
+TEST_CASE("findByteOffset returns 0xFFFFFFFFu when pattern is absent") {
+  StringReadStream s("abcdef");
+  CHECK_EQ(findByteOffset(s, String("xy"), 3), 0xFFFFFFFFu);
+}
+
+TEST_CASE("findByteOffset returns 0 for empty pattern") {
+  StringReadStream s("abcdef");
+  CHECK_EQ(findByteOffset(s, String(""), 3), 0u);
+}
+
+TEST_CASE("findByteOffset finds pattern at the very end of the stream") {
+  StringReadStream s("abcdef");
+  CHECK_EQ(findByteOffset(s, String("f"), 3), 5u);
+}
+
+TEST_CASE("findByteOffset is consistent with find_text on whole-string search") {
+  const String text = "the quick brown fox jumps over the lazy dog";
+  const String pattern = "lazy";
+  StringReadStream s(text);
+  CHECK_EQ(findByteOffset(s, pattern, 8), find_text(text, pattern));
+}
+
+TEST_CASE("findByteOffset is case-insensitive for ASCII") {
+  StringReadStream s("Hello World");
+  CHECK_EQ(findByteOffset(s, String("world"),  4), 6u);
+  CHECK_EQ(findByteOffset(s, String("HELLO"),  4), 0u);
+  CHECK_EQ(findByteOffset(s, String("hElLo"),  4), 0u);
+  CHECK_EQ(findByteOffset(s, String("WORLD"),  4), 6u);
+}
+
+TEST_CASE("findByteOffset case-insensitive match spans chunk boundary") {
+  // "LO W" straddles the chunk boundary between "Hel" and "lo World".
+  StringReadStream s("Hello World");
+  CHECK_EQ(findByteOffset(s, String("LO W"), 3), 3u);
 }


### PR DESCRIPTION
## Notes

This PR needs to be moved off of my changes from #28 before it can be merged

I know that Kev1nster's Firmware has a similar feature. We should consider which design we want and whether elements of one design should be applied to another.

## Summary

- **Find-in-Book**: new `/jumptext` POST route lets users search for text in a book from the web UI and jump to the first page containing it. Search is case-insensitive (ASCII fold). The handler saves both the byte offset and page index to NVS so the device opens to the right page on next load. A `?error=not-found` banner is shown when the text isn't present.
- **`src/pure/find_text`**: Boyer-Moore-Horspool `find_text()` for in-memory strings and `findByteOffset()` for chunked `IReadStream` search with overlap to catch cross-chunk matches. Both are host-testable; 10 new unit tests added.
- **`pageOffsetForText`**: walks the page cache (loading and extending the on-disk table) to return the start offset of the page containing the match, rather than the raw byte position.
- **Host web emulator** (`dev/`): native binary serving the same route handlers as the firmware, backed by a local filesystem. Uses the real `paginatePage` with a `helvR12_te` character-width lookup table so page boundaries are close to device output. Includes request/response logging to stderr and a VS Code debug launch config.
- **Integration tests**: 11 end-to-end tests drive the live emulator over HTTP, covering validation, redirect behaviour, offset persistence, and the not-found guard. **DEPENDS on #28**

<img width="1009" height="879" alt="image" src="https://github.com/user-attachments/assets/2d3c37f6-1625-4efa-92d6-41f683195c5f" />


## Test plan

- [x] `cmake -S test -B test/build && cmake --build test/build && ctest --test-dir test/build --output-on-failure` — all unit tests pass
- [x] `cmake -S dev -B dev/build && cmake --build dev/build && ctest --test-dir dev/build --output-on-failure` — all integration tests pass
- [x] Run `dev/build/pala_web_emu`, open `/files`, search for text present and absent in the sample book
- [x] Flash to device and verify the reader opens to the correct page after a web text search

Co-authored by [Claude Code](https://claude.com/claude-code)