### PR TITLE
chore: minor cleanup — redundant branch, stale comments, missing swit…

### DIFF
--- a/Pala_One_2_1/src/pure/paths.cpp
+++ b/Pala_One_2_1/src/pure/paths.cpp
@@ -125,8 +125,6 @@ String sanitizeUploadedAppFilename(String fname) {
         (c >= '0' && c <= '9') ||
         c == '_' || c == '-') {
       clean += (char)c;
-    } else if (c == ' ') {
-      clean += '_';
     } else {
       clean += '_';
     }

--- a/Pala_One_2_1/src/ui/pala_api_impl.cpp
+++ b/Pala_One_2_1/src/ui/pala_api_impl.cpp
@@ -27,12 +27,14 @@ static PalaAPI s_palaAPI;
 // (the apps API v3 didn't define one); treated as "no event".
 static uint8_t toPalaCode(ButtonEvent::Kind k) {
   switch (k) {
-    case ButtonEvent::Short:  return PALA_CLICK;
-    case ButtonEvent::Double: return PALA_DOUBLE;
-    case ButtonEvent::Triple: return PALA_TRIPLE;
-    case ButtonEvent::Long:   return PALA_LONG;
-    case ButtonEvent::Quad:   return 0;  // no PALA_QUAD in v3
-    case ButtonEvent::None:   return 0;
+    case ButtonEvent::Short:     return PALA_CLICK;
+    case ButtonEvent::Double:    return PALA_DOUBLE;
+    case ButtonEvent::Triple:    return PALA_TRIPLE;
+    case ButtonEvent::Long:      return PALA_LONG;
+    case ButtonEvent::Quad:      return 0;  // no PALA_QUAD in v3
+    case ButtonEvent::VeryLong:  return 0;  // no PALA_VERYLONG in v3
+    case ButtonEvent::ClickHold: return 0;  // no PALA_CLICKHOLD in v3
+    case ButtonEvent::None:      return 0;
   }
   return 0;
 }

--- a/Pala_One_2_1/src/ui/pala_api_impl.h
+++ b/Pala_One_2_1/src/ui/pala_api_impl.h
@@ -15,9 +15,10 @@
 // (re-writes the same pointers).
 void initPalaAPI();
 
-// STAGE-5 STUB: log "would run X" without actually loading the binary.
-// Stage 6 replaces this with the real loader. Exposed so AppsScreen
-// (Stage 7) can wire its launch path against a stable name today.
+// Load and run the app binary at `path` via the native loader. Handles
+// error display (drawCenter + delay) before returning so the caller can
+// simply repaint its own screen. Exposed so AppsScreen can wire its
+// launch path against a stable name.
 void runApp(const char* path);
 
 #endif  // PALA_UI_PALA_API_IMPL_H

--- a/Pala_One_2_1/src/web/screensavers.cpp
+++ b/Pala_One_2_1/src/web/screensavers.cpp
@@ -403,9 +403,6 @@ static String screensaverActionsHtml(bool single, int slot) {
 // Build the slot grid HTML — one card per slot with thumbnail (when
 // populated) and a delete form. Appended into a containing card by the
 // editor handler.
-// Build the slot grid HTML — one card per slot with thumbnail (when
-// populated) and a delete form. Appended into a containing card by the
-// editor handler.
 static String slotGridHtml() {
   String out;
   out.reserve(2000);


### PR DESCRIPTION
## Summary

- Remove redundant `else if (c == ' ')` branch in `sanitizeUploadedAppFilename` that was identical to the `else` fallthrough (both emit `'_'`)
- Add explicit `VeryLong` and `ClickHold` cases to the `toPalaCode` switch in `pala_api_impl.cpp` — both return 0 since v3 API has no codes for them, but the missing cases trigger `-Wswitch` warnings
- Replace stale "STAGE-5 STUB" comment on `runApp()` in `pala_api_impl.h` — the function is the real loader, not a stub
- Remove duplicate 3-line comment block above `slotGridHtml()` in `screensavers.cpp`

Zero behavioral changes. All cosmetic/warning fixes.

## Test plan

- [x] Verify the fix compiles for both V1.1 and V1.2 targets (`pio run -e wireless-paper-v1_1-en && pio run -e wireless-paper-v1_2-en`)
- [x] Run host tests (`cmake -S test -B test/build && cmake --build test/build && ctest --test-dir test/build -C Release --output-on-failure`)
