### PR TITLE
Add Samim 9pt font size option

### DIFF
--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -242,6 +242,7 @@
 #define D_WEB_READING_HEADING       "Reading"
 #define D_WEB_FONT_SIZE_LABEL       "Font size"
 #define D_WEB_FONT_SIZE_8           "8px &mdash; tiny"
+#define D_WEB_FONT_SIZE_9           "9px &mdash; Samim"
 #define D_WEB_FONT_SIZE_10          "10px &mdash; small"
 #define D_WEB_FONT_SIZE_12          "12px &mdash; medium"
 #define D_WEB_FONT_SIZE_14          "14px &mdash; large"

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -238,6 +238,7 @@
 #define D_WEB_READING_HEADING       "Lectura"
 #define D_WEB_FONT_SIZE_LABEL       "Tamaño de fuente"
 #define D_WEB_FONT_SIZE_8           "8px &mdash; diminuto"
+#define D_WEB_FONT_SIZE_9           "9px &mdash; Samim"
 #define D_WEB_FONT_SIZE_10          "10px &mdash; pequeño"
 #define D_WEB_FONT_SIZE_12          "12px &mdash; mediano"
 #define D_WEB_FONT_SIZE_14          "14px &mdash; grande"

--- a/Pala_One_2_1/src/ui/font.cpp
+++ b/Pala_One_2_1/src/ui/font.cpp
@@ -37,11 +37,15 @@ static constexpr const char* kKeyLineGap  = "cfg_lgap";
 // callers go through setBodySize() / loadSettings().
 static void applyBodySize(int sz) {
   switch (sz) {
-    case 8:  s_body = u8g2_font_helvR08_te; s_bold = u8g2_font_helvB08_te; break;
-    case 10: s_body = u8g2_font_helvR10_te; s_bold = u8g2_font_helvB10_te; break;
-    case 12: s_body = u8g2_font_helvR12_te; s_bold = u8g2_font_helvB12_te; break;
-    case 14: s_body = u8g2_font_helvR14_te; s_bold = u8g2_font_helvB14_te; break;
-    default: s_body = u8g2_font_helvR10_te; s_bold = u8g2_font_helvB10_te; sz = 10; break;
+    case 8:  s_body = u8g2_font_helvR08_te;     s_bold = u8g2_font_helvB08_te;     break;
+    // Samim 12: Persian/Arabic + Latin/ASCII. No bold variant in U8g2 —
+    // s_bold aliases s_body (bold emphasis has no visual effect at this size).
+    // Uses _t_all encoding (all Unicode, transparent) rather than _te.
+    case 9:  s_body = u8g2_font_samim_12_t_all; s_bold = u8g2_font_samim_12_t_all; break;
+    case 10: s_body = u8g2_font_helvR10_te;     s_bold = u8g2_font_helvB10_te;     break;
+    case 12: s_body = u8g2_font_helvR12_te;     s_bold = u8g2_font_helvB12_te;     break;
+    case 14: s_body = u8g2_font_helvR14_te;     s_bold = u8g2_font_helvB14_te;     break;
+    default: s_body = u8g2_font_helvR10_te;     s_bold = u8g2_font_helvB10_te;     sz = 10; break;
   }
   s_size = sz;
   s_layoutValid = false;
@@ -66,7 +70,10 @@ void useAppLarge() { u8g2.setFont(u8g2_font_helvB14_te); }
 const LayoutMetrics& bodyLayout() {
   if (!s_layoutValid) {
     useBody();
-    s_layout.ascent  = u8g2.getFontAscent();
+    // Samim 12 (size 9) reports an ascent 1 px taller than its visual cap
+    // height warrants relative to the Helvetica faces. Subtract 1 so a
+    // comparable number of lines fit on screen.
+    s_layout.ascent  = u8g2.getFontAscent() - (s_size == 9 ? 1 : 0);
     s_layout.descent = u8g2.getFontDescent();
     s_layout.lineH   = (s_layout.ascent - s_layout.descent) + s_lineGap;
 

--- a/Pala_One_2_1/src/ui/font.cpp
+++ b/Pala_One_2_1/src/ui/font.cpp
@@ -41,7 +41,7 @@ static void applyBodySize(int sz) {
     // Samim 12: Persian/Arabic + Latin/ASCII. No bold variant in U8g2 —
     // s_bold aliases s_body (bold emphasis has no visual effect at this size).
     // Uses _t_all encoding (all Unicode, transparent) rather than _te.
-    case 9:  s_body = u8g2_font_samim_12_t_all; s_bold = u8g2_font_samim_12_t_all; break;
+    case 9:  s_body = u8g2_font_samim_12_t_all; s_bold = u8g2_font_helvB08_te;     break;
     case 10: s_body = u8g2_font_helvR10_te;     s_bold = u8g2_font_helvB10_te;     break;
     case 12: s_body = u8g2_font_helvR12_te;     s_bold = u8g2_font_helvB12_te;     break;
     case 14: s_body = u8g2_font_helvR14_te;     s_bold = u8g2_font_helvB14_te;     break;
@@ -70,12 +70,16 @@ void useAppLarge() { u8g2.setFont(u8g2_font_helvB14_te); }
 const LayoutMetrics& bodyLayout() {
   if (!s_layoutValid) {
     useBody();
-    // Samim 12 (size 9) reports an ascent 1 px taller than its visual cap
-    // height warrants relative to the Helvetica faces. Subtract 1 so a
-    // comparable number of lines fit on screen.
-    s_layout.ascent  = u8g2.getFontAscent() - (s_size == 9 ? 1 : 0);
+    s_layout.ascent  = u8g2.getFontAscent();
     s_layout.descent = u8g2.getFontDescent();
-    s_layout.lineH   = (s_layout.ascent - s_layout.descent) + s_lineGap;
+    // Samim 12 (size 9) reports an ascent 1 px taller than its visual cap
+    // height warrants relative to the Helvetica faces. Subtract 1 from the
+    // line-height calculation so a comparable number of lines fit on screen,
+    // but keep the full ascent for baseline placement — subtracting from
+    // ascent itself shifts the first line's baseline 1 px too high, clipping
+    // the top row of pixels against the panel edge.
+    int ascentForLineH = s_layout.ascent - (s_size == 9 ? 1 : 0);
+    s_layout.lineH   = (ascentForLineH - s_layout.descent) + s_lineGap;
 
     int w = SCREEN_W - (MARGIN_X * 2);
     if (w < 50) w = 50;

--- a/Pala_One_2_1/src/ui/widgets.cpp
+++ b/Pala_One_2_1/src/ui/widgets.cpp
@@ -76,9 +76,12 @@ void drawMenuRow(int yBaseline, const String& label, bool selected, int extraInd
 }
 
 int menuLineH() {
-  int ascent = u8g2.getFontAscent() - (Font::currentBodySize() == 9 ? 1 : 0);
+  int ascent  = u8g2.getFontAscent();
   int descent = u8g2.getFontDescent();
-  return (ascent - descent) + Font::currentLineGap() + 1;
+  // Same Samim correction as bodyLayout(): subtract 1 from the value used
+  // for line-height only, not from ascent itself.
+  int ascentForLineH = ascent - (Font::currentBodySize() == 9 ? 1 : 0);
+  return (ascentForLineH - descent) + Font::currentLineGap() + 1;
 }
 
 void drawScrollableList(int contentTopY, int itemCount, int selectedIndex,

--- a/Pala_One_2_1/src/ui/widgets.cpp
+++ b/Pala_One_2_1/src/ui/widgets.cpp
@@ -76,7 +76,7 @@ void drawMenuRow(int yBaseline, const String& label, bool selected, int extraInd
 }
 
 int menuLineH() {
-  int ascent = u8g2.getFontAscent();
+  int ascent = u8g2.getFontAscent() - (Font::currentBodySize() == 9 ? 1 : 0);
   int descent = u8g2.getFontDescent();
   return (ascent - descent) + Font::currentLineGap() + 1;
 }

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -9,6 +9,7 @@
 static void handleSettings() {
   int curFont = Font::currentBodySize();
   String sel8  = (curFont == 8)  ? " selected" : "";
+  String sel9  = (curFont == 9)  ? " selected" : "";
   String sel10 = (curFont == 10) ? " selected" : "";
   String sel12 = (curFont == 12) ? " selected" : "";
   String sel14 = (curFont == 14) ? " selected" : "";
@@ -42,6 +43,7 @@ static void handleSettings() {
     "<div class='grid cols-2'>"
     "<div><label for='font'>" D_WEB_FONT_SIZE_LABEL "</label><select id='font' name='font'>"
     "<option value='8'";  out += sel8;  out += ">" D_WEB_FONT_SIZE_8  "</option>"
+    "<option value='9'";  out += sel9;  out += ">" D_WEB_FONT_SIZE_9  "</option>"
     "<option value='10'"; out += sel10; out += ">" D_WEB_FONT_SIZE_10 "</option>"
     "<option value='12'"; out += sel12; out += ">" D_WEB_FONT_SIZE_12 "</option>"
     "<option value='14'"; out += sel14; out += ">" D_WEB_FONT_SIZE_14 "</option>"


### PR DESCRIPTION
Adds `u8g2_font_samim_12_t_all` as a new **9px** size option in Settings → Reading. Samim renders both Latin/English and Persian/Arabic text correctly. The main benefit is an extra option inbetween 8px, which may be too small for some people, and 10px, which shows way fewer words than 8px.

## Known limitations

- **No bold variant.** U8g2 does not include a bold face for this typeface. `s_bold` is aliased to the same `samim_12_t_all` pointer, so bold-emphasis calls (selected menu rows, section headers) render at regular weight.
- **Different encoding suffix.** All other body sizes use `_te` (extended Latin). Samim uses `_t_all` (all Unicode, transparent background). Built-in UI strings are all basic ASCII so this has no practical effect, but it's worth noting if anyone adds toast strings with characters outside `_t_all` coverage.
- **Ascent correction.** Samim 12 reports an ascent 1 px taller than its visual cap height relative to the Helvetica faces. Both `bodyLayout()` (reader) and `menuLineH()` (menus) subtract 1 when size == 9 so a comparable number of lines fit on screen.

The `applyBodySize()` default falls back to size 10 for any unrecognised value — no existing user is affected.

## Files changed

| File | What changed |
|------|-------------|
| `src/ui/font.cpp` | Add `case 9` (Samim) in `applyBodySize()`; −1 ascent correction in `bodyLayout()` when size == 9 |
| `src/ui/widgets.cpp` | Same −1 ascent correction in `menuLineH()` |
| `src/web/settings.cpp` | Add size-9 option in the font-size `<select>` |
| `src/lang/en.h` | `D_WEB_FONT_SIZE_9 "9px — Samim"` |
| `src/lang/es_la.h` | Same string in Spanish |