### PR TITLE
Add no-screensaver mode

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -133,12 +133,17 @@ void setup() {
   prefs.begin("ereader", false);
   Sleep::loadSettings();
 
-  // In no-screensaver mode, skip the full-refresh clear on deep-sleep wake so
-  // the last page is not blanked before the fast-mode redraw. On a fresh boot
-  // (or normal screensaver mode) always clear to white first.
+  // Skip the full-refresh boot clear only when all three are true:
+  //   (a) waking from deep sleep (not a fresh boot),
+  //   (b) no-screensaver mode is on, and
+  //   (c) we were reading a book (wake_path was set by armResumeOnWake during
+  //       the sleep entry — tryRestoreReadingSession() will consume it later).
+  // If the user fell asleep in a menu the screensaver was shown, so we always
+  // clear normally in that case.
   bool wokeFromSleep = (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT0);
+  bool wereReading   = (prefs.getString("wake_path", "").length() > 0);
   display.fastmodeOff();
-  if (!wokeFromSleep || !Sleep::noScreensaver()) {
+  if (!wokeFromSleep || !Sleep::noScreensaver() || !wereReading) {
     display.clear();
   }
 

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -128,8 +128,19 @@ void setup() {
   updateBatteryCached(true);
 #endif
 
+  // Load Sleep settings early — before display.clear() — so the no-screensaver
+  // flag is available to gate the full-refresh boot clear below.
+  prefs.begin("ereader", false);
+  Sleep::loadSettings();
+
+  // In no-screensaver mode, skip the full-refresh clear on deep-sleep wake so
+  // the last page is not blanked before the fast-mode redraw. On a fresh boot
+  // (or normal screensaver mode) always clear to white first.
+  bool wokeFromSleep = (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT0);
   display.fastmodeOff();
-  display.clear();
+  if (!wokeFromSleep || !Sleep::noScreensaver()) {
+    display.clear();
+  }
 
   if (!fsBegin()) {
     drawCenter(D_BOOT_STORAGE_ERROR, D_BOOT_TRY_FACTORY_RESET);
@@ -142,9 +153,8 @@ void setup() {
     snprintf(AP_SSID, sizeof(AP_SSID), "PALA-%06llX", chipId & 0xFFFFFFULL);
   }
 
-  prefs.begin("ereader", false);
   Font::loadSettings();
-  Sleep::loadSettings();
+  // Sleep::loadSettings() already called above.
   loadBooks();
   loadListItems();
   loadApps();

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -261,7 +261,7 @@
 #define D_WEB_LINE_SPACING_3        "3 px &mdash; loose"
 #define D_WEB_LINE_SPACING_HINT     "A small change here can make text much easier to scan."
 #define D_WEB_NO_SCREENSAVER_LABEL  "No-screensaver mode"
-#define D_WEB_NO_SCREENSAVER_HINT   "Device still sleeps on the normal timer. When asleep, the last page stays on screen instead of the screensaver. Waking skips the full display refresh."
+#define D_WEB_NO_SCREENSAVER_HINT   "Device still sleeps on the normal timer and refreshes the screen before going to sleep. Then it shows the last page of the book, and skips a full refresh on wake, so you can continue reading with a single click of the button without the interruption of a display refresh."
 #define D_WEB_SAVE_SETTINGS_BUTTON  "Save settings"
 #define D_WEB_SETTINGS_NO_EXTRAS    "No extra files, scripts, or fonts."
 #define D_WEB_SCREENSAVER_HEADING   "Screensaver"

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -260,6 +260,8 @@
 #define D_WEB_LINE_SPACING_2        "2 px &mdash; relaxed"
 #define D_WEB_LINE_SPACING_3        "3 px &mdash; loose"
 #define D_WEB_LINE_SPACING_HINT     "A small change here can make text much easier to scan."
+#define D_WEB_NO_SCREENSAVER_LABEL  "No-screensaver mode"
+#define D_WEB_NO_SCREENSAVER_HINT   "Device still sleeps on the normal timer. When asleep, the last page stays on screen instead of the screensaver. Waking skips the full display refresh."
 #define D_WEB_SAVE_SETTINGS_BUTTON  "Save settings"
 #define D_WEB_SETTINGS_NO_EXTRAS    "No extra files, scripts, or fonts."
 #define D_WEB_SCREENSAVER_HEADING   "Screensaver"

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -257,7 +257,7 @@
 #define D_WEB_LINE_SPACING_3        "3 px &mdash; suelto"
 #define D_WEB_LINE_SPACING_HINT     "Un pequeño cambio aquí puede facilitar mucho la lectura."
 #define D_WEB_NO_SCREENSAVER_LABEL  "Modo sin salvapantallas"
-#define D_WEB_NO_SCREENSAVER_HINT   "El dispositivo sigue durmiéndose según el temporizador habitual. Al dormir, la última página permanece en pantalla en lugar del salvapantallas. Al despertar se omite la actualización completa de la pantalla."
+#define D_WEB_NO_SCREENSAVER_HINT   "El dispositivo sigue durmiéndose según el temporizador habitual y actualiza la pantalla antes de dormirse. Luego muestra la última página del libro y omite la actualización completa al despertar, para que puedas continuar leyendo con un solo clic sin la interrupción de un refresco de pantalla."
 #define D_WEB_SAVE_SETTINGS_BUTTON  "Guardar ajustes"
 #define D_WEB_SETTINGS_NO_EXTRAS    "Sin archivos extra, scripts ni fuentes."
 #define D_WEB_SCREENSAVER_HEADING   "Salvapantallas"

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -256,6 +256,8 @@
 #define D_WEB_LINE_SPACING_2        "2 px &mdash; relajado"
 #define D_WEB_LINE_SPACING_3        "3 px &mdash; suelto"
 #define D_WEB_LINE_SPACING_HINT     "Un pequeño cambio aquí puede facilitar mucho la lectura."
+#define D_WEB_NO_SCREENSAVER_LABEL  "Modo sin salvapantallas"
+#define D_WEB_NO_SCREENSAVER_HINT   "El dispositivo sigue durmiéndose según el temporizador habitual. Al dormir, la última página permanece en pantalla en lugar del salvapantallas. Al despertar se omite la actualización completa de la pantalla."
 #define D_WEB_SAVE_SETTINGS_BUTTON  "Guardar ajustes"
 #define D_WEB_SETTINGS_NO_EXTRAS    "Sin archivos extra, scripts ni fuentes."
 #define D_WEB_SCREENSAVER_HEADING   "Salvapantallas"

--- a/Pala_One_2_1/src/ui/sleep.cpp
+++ b/Pala_One_2_1/src/ui/sleep.cpp
@@ -76,8 +76,20 @@ void enter() {
 
   delay(50);
 
-  // In no-screensaver mode the last page stays visible; skip the sleep image.
-  if (!s_noScreensaver) {
+  // No-screensaver mode only applies when coming from the reader. If the user
+  // fell asleep in the library or a menu, show the screensaver as normal.
+  // ReaderScreen::onSleep() has already called armResumeOnWake() above, which
+  // writes wake_path to NVS — so checking it here tells us reliably whether
+  // we were reading without coupling sleep.cpp to any screen type.
+  bool wasReading = (prefs.getString("wake_path", "").length() > 0);
+
+  if (s_noScreensaver && wasReading) {
+    // Full refresh of the last page so it sits cleanly on the panel.
+    // The reader's framebuffer content is still intact at this point.
+    display.fastmodeOff();
+    display.update();
+    delay(600);
+  } else {
     drawSleepScreen();
     delay(600);
   }

--- a/Pala_One_2_1/src/ui/sleep.cpp
+++ b/Pala_One_2_1/src/ui/sleep.cpp
@@ -15,15 +15,18 @@
 
 namespace Sleep {
 
-// Owned setting + NVS key — file-private.
-static int s_idleSecs = 120;
-static constexpr const char* kKeyIdleSecs = "cfg_sleep";
+// Owned settings + NVS keys — file-private.
+static int  s_idleSecs      = 120;
+static bool s_noScreensaver = false;
+static constexpr const char* kKeyIdleSecs      = "cfg_sleep";
+static constexpr const char* kKeyNoScreensaver = "cfg_noscr";
 
 void loadSettings() {
   int s = prefs.getInt(kKeyIdleSecs, 120);
   if (s < 10)   s = 10;
   if (s > 3600) s = 3600;
   s_idleSecs = s;
+  s_noScreensaver = prefs.getBool(kKeyNoScreensaver, false);
 }
 
 void setIdleTimeout(int secs) {
@@ -35,6 +38,12 @@ void setIdleTimeout(int secs) {
 
 int      idleTimeoutSecs() { return s_idleSecs; }
 uint32_t idleTimeoutMs()   { return (uint32_t)s_idleSecs * 1000UL; }
+bool     noScreensaver()   { return s_noScreensaver; }
+
+void setNoScreensaver(bool val) {
+  s_noScreensaver = val;
+  prefs.putBool(kKeyNoScreensaver, val);
+}
 
 // Render the sleep image onto the e-ink before powering down. Tries the
 // user-uploaded /sleep.bin first; falls back to the built-in icon.
@@ -67,8 +76,11 @@ void enter() {
 
   delay(50);
 
-  drawSleepScreen();
-  delay(600);
+  // In no-screensaver mode the last page stays visible; skip the sleep image.
+  if (!s_noScreensaver) {
+    drawSleepScreen();
+    delay(600);
+  }
 
   WiFi.softAPdisconnect(true);
   WiFi.disconnect(true, true);

--- a/Pala_One_2_1/src/ui/sleep.h
+++ b/Pala_One_2_1/src/ui/sleep.h
@@ -5,11 +5,12 @@
 
 // ============================================================================
 //  Sleep module — owns the deep-sleep entry sequence and the user-tunable
-//  idle-timeout setting (NVS key `cfg_sleep`, default 120s, range [10, 3600]).
+//  idle-timeout setting (NVS key `cfg_sleep`, default 120s, range [10, 3600])
+//  plus the no-screensaver toggle (NVS key `cfg_noscr`, default false).
 // ============================================================================
 namespace Sleep {
 
-// Read persisted idle-timeout from NVS into Sleep's internal state.
+// Read persisted settings from NVS into Sleep's internal state.
 // Call once from setup() after `prefs.begin`.
 void loadSettings();
 
@@ -19,6 +20,13 @@ void setIdleTimeout(int secs);
 // Current applied values.
 int      idleTimeoutSecs();   // for the web settings UI selects
 uint32_t idleTimeoutMs();     // for the main loop's sleep deadline check
+
+// No-screensaver mode. When true: Sleep::enter() skips drawSleepScreen() so
+// the last page stays visible on the e-ink panel, and setup() skips the
+// boot-time display.clear() when waking from deep sleep so the panel is not
+// blanked before the page is redrawn in fast mode.
+bool noScreensaver();
+void setNoScreensaver(bool val);
 
 // Enter deep sleep right now. Notifies the active screen, draws the sleep
 // image, releases peripherals, then `esp_deep_sleep_start`s.

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -61,6 +61,16 @@ static void handleSettings() {
     "<option value='3'"; out += lg3; out += ">" D_WEB_LINE_SPACING_3 "</option>"
     "</select><div class='hint'>" D_WEB_LINE_SPACING_HINT "</div></div>"
     "</div>"
+    "<div style='margin-top:14px'>"
+    "<label style='display:flex;align-items:center;gap:8px;font-weight:600;cursor:pointer'>"
+    "<input type='checkbox' name='noscr' id='noscr' style='width:auto'";
+  if (Sleep::noScreensaver()) out += " checked";
+  out +=
+    "><span>" D_WEB_NO_SCREENSAVER_LABEL "</span></label>"
+    "<div class='hint'>" D_WEB_NO_SCREENSAVER_HINT "</div></div>"
+    // Hidden sentinel — lets handleSettingsPost() distinguish an explicit
+    // unchecked state from a POST that didn't come from the settings form.
+    "<input type='hidden' name='noscr_form' value='1'>"
     "<div class='actions' style='margin-top:24px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button><span class='muted'>" D_WEB_SETTINGS_NO_EXTRAS "</span></div>"
     "</form></div>"
     "<div class='card'><h2>" D_WEB_SCREENSAVER_HEADING "</h2>"
@@ -97,6 +107,13 @@ static void handleSettingsPost() {
   if (server.hasArg("lgap")) {
     int lg = server.arg("lgap").toInt();
     if (lg != Font::currentLineGap()) Font::setLineGap(lg);
+  }
+  // noscr_form is a hidden sentinel always present when the settings form is
+  // submitted, which lets us distinguish an explicit unchecked checkbox from a
+  // POST that didn't come from the settings form at all.
+  if (server.hasArg("noscr_form")) {
+    bool ns = server.hasArg("noscr");
+    if (ns != Sleep::noScreensaver()) Sleep::setNoScreensaver(ns);
   }
   // On-disk page caches are layout-stamped and self-invalidate on load, so
   // a font/lineGap change needs no cross-cutting cleanup here.


### PR DESCRIPTION
Adds a **No-screensaver mode** checkbox in Settings → Reading (NVS key \`cfg_noscr\`, default \`false\`).

## Behaviour when enabled

- The device still goes to sleep on the normal idle timer — nothing changes there.
- **Only applies when reading a book.** If the user falls asleep in the library or a menu, the screensaver is shown as normal.
- **When going to sleep from the reader:** the screensaver image is skipped. Instead, \`display.fastmodeOff() + display.update()\` flushes the reader's framebuffer with a full refresh, so the last page sits cleanly on the panel before power-down.
- **On wake from deep sleep:** \`setup()\` skips \`display.clear()\` so the panel is not blanked before the fast-mode redraw of the restored page. The user can continue reading with a single button click, without the interruption of a full display refresh.

The wake-side skip is gated on all three: woke-from-sleep AND no-screensaver enabled AND \`wake_path\` is set (i.e. we were reading). \`wake_path\` is written by \`armResumeOnWake()\` inside \`ReaderScreen::onSleep()\`, which runs before the sleep-image decision — so it doubles as a zero-coupling "was in reader" signal in both \`Sleep::enter()\` and \`setup()\`.

## Implementation notes

- Hidden \`noscr_form\` sentinel in the settings form body: lets \`handleSettingsPost()\` distinguish an explicit unchecked checkbox from an unrelated POST.
- \`Sleep::noScreensaver()\` / \`Sleep::setNoScreensaver()\` follow the same ownership pattern as the existing \`idleTimeoutSecs\` / \`setIdleTimeout\` pair — setting + NVS key are file-private to \`sleep.cpp\`.

## Files changed

| File | What changed |
|------|-------------|
| \`src/ui/sleep.cpp\` | \`s_noScreensaver\` flag; in \`enter()\`, checks \`wake_path\` to skip screensaver only from reader; does full refresh with page content instead |
| \`src/ui/sleep.h\` | Expose \`noScreensaver()\` / \`setNoScreensaver()\` |
| \`src/web/settings.cpp\` | No-screensaver checkbox + POST sentinel handling |
| \`src/lang/en.h\` | \`D_WEB_NO_SCREENSAVER_LABEL\` / \`D_WEB_NO_SCREENSAVER_HINT\` |
| \`src/lang/es_la.h\` | Same strings in Spanish |
| \`Pala_One_2_1.ino\` | Move \`prefs.begin()\` + \`Sleep::loadSettings()\` before \`display.clear()\`; gate \`display.clear()\` on wake cause + flag + \`wake_path\` |