### PR TITLE
settings: user-configurable library header title

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -102,6 +102,7 @@
 #include "src/ui/screens/reader_screen.h"
 #include "src/ui/screens/statistics_screen.h"
 #include "src/ui/screens/upload_screen.h"
+#include "src/ui/header_title.h"
 #include "src/ui/lock.h"
 #include "src/ui/screensavers.h"
 #include "src/ui/sleep.h"
@@ -194,6 +195,7 @@ void setup() {
   Screensavers::loadSettings();
   Statusbar::loadSettings();
   Gestures::loadSettings();
+  HeaderTitle::loadSettings();
   // Sleep::loadSettings() and Lock::loadSettings() already ran earlier in
   // setup() so both flags were available for the boot-clear gate above —
   // don't reload them here.

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -308,6 +308,13 @@
 #define D_WEB_BUTTONS_ACTION_LOCK     "Lock device"
 #define D_WEB_BUTTONS_ACTION_MENU     "Open menu"
 
+// Device personalization card (src/web/settings.cpp).
+#define D_WEB_DEVICE_HEADING        "Device"
+#define D_WEB_DEVICE_INTRO          "Personalize the device name shown on the library screen header."
+#define D_WEB_HEADER_TITLE_LABEL    "Header title"
+#define D_WEB_HEADER_TITLE_HINT     "Shown at the top of the library screen. Leave empty for no title."
+#define D_WEB_HEADER_TITLE_RESET    "Reset to default"
+
 // ----------------------------------------------------------------------------
 //  Upload (book + sleep image) routes (src/web/upload.cpp)
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -302,6 +302,13 @@
 #define D_WEB_BUTTONS_ACTION_LOCK     "Bloquear dispositivo"
 #define D_WEB_BUTTONS_ACTION_MENU     "Abrir menú"
 
+// Device personalization card (src/web/settings.cpp).
+#define D_WEB_DEVICE_HEADING        "Dispositivo"
+#define D_WEB_DEVICE_INTRO          "Personaliza el nombre que aparece en el encabezado de la biblioteca."
+#define D_WEB_HEADER_TITLE_LABEL    "Título del encabezado"
+#define D_WEB_HEADER_TITLE_HINT     "Se muestra arriba de la pantalla de biblioteca. Deja vacío para ocultarlo."
+#define D_WEB_HEADER_TITLE_RESET    "Restaurar predeterminado"
+
 // ----------------------------------------------------------------------------
 //  Upload routes
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/ui/header_title.cpp
+++ b/Pala_One_2_1/src/ui/header_title.cpp
@@ -1,0 +1,49 @@
+#include "src/ui/header_title.h"
+
+#include "src/config.h"
+#include "src/state.h"
+
+namespace HeaderTitle {
+
+static constexpr int kMaxLen = 31;
+static constexpr const char* kNvsKey = "cfg_hdr_title";
+
+static char s_title[kMaxLen + 1] = "";
+static bool s_custom = false;
+
+void loadSettings() {
+  if (prefs.isKey(kNvsKey)) {
+    s_custom = true;
+    String val = prefs.getString(kNvsKey, "");
+    strncpy(s_title, val.c_str(), kMaxLen);
+    s_title[kMaxLen] = '\0';
+  } else {
+    s_custom = false;
+    strncpy(s_title, LIB_HEADER_TITLE, kMaxLen);
+    s_title[kMaxLen] = '\0';
+  }
+}
+
+const char* current() {
+  return s_title;
+}
+
+void set(const char* title) {
+  if (title == nullptr) {
+    resetToDefault();
+    return;
+  }
+  s_custom = true;
+  strncpy(s_title, title, kMaxLen);
+  s_title[kMaxLen] = '\0';
+  prefs.putString(kNvsKey, s_title);
+}
+
+void resetToDefault() {
+  s_custom = false;
+  prefs.remove(kNvsKey);
+  strncpy(s_title, LIB_HEADER_TITLE, kMaxLen);
+  s_title[kMaxLen] = '\0';
+}
+
+}  // namespace HeaderTitle

--- a/Pala_One_2_1/src/ui/header_title.h
+++ b/Pala_One_2_1/src/ui/header_title.h
@@ -1,0 +1,21 @@
+#ifndef PALA_UI_HEADER_TITLE_H
+#define PALA_UI_HEADER_TITLE_H
+
+// ============================================================================
+//  HeaderTitle module — owns the user-configurable library screen header
+//  title (NVS key `cfg_hdr_title`, default: compile-time LIB_HEADER_TITLE,
+//  max 31 chars). An empty string means "show no header text."
+// ============================================================================
+namespace HeaderTitle {
+
+void loadSettings();
+
+const char* current();
+
+void set(const char* title);
+
+void resetToDefault();
+
+}  // namespace HeaderTitle
+
+#endif  // PALA_UI_HEADER_TITLE_H

--- a/Pala_One_2_1/src/ui/screens/library_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/library_screen.cpp
@@ -1,6 +1,7 @@
 #include "src/ui/screens/library_screen.h"
 
 #include "src/hal/display.h"
+#include "src/ui/header_title.h"
 #include "src/pure/library_nav.h"         // buildLibraryEntries
 #include "src/pure/paths.h"               // folderLeafLabel, bookLeafLabel
 #include "src/storage/library.h"
@@ -178,7 +179,7 @@ void LibraryScreen::draw() {
   if (s_cursor < 0) s_cursor = 0;
   if (s_cursor >= s_entryCount) s_cursor = max(0, s_entryCount - 1);
 
-  int y = drawSectionHeader(LIB_HEADER_TITLE);
+  int y = drawSectionHeader(HeaderTitle::current());
 
   drawScrollableList(y, s_entryCount, s_cursor,
     [&](int idx, int rowY, bool selected, int /*budget*/) {

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -7,11 +7,32 @@
 #include "src/storage/page_cache.h"       // deletePageCacheForBook
 #include "src/storage/preferences_store.h"
 #include "src/ui/font.h"
+#include "src/ui/header_title.h"
 #include "src/ui/reader.h"                // g_bookview, findPageForOffset, renderCurrentPage
 #include "src/ui/reader_actions.h"        // ButtonAction + Gestures
 #include "src/ui/screens/reader_screen.h" // g_readerScreen — active-reader check
 #include "src/ui/sleep.h"
 #include "src/web/chrome.h"
+
+// ----------------------------------------------------------------------------
+//  HTML escaping for user-supplied text rendered in attributes
+// ----------------------------------------------------------------------------
+static String htmlAttrEscape(const char* raw) {
+  String out;
+  out.reserve(strlen(raw) + 8);
+  while (*raw) {
+    switch (*raw) {
+      case '&':  out += "&amp;";  break;
+      case '"':  out += "&quot;"; break;
+      case '\'': out += "&#39;";  break;
+      case '<':  out += "&lt;";   break;
+      case '>':  out += "&gt;";   break;
+      default:   out += *raw;     break;
+    }
+    raw++;
+  }
+  return out;
+}
 
 // ----------------------------------------------------------------------------
 //  Helpers for the remappable-button section
@@ -79,7 +100,22 @@ static void handleSettings() {
     D_WEB_SETTINGS_SUBTITLE_PREFIX FW_VERSION D_WEB_SETTINGS_SUBTITLE_SUFFIX,
     "<a href='/'>" D_WEB_SETTINGS_BACK_NAV "</a>"
   );
-  out.reserve(out.length() + 4000);
+  out.reserve(out.length() + 4500);
+
+  // Device personalization card — separate form, no layout-remap interaction.
+  out += "<div class='card'><h2>" D_WEB_DEVICE_HEADING "</h2>";
+  out += "<p class='muted'>" D_WEB_DEVICE_INTRO "</p>";
+  out += "<form method='POST' action='/settings' accept-charset='UTF-8' style='margin-top:12px'>";
+  out += "<div><label for='hdr'>" D_WEB_HEADER_TITLE_LABEL "</label>";
+  out += "<input type='text' id='hdr' name='hdr' maxlength='31' value='";
+  out += htmlAttrEscape(HeaderTitle::current());
+  out += "' placeholder='" LIB_HEADER_TITLE "'>";
+  out += "<div class='hint'>" D_WEB_HEADER_TITLE_HINT "</div></div>";
+  out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
+  out += "<input type='checkbox' name='hdr_rst' value='1' style='width:auto'>";
+  out += "<span>" D_WEB_HEADER_TITLE_RESET "</span></label>";
+  out += "<div class='actions' style='margin-top:14px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button></div>";
+  out += "</form></div>";
 
   out +=
     "<div class='card'><h2>" D_WEB_READING_HEADING "</h2>"
@@ -229,6 +265,17 @@ static void handleSettingsPost() {
   if (server.hasArg("noscr_form")) {
     bool ns = server.hasArg("noscr");
     if (ns != Sleep::noScreensaver()) Sleep::setNoScreensaver(ns);
+  }
+
+  // Header title — its own form card.
+  if (server.hasArg("hdr")) {
+    if (server.hasArg("hdr_rst")) {
+      HeaderTitle::resetToDefault();
+    } else {
+      String hdr = server.arg("hdr");
+      hdr.trim();
+      HeaderTitle::set(hdr.c_str());
+    }
   }
 
   // Gesture bindings — `setAction*` clamp internally, but we still check


### PR DESCRIPTION
## Summary

Adds a "Device" card to the web settings page (`/settings`) that lets users set the library screen header to any string — including empty to hide it entirely. Persisted via NVS key `cfg_hdr_title`; defaults to the compile-time `LIB_HEADER_TITLE` when unset.

Closes issue #49

## Changes

- New `src/ui/header_title.{h,cpp}` module (mirrors `Sleep`/`Font` pattern): `loadSettings()` at boot, `current()` for the display, `set()`/`resetToDefault()` for the web handler
- Library screen reads `HeaderTitle::current()` instead of the `LIB_HEADER_TITLE` macro
- Web settings page gets a text input (max 31 chars) with a "Reset to default" checkbox, in its own form card so it doesn't trigger the reader layout-remap logic
- HTML attribute escaping on the rendered value to prevent XSS
- Both `en.h` and `es_la.h` lang strings added

## Notes

- `prefs.isKey()` distinguishes "never set" (use compile-time default) from "set to empty string" (show no title)
- 31-byte cap is a practical limit — bold Helvetica on a 250px-wide display fits ~22 chars after margins + battery indicator. Overflow clips at screen edge.
- Factory reset (`prefs.clear()`) naturally restores the default since the NVS key is removed

## Test plan

- [x] `pio run` all 4 leaf envs (v1_1-en, v1_1-es, v1_2-en, v1_2-es)
- [x] Host CMake tests pass (no `config.h` contamination)
- [x] Flash, enter upload mode, open `/settings`, set custom title → confirm library header changes
- [x] Set empty string → confirm header line disappears
- [x] Check "Reset to default" → confirm original title restored
