### PR TITLE
Fix/upload streaming caps

### DIFF
--- a/Pala_One_2_1/src/web/screensavers.cpp
+++ b/Pala_One_2_1/src/web/screensavers.cpp
@@ -239,7 +239,13 @@ static void handleScreensaverUploadStream() {
         s_up.error = "Image file is too large";
         return;
       }
-      s_up.tmpFile.write(up.buf, up.currentSize);
+      size_t wrote = s_up.tmpFile.write(up.buf, up.currentSize);
+      if (wrote != up.currentSize) {
+        s_up.tmpFile.close();
+        if (FS.exists(s_up.tmpPath)) FS.remove(s_up.tmpPath);
+        s_up.error = "Write failed (disk full?)";
+        return;
+      }
     }
   }
   else if (up.status == UPLOAD_FILE_END) {

--- a/Pala_One_2_1/src/web/screensavers.cpp
+++ b/Pala_One_2_1/src/web/screensavers.cpp
@@ -231,7 +231,16 @@ static void handleScreensaverUploadStream() {
     if (!s_up.tmpFile) s_up.error = "Cannot create temp file";
   }
   else if (up.status == UPLOAD_FILE_WRITE) {
-    if (s_up.tmpFile) s_up.tmpFile.write(up.buf, up.currentSize);
+    if (s_up.error.length() > 0) return;
+    if (s_up.tmpFile && up.currentSize > 0) {
+      if (s_up.tmpFile.size() + up.currentSize > 8192) {
+        s_up.tmpFile.close();
+        if (FS.exists(s_up.tmpPath)) FS.remove(s_up.tmpPath);
+        s_up.error = "Image file is too large";
+        return;
+      }
+      s_up.tmpFile.write(up.buf, up.currentSize);
+    }
   }
   else if (up.status == UPLOAD_FILE_END) {
     if (s_up.tmpFile) s_up.tmpFile.close();

--- a/Pala_One_2_1/src/web/upload.cpp
+++ b/Pala_One_2_1/src/web/upload.cpp
@@ -20,6 +20,7 @@ struct BookUpload {
   String finalName;
   bool   ok = false;
   String error;
+  size_t maxBytes = 0;
   // Cross-chunk state for streaming compactText() during upload, so a
   // whitespace or newline run that spans a chunk boundary collapses
   // correctly. Reset in UPLOAD_FILE_START. See pure/text_util.h.
@@ -120,6 +121,7 @@ static void handleUploadBookStream() {
       s_book.error = D_WEB_ERR_NOT_ENOUGH_SPACE;
       return;
     }
+    s_book.maxBytes = freeBytes;
 
     String clean = sanitizeUploadedFilename(up.filename);
     s_book.finalName = clean;
@@ -135,6 +137,12 @@ static void handleUploadBookStream() {
   else if (up.status == UPLOAD_FILE_WRITE) {
     if (s_book.error.length() > 0) return;
     if (s_book.tmpFile && up.currentSize > 0) {
+      if (s_book.tmpFile.size() + up.currentSize > s_book.maxBytes) {
+        s_book.error = D_WEB_ERR_WRITE_FAILED;
+        s_book.tmpFile.close();
+        if (s_book.tmpPath.length() > 0 && FS.exists(s_book.tmpPath)) FS.remove(s_book.tmpPath);
+        return;
+      }
       String chunk = s_book.pendingUtf8Tail + String((const char*)up.buf, up.currentSize);
       int len = (int)chunk.length();
       if (len > 4) {
@@ -258,7 +266,16 @@ static void handleUploadSleepStream() {
     if (!s_sleep.tmpFile) s_sleep.error = D_WEB_SLEEP_ERR_TEMP;
   }
   else if (upS.status == UPLOAD_FILE_WRITE) {
-    if (s_sleep.tmpFile) s_sleep.tmpFile.write(upS.buf, upS.currentSize);
+    if (s_sleep.error.length() > 0) return;
+    if (s_sleep.tmpFile && upS.currentSize > 0) {
+      if (s_sleep.tmpFile.size() + upS.currentSize > 8192) {
+        s_sleep.tmpFile.close();
+        if (FS.exists(s_sleep.tmpPath)) FS.remove(s_sleep.tmpPath);
+        s_sleep.error = D_WEB_SLEEP_ERR_SIZE;
+        return;
+      }
+      s_sleep.tmpFile.write(upS.buf, upS.currentSize);
+    }
   }
   else if (upS.status == UPLOAD_FILE_END) {
     if (s_sleep.tmpFile) s_sleep.tmpFile.close();

--- a/Pala_One_2_1/src/web/upload.cpp
+++ b/Pala_One_2_1/src/web/upload.cpp
@@ -274,7 +274,13 @@ static void handleUploadSleepStream() {
         s_sleep.error = D_WEB_SLEEP_ERR_SIZE;
         return;
       }
-      s_sleep.tmpFile.write(upS.buf, upS.currentSize);
+      size_t wrote = s_sleep.tmpFile.write(upS.buf, upS.currentSize);
+      if (wrote != upS.currentSize) {
+        s_sleep.tmpFile.close();
+        if (FS.exists(s_sleep.tmpPath)) FS.remove(s_sleep.tmpPath);
+        s_sleep.error = D_WEB_SLEEP_ERR_SAVE;
+        return;
+      }
     }
   }
   else if (upS.status == UPLOAD_FILE_END) {


### PR DESCRIPTION
## Summary

- Add streaming size caps to the three upload handlers that lacked them, matching the pattern already used by the app upload handler
- Sleep image upload: hard cap at 8 KB (image is exactly 3904 bytes)
- Screensaver upload: hard cap at 8 KB (same image format)
- Book upload: cap at available free space captured when the upload starts
- Check `write()` return value in sleep and screensaver upload handlers, aborting with cleanup on short write (matching the existing book upload pattern)

The app upload handler (`apps_upload.cpp`) already enforces a cumulative size cap during `UPLOAD_FILE_WRITE` that aborts early if the file exceeds `MAX_APP_BINARY`. The sleep, screensaver, and book upload handlers only checked size at `UPLOAD_FILE_END`, allowing a client to stream arbitrarily large data to the temp file during transfer. This could fill the LittleFS partition and block other filesystem operations until the transfer completes and the oversized temp file is deleted.

The fix aborts the upload during streaming as soon as the cumulative size exceeds the cap, immediately cleaning up the temp file. Additionally, the sleep and screensaver handlers now detect short writes (e.g. filesystem full mid-transfer) and abort cleanly instead of silently producing corrupt temp files.

## Test plan

- [x] Verify the fix compiles for both V1.1 and V1.2 targets
- [x] Upload a normal book via the web UI -- should work unchanged
- [x] Upload a sleep image via the web UI -- should work unchanged
- [x] Upload a screensaver image via the web UI -- should work unchanged
- [ ] (Optional) Attempt uploading an oversized file to each endpoint to verify the cap triggers and the error is reported cleanly