### PR TITLE
fix: use wrap-safe millis comparison in resetInputFrontend

### DIFF
--- a/Pala_One_2_1/src/hal/input.cpp
+++ b/Pala_One_2_1/src/hal/input.cpp
@@ -414,8 +414,8 @@ void resetInputFrontend() {
   // from leaking into the new mode as an accidental action.
   // We do NOT clear the whole ISR queue — any presses that arrive AFTER
   // release are intentional and should be processed normally.
-  uint32_t deadline = millis() + 600; // safety timeout
-  while (digitalRead(BTN) == LOW && (uint32_t)(millis()) < deadline) delay(1);
+  uint32_t start = millis();
+  while (digitalRead(BTN) == LOW && (uint32_t)(millis() - start) < 600) delay(1);
   delay(DEBOUNCE_MS + 2); // minimal debounce after release
 
   // Discard only events that happened BEFORE this moment (the transition press).


### PR DESCRIPTION
## Summary

- Use wrap-safe subtraction for the millis() safety timeout in `resetInputFrontend()`, preventing incorrect behavior if the 32-bit counter wraps at ~49.7 days of continuous uptime

The original code computed `deadline = millis() + 600` and compared `millis() < deadline`. If `millis()` is near `UINT32_MAX`, `deadline` wraps to near 0 and the comparison is immediately false, skipping the button-release wait entirely. The subtraction form `(millis() - start) < 600` handles wraparound correctly because unsigned subtraction wraps naturally.

In practice this is nearly impossible to trigger on the Pala One since deep sleep resets the millis counter, but the fix is a trivial two-line change with zero behavioral impact in normal operation.

## Test plan

- [x] Verify the fix compiles for both V1.1 and V1.2 targets (`pio run -e wireless-paper-v1_1-en && pio run -e wireless-paper-v1_2-en`)
- [x] Test screen transitions (library -> reader -> upload -> about) still debounce correctly with no phantom button events leaking through