### PR TITLE
Reader menu fixes

### DIFF
--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -30,17 +30,18 @@ void forceNextRenderFull() { s_forceNextFull = true; }
 // Deferred-repagination flag. Set by `markPagesDirtyForLayoutChange` when a
 // mid-session layout change (currently only Statusbar mode cycling) has
 // invalidated the in-memory page offset table. Consumed at the top of
-// `prepareForRender` so the slow re-walk happens once, on the next reader
-// draw, rather than synchronously inside the setting cycle.
+// `prepareForRender` so the rebase happens once, on the next reader draw,
+// rather than inside the setting cycle.
 //
-// Why lazy: `repaginateForLayoutChange` may walk hundreds of pages forward
-// to relocate the current byte offset under the new layout. Doing that
-// inside `Statusbar::setMode` blocks the main loop for hundreds of ms while
-// the reader menu is open — short clicks queue up in the ISR buffer, the
-// classifier groups them into Double/Triple, and the menu closes from what
-// the user thought was a single cycle. Deferring to the next render moves
-// the wait to menu-close (where a slow redraw is already expected) and
-// keeps in-menu cycling responsive.
+// Two reasons to defer rather than rebase inside `Statusbar::setMode`:
+//   1. Batching — cycling Full -> Minimal -> Hidden marks dirty three times
+//      but only needs one rebase, on the eventual redraw.
+//   2. Decoupling — `setMode` stays a plain setting write with no reader /
+//      page-table coupling at call time; the reader owns the table and
+//      rebases on its own schedule.
+// (`repaginateForLayoutChange` is now O(1) — see its definition — so the old
+// "slow re-walk blocks the loop" hazard is gone, but deferral is still the
+// cleaner shape and keeps the menu's per-click feedback instant.)
 static bool s_pagesLayoutDirty = false;
 
 void markPagesDirtyForLayoutChange() { s_pagesLayoutDirty = true; }
@@ -378,28 +379,40 @@ bool retreatPage() {
 void repaginateForLayoutChange() {
   if (!g_bookview.book.isOpen()) return;
 
-  // Remember the byte offset of the current page so we can find the
-  // matching page under the new layout. Offsets are file-position-based
-  // and invariant under any layout change.
-  uint32_t savedOffset = 0;
-  if (g_bookview.cursor.pageIndex >= 0
-      && g_bookview.cursor.pageIndex < g_bookview.pages.count) {
-    savedOffset = g_bookview.pages.offsets[g_bookview.cursor.pageIndex];
+  // Fast rebase, NOT a full re-walk. A mid-session layout change (Statusbar
+  // mode cycling) shifts every page boundary, but the byte offset of the page
+  // we're *on* is layout-invariant — it's where the current page's first word
+  // sits in the file. Earlier versions relocated that offset by paginating the
+  // book from page 0 (reset table + findPageForOffset). Deep in a book that's
+  // hundreds of file reads + line layouts and blocks the loop for seconds:
+  // that was the menu-close freeze.
+  //
+  // Instead, keep the offsets we already have as back-history and just drop
+  // everything past the current page. The current page redraws from its
+  // unchanged offset (exactly correct under the new layout); pages ahead get
+  // recomputed under the new layout lazily by tryExtendPageTable as the reader
+  // advances. O(1), no file I/O here.
+  //
+  // Trade-off: the retained back-history offsets are still the *old* layout's
+  // boundaries, so paging back across the change point can show a slightly
+  // different break than a from-scratch paginate would. That's a one-boundary
+  // cosmetic nit versus a frozen UI, and the page *number* stays put — which
+  // is what users expect when toggling a display option mid-book.
+  if (g_bookview.pages.count < 1) {
+    g_bookview.pages.count = 1;
+    g_bookview.pages.offsets[0] = 0;
   }
+  int cur = g_bookview.cursor.pageIndex;
+  if (cur < 0) cur = 0;
+  if (cur >= g_bookview.pages.count) cur = g_bookview.pages.count - 1;
 
-  // Reset the in-memory table to the empty seed and let the disk cache
-  // populate it if it happens to be valid for the new layout. The cache
-  // file's layout stamp will mismatch in the actually-changed case and
-  // the load is a no-op; ensureOffsetsUpTo will rebuild on the next render.
-  g_bookview.pages.count = 1;
-  g_bookview.pages.offsets[0] = 0;
-  g_bookview.pages.eofReached = false;
-  loadPageOffsetCacheForBook(g_bookview.book.path(), g_bookview.book.size(),
-                             Font::layoutForCache(),
-                             g_bookview.pages);
-
-  g_bookview.cursor.pageIndex = findPageForOffset(savedOffset);
-  g_bookview.cursor.pageTurnsSinceFull = 0;
+  g_bookview.cursor.pageIndex = cur;
+  g_bookview.pages.count      = cur + 1;   // keep [0..cur], discard stale forward
+  g_bookview.pages.eofReached = false;     // forward re-extension may be needed
+  // NB: pageTurnsSinceFull is intentionally left alone. The screen layer forces
+  // a full e-ink refresh on menu close to clear the overlay; that decision is
+  // owned there, and zeroing the counter here would silently downgrade it to a
+  // partial refresh (ghosting the menu behind the page).
   resetSaveThrottle();
 }
 

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -27,6 +27,24 @@ static bool s_forceNextFull = false;
 
 void forceNextRenderFull() { s_forceNextFull = true; }
 
+// Deferred-repagination flag. Set by `markPagesDirtyForLayoutChange` when a
+// mid-session layout change (currently only Statusbar mode cycling) has
+// invalidated the in-memory page offset table. Consumed at the top of
+// `prepareForRender` so the slow re-walk happens once, on the next reader
+// draw, rather than synchronously inside the setting cycle.
+//
+// Why lazy: `repaginateForLayoutChange` may walk hundreds of pages forward
+// to relocate the current byte offset under the new layout. Doing that
+// inside `Statusbar::setMode` blocks the main loop for hundreds of ms while
+// the reader menu is open — short clicks queue up in the ISR buffer, the
+// classifier groups them into Double/Triple, and the menu closes from what
+// the user thought was a single cycle. Deferring to the next render moves
+// the wait to menu-close (where a slow redraw is already expected) and
+// keeps in-menu cycling responsive.
+static bool s_pagesLayoutDirty = false;
+
+void markPagesDirtyForLayoutChange() { s_pagesLayoutDirty = true; }
+
 // Auto-save throttle bookkeeping. Private to this translation unit — only
 // the save-progress functions and `resetSaveThrottle` touch it, and only
 // the reader calls them on its hot path (preview never auto-saves).
@@ -253,6 +271,13 @@ static void drawStatusBar(uint32_t startOffset) {
 // (modulo pageTurnsSinceFull, which is render-side bookkeeping).
 static bool prepareForRender() {
   if (g_bookview.book.size() == 0) return false;
+  // Consume any deferred layout-change repagination *before* extending the
+  // page table — otherwise `ensureOffsetsUpTo` would happily extend the
+  // stale table with new-layout offsets glued onto old-layout offsets.
+  if (s_pagesLayoutDirty) {
+    s_pagesLayoutDirty = false;
+    repaginateForLayoutChange();
+  }
   ensureOffsetsUpTo(g_bookview.cursor.pageIndex);
   if (g_bookview.pages.count <= 0) return false;
 

--- a/Pala_One_2_1/src/ui/reader.h
+++ b/Pala_One_2_1/src/ui/reader.h
@@ -100,11 +100,22 @@ void armResumeOnWake();    // arm: persist currently-open book for resume
 // differs), and re-finds the current page from the saved byte offset.
 // No-op if no book is open. Caller is responsible for the redraw.
 //
-// Called from `Statusbar::setMode`, which is the only path that can change
-// layout while the reader screen is active. Font size / line gap go through
-// the web /settings form — the user can't be in the reader at that moment,
-// and the next `openBookByIndex` rebuilds the table from scratch anyway.
+// Direct callers should be rare — the slow re-walk inside `findPageForOffset`
+// can block the loop for hundreds of ms on a large book. Mid-session callers
+// go through `markPagesDirtyForLayoutChange` instead so the work is deferred
+// to the next reader render (typically after the user closes whatever
+// settings UI triggered the change). Font size / line gap go through the
+// web /settings form — the user can't be in the reader at that moment, and
+// the next `openBookByIndex` rebuilds the table from scratch anyway.
 void repaginateForLayoutChange();
+
+// Mark the in-memory page offset table as stale because a layout-affecting
+// setting (currently: Statusbar mode) just changed. The actual rebuild
+// happens lazily on the next `renderCurrentPage` call, keeping the
+// triggering input handler responsive. No-op-safe if no book is open: the
+// flag is set unconditionally and consumed inside `prepareForRender`, which
+// already early-outs when the book is closed.
+void markPagesDirtyForLayoutChange();
 
 // ============================================================================
 //  View lifecycle — full reset of every piece of `g_bookview` (and the reader's

--- a/Pala_One_2_1/src/ui/reader.h
+++ b/Pala_One_2_1/src/ui/reader.h
@@ -95,18 +95,18 @@ void armResumeOnWake();    // arm: persist currently-open book for resume
 
 // Layout changed mid-session — the byte offsets in `g_bookview.pages` were
 // computed under the old layout and no longer map to page boundaries under
-// the new one. Resets the in-memory table, reloads the on-disk cache (which
-// is layout-fingerprinted and will be rejected if the layout actually
-// differs), and re-finds the current page from the saved byte offset.
+// the new one. The byte offset of the *current* page is layout-invariant,
+// though, so this keeps the existing offsets as back-history, truncates the
+// table at the current page, and lets pages ahead re-paginate lazily under
+// the new layout on the next advance. O(1) — no file I/O, no full re-walk.
 // No-op if no book is open. Caller is responsible for the redraw.
 //
-// Direct callers should be rare — the slow re-walk inside `findPageForOffset`
-// can block the loop for hundreds of ms on a large book. Mid-session callers
-// go through `markPagesDirtyForLayoutChange` instead so the work is deferred
-// to the next reader render (typically after the user closes whatever
-// settings UI triggered the change). Font size / line gap go through the
-// web /settings form — the user can't be in the reader at that moment, and
-// the next `openBookByIndex` rebuilds the table from scratch anyway.
+// Mid-session callers should still route through
+// `markPagesDirtyForLayoutChange` so multiple rapid changes (cycling the
+// Statusbar mode) collapse into a single rebase on the next render. Font
+// size / line gap go through the web /settings form — the user can't be in
+// the reader at that moment, and the next `openBookByIndex` rebuilds the
+// table from scratch anyway.
 void repaginateForLayoutChange();
 
 // Mark the in-memory page offset table as stale because a layout-affecting

--- a/Pala_One_2_1/src/ui/reader_menu.cpp
+++ b/Pala_One_2_1/src/ui/reader_menu.cpp
@@ -25,6 +25,11 @@ bool isActive() { return s_active; }
 
 void open() {
   s_active = true;
+  // First paint of the menu sits over whatever the reader last drew. Use a
+  // full refresh so reader text doesn't ghost through the partial-refresh
+  // overlay; subsequent in-menu redraws (statusbar cycles) go through
+  // prepareMenuFrame's normal fastmode path for snappy feedback.
+  forceNextMenuFrameFull();
   draw();
 }
 

--- a/Pala_One_2_1/src/ui/statusbar.cpp
+++ b/Pala_One_2_1/src/ui/statusbar.cpp
@@ -39,12 +39,10 @@ void setMode(Mode m) {
   // Layout's `maxLines` is computed from `SCREEN_H - reserveH()`, so a mode
   // change shifts pagination. Invalidate the font's layout-metrics cache
   // (cheap — recomputed on the next bodyLayout()) and mark the reader's
-  // in-memory page-offset table as stale so the next reader render rebuilds
-  // it. Synchronously repaginating here would block the caller (the reader
-  // menu's short-click handler) for hundreds of ms on a large book while
-  // `findPageForOffset` walks the file forward, queueing follow-up clicks
-  // in the ISR buffer that the classifier then groups into a Double — the
-  // menu would close from what the user thought was a single cycle.
+  // in-memory page-offset table as stale so the next reader render rebases
+  // it. Deferring (rather than rebasing here) keeps `setMode` a plain setting
+  // write and collapses rapid cycles into one rebase on the next render — see
+  // markPagesDirtyForLayoutChange / repaginateForLayoutChange in reader.cpp.
   Font::invalidateLayoutCache();
   markPagesDirtyForLayoutChange();
 }

--- a/Pala_One_2_1/src/ui/statusbar.cpp
+++ b/Pala_One_2_1/src/ui/statusbar.cpp
@@ -3,7 +3,7 @@
 #include "src/config.h"     // STATUS_H
 #include "src/state.h"      // prefs
 #include "src/ui/font.h"    // Font::invalidateLayoutCache
-#include "src/ui/reader.h"  // repaginateForLayoutChange
+#include "src/ui/reader.h"  // markPagesDirtyForLayoutChange
 
 namespace Statusbar {
 
@@ -38,10 +38,15 @@ void setMode(Mode m) {
   prefs.putInt(kKey, (int)s_mode);
   // Layout's `maxLines` is computed from `SCREEN_H - reserveH()`, so a mode
   // change shifts pagination. Invalidate the font's layout-metrics cache
-  // and the reader's in-memory page-offset table together — they would
-  // otherwise hold offsets computed under the old reserve.
+  // (cheap — recomputed on the next bodyLayout()) and mark the reader's
+  // in-memory page-offset table as stale so the next reader render rebuilds
+  // it. Synchronously repaginating here would block the caller (the reader
+  // menu's short-click handler) for hundreds of ms on a large book while
+  // `findPageForOffset` walks the file forward, queueing follow-up clicks
+  // in the ISR buffer that the classifier then groups into a Double — the
+  // menu would close from what the user thought was a single cycle.
   Font::invalidateLayoutCache();
-  repaginateForLayoutChange();
+  markPagesDirtyForLayoutChange();
 }
 
 void cycleMode() {

--- a/Pala_One_2_1/src/ui/widgets.cpp
+++ b/Pala_One_2_1/src/ui/widgets.cpp
@@ -11,8 +11,18 @@ static const int UI_HEADER_GAP = 6;
 // e-ink ghosting). File-private; nothing outside `prepareMenuFrame` reads it.
 static int s_menuDrawsSinceFull = 0;
 
+// One-shot override: when set, the next `prepareMenuFrame` does a full
+// refresh regardless of the counter. Set by `forceNextMenuFrameFull` at
+// transitions into a menu overlay so the underlying screen (typically the
+// reader page) doesn't ghost through a partial refresh.
+static bool s_forceMenuFrameFull = false;
+
+void forceNextMenuFrameFull() { s_forceMenuFrameFull = true; }
+
 void prepareMenuFrame() {
-  bool doFull = (s_menuDrawsSinceFull >= MENU_FULL_REFRESH_EVERY);
+  bool doFull = s_forceMenuFrameFull
+             || (s_menuDrawsSinceFull >= MENU_FULL_REFRESH_EVERY);
+  s_forceMenuFrameFull = false;
   if (doFull) {
     display.fastmodeOff();
     s_menuDrawsSinceFull = 0;

--- a/Pala_One_2_1/src/ui/widgets.h
+++ b/Pala_One_2_1/src/ui/widgets.h
@@ -21,6 +21,13 @@ void drawCenter(const char* a, const char* b = nullptr);
 // independently of the reader's full-refresh schedule.
 void prepareMenuFrame();
 
+// Force the *next* call to `prepareMenuFrame` to do a full refresh,
+// regardless of the periodic counter. Used at transitions into a menu
+// overlay where the previous screen (e.g. the reader page) would otherwise
+// ghost through a partial refresh. No-op if a full refresh would have
+// happened anyway.
+void forceNextMenuFrameFull();
+
 // Draw one row of a scrollable menu list. Text starts at
 // `UI_LIST_LEFT + extraIndent` on the given baseline; bold if selected.
 // Resets font to Body afterwards. Most callers pass no indent;


### PR DESCRIPTION
Issues #71 #63 

Reader menu (click-hold in a book) was unusable: clicks seemed to do nothing, the menu closed on its own, statusbar changes didn't show, and double-click-to-close froze the device.

Cause: changing the statusbar mode re-paginated the whole book on the click handler — seconds of blocked main loop. Queued clicks got misread as double/triple presses (menu self-closing); close itself froze.

Fix:

Defer repagination to the next render — in-menu clicks stay responsive.
Make repagination O(1): the current page's byte offset is layout-invariant, so keep existing offsets as back-history, truncate the table forward, and re-flow lazily. No book re-walk on close.
Force a full e-ink refresh on menu open/close so the overlay doesn't ghost.
Tested: flashed to Wireless Paper v1.2 — menu responsive, statusbar cycles with live feedback, double-click closes instantly even deep in a large book.