### PR TITLE
Fix: Screen Lock

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -143,8 +143,13 @@ void setup() {
   // never made it into the queue. Seed the input state so the upcoming
   // release edge is classified as a real press, not silently dropped.
   // Required for "click-then-hold on wake" to form a single chord gesture.
+  // Pass 0 (not millis()) so the duration is measured from boot-start, giving
+  // the full boot time as credit toward the hold — the button press triggered
+  // the ext0 wakeup, so it was down before the MCU started. Using millis() here
+  // would subtract the ~200ms delay() above and incorrectly shorten the
+  // measured hold, causing a Long press to be misclassified as Short.
   if (digitalRead(BTN) == LOW) {
-    g_btns.seedPressOnWake(millis());
+    g_btns.seedPressOnWake(0);
   }
 
   u8g2.begin(gfx);
@@ -292,6 +297,10 @@ void loop() {
         markUserActivity();
         Toast::show(D_TOAST_UNLOCKED);
         // Full refresh to clear screensaver ghosting on unlock.
+        // forceNextRenderFull() overrides the reader's per-page fast-mode
+        // decision so renderCurrentPage() uses fastmodeOff regardless of
+        // pageTurnsSinceFull. display.fastmodeOff() covers non-reader screens.
+        forceNextRenderFull();
         display.fastmodeOff();
         g_currentScreen->draw();
         return;
@@ -305,7 +314,10 @@ void loop() {
         }
       }
       // Short locked-idle: re-sleep after 1500ms with no input.
-      if (ENABLE_DEEP_SLEEP && g_currentScreen->allowSleep() && userIdleMs() > 1500) {
+      // Don't sleep while the button is held — a Long-press unlock gesture
+      // fires on release, so sleeping mid-hold would swallow the gesture.
+      if (ENABLE_DEEP_SLEEP && g_currentScreen->allowSleep()
+          && userIdleMs() > 1500 && !g_btns.isPressed()) {
         Sleep::enter();
         return;
       }

--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -138,16 +138,10 @@ void setup() {
   pinMode(BTN, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(BTN), btnISR, CHANGE);
 
-  // If we just woke from deep sleep via ext0 and the button is still being
-  // held, the press started BEFORE the ISR was attached — its down-edge
-  // never made it into the queue. Seed the input state so the upcoming
-  // release edge is classified as a real press, not silently dropped.
-  // Required for "click-then-hold on wake" to form a single chord gesture.
-  // Pass 0 (not millis()) so the duration is measured from boot-start, giving
-  // the full boot time as credit toward the hold — the button press triggered
-  // the ext0 wakeup, so it was down before the MCU started. Using millis() here
-  // would subtract the ~200ms delay() above and incorrectly shorten the
-  // measured hold, causing a Long press to be misclassified as Short.
+  // Button held through ext0 wake: its down-edge predates the ISR, so seed
+  // the press state manually. Pass 0 (not millis()) to credit the full boot
+  // time; millis() ≈ 200 here (after delay(200)) would shorten the hold and
+  // misclassify a Long press as Short.
   if (digitalRead(BTN) == LOW) {
     g_btns.seedPressOnWake(0);
   }

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -20,6 +20,13 @@
 // the reader.
 BookView g_bookview;
 
+// One-shot flag: force the next renderCurrentPage() to do a full e-ink refresh
+// regardless of pageTurnsSinceFull. Set by forceNextRenderFull() (called from
+// the unlock path to clear screensaver ghosting).
+static bool s_forceNextFull = false;
+
+void forceNextRenderFull() { s_forceNextFull = true; }
+
 // Auto-save throttle bookkeeping. Private to this translation unit — only
 // the save-progress functions and `resetSaveThrottle` touch it, and only
 // the reader calls them on its hot path (preview never auto-saves).
@@ -273,7 +280,9 @@ void renderCurrentPage() {
 
   uint32_t start = g_bookview.pages.offsets[g_bookview.cursor.pageIndex];
 
-  bool doFull = (g_bookview.cursor.pageTurnsSinceFull >= FULL_REFRESH_EVERY_N_PAGES);
+  bool doFull = s_forceNextFull
+             || (g_bookview.cursor.pageTurnsSinceFull >= FULL_REFRESH_EVERY_N_PAGES);
+  s_forceNextFull = false;
   if (doFull) {
     display.fastmodeOff();
     g_bookview.cursor.pageTurnsSinceFull = 0;

--- a/Pala_One_2_1/src/ui/reader.h
+++ b/Pala_One_2_1/src/ui/reader.h
@@ -63,6 +63,7 @@ extern BookView g_bookview;
 
 bool openBookByIndex(int idx);
 void renderCurrentPage();
+void forceNextRenderFull();  // one-shot: next renderCurrentPage() does a full refresh
 
 // Cursor navigation. Both move the cursor and bump `pageTurnsSinceFull` on
 // a real page change; `advancePage` lazily paginates one ahead and clamps


### PR DESCRIPTION
## fix: Lock screen does not exit on Long press (closes #48)

### Problem

Three bugs combined to make the lock screen nearly impossible to exit with a Long press:

**1. `seedPressOnWake(millis())` underestimates hold duration**

`setup()` runs `delay(200)` before attaching the button ISR. By the time
`seedPressOnWake` is called, `millis()` is already ~202 ms. This value was stored
as `pressStart_`, so the measured hold duration was `release_time − 202 ms`.
A user holding for 900 ms total only got 698 ms counted — below `LONG_MS = 850 ms`
— so the gesture was misclassified as a Short click and silently absorbed as the
"wake press", making it look like nothing happened.

**2. Locked-idle timeout fires while button is held**

The 1500 ms re-sleep timer ran without checking whether the button was currently
pressed. If the timer expired mid-hold, the device entered deep sleep, the
Long-press release happened with no ISR running, and the gesture was lost entirely.
On the next ext0 wake the cycle repeated, causing the screen to blink (full refresh
from `drawSleepScreen`) while staying locked.

**3. Reader overrides `fastmodeOff()` before `display.update()`**

`renderCurrentPage()` always calls `display.fastmodeOn()` or `display.fastmodeOff()`
based on its own `pageTurnsSinceFull` counter (`FULL_REFRESH_EVERY_N_PAGES = 100`).
The unlock path set `display.fastmodeOff()` before `g_currentScreen->draw()`, but
the reader immediately overrode it with `fastmodeOn()` — so `display.update()` ran
in fast mode and screensaver ghosting remained visible, making the device appear
still locked.

### Fix

| File | Change |
|---|---|
| `Pala_One_2_1.ino` | `seedPressOnWake(0)` — measures hold from boot-start, giving full credit for time held before the MCU started |
| `Pala_One_2_1.ino` | `&& !g_btns.isPressed()` guard on the locked-idle sleep gate — mirrors the same pattern already used in `idleLightSleep()` |
| `reader.cpp` / `reader.h` | `forceNextRenderFull()` — one-shot flag consumed by `renderCurrentPage()`, forcing `fastmodeOff` regardless of `pageTurnsSinceFull` |
| `Pala_One_2_1.ino` | Unlock path calls `forceNextRenderFull()` before `g_currentScreen->draw()` |

### Testing

- [x] Tested on V1.1 / V1.2
- [x] Long press, VeryLong press, and ClickHold all unlock correctly
- [x] No ghosting remains after unlock from screensaver
- [x] Normal page-turn fast mode is unaffected (`s_forceNextFull` is one-shot)
