### PR TITLE
Add GitHub Pages web installer + release workflow

### DIFF
--- a/.github/workflows/deploy-installer.yml
+++ b/.github/workflows/deploy-installer.yml
@@ -1,0 +1,94 @@
+name: Deploy installer page
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+            ~/.platformio/platforms
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+
+      - name: Install PlatformIO and esptool
+        run: pip install --upgrade platformio esptool
+
+      - name: Build firmware (V1.2)
+        env:
+          # Tag pushes build a clean release (no git hash in UI). Anything
+          # else (workflow_dispatch) keeps DEBUG_BUILD=1 from config.h so the
+          # hash stays visible during iteration.
+          PLATFORMIO_BUILD_FLAGS: ${{ startsWith(github.ref, 'refs/tags/') && '-DDEBUG_BUILD=0' || '' }}
+        run: pio run -e wireless-paper-v1_2
+
+      - name: Build firmware (V1.1)
+        env:
+          PLATFORMIO_BUILD_FLAGS: ${{ startsWith(github.ref, 'refs/tags/') && '-DDEBUG_BUILD=0' || '' }}
+        run: pio run -e wireless-paper-v1_1
+
+      - name: Assemble site
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          cp install/index.html site/
+
+          # bootloader / partitions / boot_app0 are byte-identical between the
+          # two envs (same chip, same partition table). Take them from the V1.2
+          # build dir; the V1.1 build produces the same bytes.
+          V12=.pio/build/wireless-paper-v1_2
+          V11=.pio/build/wireless-paper-v1_1
+          BOOT_APP0=$(find ~/.platformio/packages/framework-arduinoespressif32/tools/partitions -name boot_app0.bin | head -n1)
+
+          cp "$V12/bootloader.bin" site/bootloader.bin
+          cp "$V12/partitions.bin" site/partitions.bin
+          cp "$BOOT_APP0"          site/boot_app0.bin
+          cp "$V12/firmware.bin"   site/firmware-v1_2.bin
+          cp "$V11/firmware.bin"   site/firmware-v1_1.bin
+
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+          else
+            VERSION="dev-${GITHUB_SHA::7}"
+          fi
+          jq --arg v "$VERSION" '.version = $v' install/manifest-v1_2.json > site/manifest-v1_2.json
+          jq --arg v "$VERSION" '.version = $v' install/manifest-v1_1.json > site/manifest-v1_1.json
+
+          ls -lh site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Pala_One_2_1/src/config.h
+++ b/Pala_One_2_1/src/config.h
@@ -20,7 +20,7 @@
 
 #include "src/pure/arduino_compat.h"
 
-#define FW_VERSION "2.1c"
+#define FW_VERSION "2.1d"
 
 // BUILD_GIT_HASH is injected by scripts/build_info.py at PlatformIO build
 // time. Host-test builds skip that script, so provide a fallback so the

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Pala One — A tiny E-Ink reader project by Paul Lagier
 
 The goal of the project was to create a simple, distraction-free reading device that feels minimal, portable and easy to build while still looking and behaving more like a real product than a typical DIY electronics project.
 
+## Install (no toolchain needed)
+
+[Web Installer](https://gnatpat.github.io/pala-one-firmware/)
+
+The easiest way to flash a board is via the web installer. Plug your Heltec Wireless Paper into a desktop computer running Chrome, Edge, or Opera, then open the installer page and click **Install** for your display revision (V1.1 or V1.2).
+
+The installer keeps existing reading progress, bookmarks, and uploaded books across re-flashes.
+
 ## Contributing
 
 If you improve the firmware, add features or fix bugs, feel free to open a pull request.
@@ -74,6 +82,7 @@ docs/                    # Architecture notes + refactor journal
 scripts/                 # PlatformIO pre-build helpers
 test/                    # Host-side CMake unit tests for pure/ + storage/
 examples/                # Sample apps (click_counter, palagotchi)
+install/                 # ESP Web Tools installer page (deployed to GitHub Pages by CI)
 archive/                 # Past firmware revisions, kept for reference
 ```
 

--- a/install/index.html
+++ b/install/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pala One Installer</title>
+  <script
+    type="module"
+    src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
+  ></script>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 640px;
+      margin: 4rem auto;
+      padding: 0 1.5rem;
+      line-height: 1.5;
+    }
+    h1 { margin-bottom: 0.25rem; }
+    .sub { color: #666; margin-top: 0; }
+    .variant {
+      border: 1px solid rgba(127,127,127,0.3);
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin: 1rem 0;
+    }
+    .variant h3 { margin: 0 0 0.25rem; }
+    .variant p { margin: 0.25rem 0 0.75rem; color: #666; }
+    .note {
+      background: #fff8c5;
+      border: 1px solid #e6dba0;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      font-size: 0.95rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .note { background: #2a2a1a; border-color: #5a5a3a; }
+      .variant p { color: #aaa; }
+    }
+    code {
+      background: rgba(127,127,127,0.15);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    ol li { margin: 0.4rem 0; }
+  </style>
+</head>
+<body>
+  <h1>Pala One Installer</h1>
+  <p class="sub">Flash the firmware directly from your browser.</p>
+
+  <div class="variant">
+    <h3>V1.2 board</h3>
+    <p>Newer Heltec Wireless Paper. If your board's silkscreen says <code>V1.2</code>, pick this.</p>
+    <esp-web-install-button manifest="manifest-v1_2.json">
+      <button slot="activate">Install V1.2</button>
+      <span slot="unsupported">
+        Your browser doesn't support Web Serial. Use desktop Chrome, Edge, or Opera.
+      </span>
+      <span slot="not-allowed">Open this page over HTTPS.</span>
+    </esp-web-install-button>
+  </div>
+
+  <div class="variant">
+    <h3>V1.1 board</h3>
+    <p>Older revision of the Heltec Wireless Paper.</p>
+    <esp-web-install-button manifest="manifest-v1_1.json">
+      <button slot="activate">Install V1.1</button>
+      <span slot="unsupported">
+        Your browser doesn't support Web Serial. Use desktop Chrome, Edge, or Opera.
+      </span>
+      <span slot="not-allowed">Open this page over HTTPS.</span>
+    </esp-web-install-button>
+  </div>
+
+  <h2>Before you click install</h2>
+  <ol>
+    <li>Use a desktop browser: <strong>Chrome, Edge, or Opera</strong>. Safari, Firefox, and mobile browsers won't work.</li>
+    <li>Plug the board into your computer with a USB-C cable that supports data (not power-only).</li>
+    <li>Click the install button for your board, pick the serial port, then choose <strong>Install</strong>.</li>
+  </ol>
+
+  <p class="note">
+    Not sure which version you have? Flashing the wrong one won't brick the board — the e-ink panel just won't draw correctly. Try the other variant if the screen looks wrong after the first boot.
+  </p>
+</body>
+</html>

--- a/install/manifest-v1_1.json
+++ b/install/manifest-v1_1.json
@@ -1,0 +1,16 @@
+{
+  "name": "Pala One (V1.1 display)",
+  "version": "dev",
+  "new_install_skip_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        { "path": "bootloader.bin",    "offset": 0 },
+        { "path": "partitions.bin",    "offset": 32768 },
+        { "path": "boot_app0.bin",     "offset": 57344 },
+        { "path": "firmware-v1_1.bin", "offset": 65536 }
+      ]
+    }
+  ]
+}

--- a/install/manifest-v1_2.json
+++ b/install/manifest-v1_2.json
@@ -1,0 +1,16 @@
+{
+  "name": "Pala One (V1.2 display)",
+  "version": "dev",
+  "new_install_skip_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        { "path": "bootloader.bin",    "offset": 0 },
+        { "path": "partitions.bin",    "offset": 32768 },
+        { "path": "boot_app0.bin",     "offset": 57344 },
+        { "path": "firmware-v1_2.bin", "offset": 65536 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Pushing a v* tag triggers a clean build (DEBUG_BUILD=0) of both V1.1 and V1.2 envs, assembles an esp-web-tools site, and deploys to Pages. workflow_dispatch keeps DEBUG_BUILD on so the git hash stays visible during iteration.