### PR TITLE
Lock default option in WebUI

### DIFF
--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -284,6 +284,8 @@
 #define D_WEB_LINE_SPACING_HINT     "A small change here can make text much easier to scan."
 #define D_WEB_NO_SCREENSAVER_LABEL  "No-screensaver mode"
 #define D_WEB_NO_SCREENSAVER_HINT   "Device still sleeps on the normal timer and refreshes the screen before going to sleep. Then it shows the last page of the book, and skips a full refresh on wake, so you can continue reading with a single click of the button without the interruption of a display refresh."
+#define D_WEB_LOCK_ON_SLEEP_LABEL   "Lock on sleep"
+#define D_WEB_LOCK_ON_SLEEP_HINT    "Automatically lock the device every time it goes to sleep. You will need to perform a long press to unlock on the next wake."
 #define D_WEB_SAVE_SETTINGS_BUTTON  "Save settings"
 #define D_WEB_SETTINGS_NO_EXTRAS    "No extra files, scripts, or fonts."
 #define D_WEB_SCREENSAVER_HEADING   "Screensaver"

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -278,6 +278,8 @@
 #define D_WEB_LINE_SPACING_HINT     "Un pequeño cambio aquí puede facilitar mucho la lectura."
 #define D_WEB_NO_SCREENSAVER_LABEL  "Modo sin salvapantallas"
 #define D_WEB_NO_SCREENSAVER_HINT   "El dispositivo sigue durmiéndose según el temporizador habitual y actualiza la pantalla antes de dormirse. Luego muestra la última página del libro y omite la actualización completa al despertar, para que puedas continuar leyendo con un solo clic sin la interrupción de un refresco de pantalla."
+#define D_WEB_LOCK_ON_SLEEP_LABEL   "Bloquear al dormir"
+#define D_WEB_LOCK_ON_SLEEP_HINT    "Bloquea el dispositivo automáticamente cada vez que se duerme. Necesitarás una pulsación larga para desbloquearlo al despertar."
 #define D_WEB_SAVE_SETTINGS_BUTTON  "Guardar ajustes"
 #define D_WEB_SETTINGS_NO_EXTRAS    "Sin archivos extra, scripts ni fuentes."
 #define D_WEB_SCREENSAVER_HEADING   "Salvapantallas"

--- a/Pala_One_2_1/src/ui/sleep.cpp
+++ b/Pala_One_2_1/src/ui/sleep.cpp
@@ -124,6 +124,12 @@ void enter() {
   // we were reading without coupling sleep.cpp to any screen type.
   bool wasReading = (prefs.getString("wake_path", "").length() > 0);
 
+  // Engage the lock BEFORE drawing so the badge gates (Lock::isLocked()) in
+  // both branches below see the new state. If we flipped it after the draw,
+  // the framebuffer flushed to the panel would render unlocked and the badge
+  // wouldn't appear until the next refresh (e.g. a button press on wake).
+  if (s_lockOnSleep) Lock::engage();
+
   if (s_noScreensaver && wasReading) {
     // Full refresh of the last page so it sits cleanly on the panel.
     // The reader's framebuffer content is still intact at this point.
@@ -138,8 +144,6 @@ void enter() {
     drawSleepScreen();
     delay(600);
   }
-
-  if (s_lockOnSleep) Lock::engage();
 
   WiFi.softAPdisconnect(true);
   WiFi.disconnect(true, true);

--- a/Pala_One_2_1/src/ui/sleep.cpp
+++ b/Pala_One_2_1/src/ui/sleep.cpp
@@ -22,8 +22,10 @@ namespace Sleep {
 // Owned settings + NVS keys — file-private.
 static int  s_idleSecs      = 120;
 static bool s_noScreensaver = false;
+static bool s_lockOnSleep   = false;
 static constexpr const char* kKeyIdleSecs      = "cfg_sleep";
 static constexpr const char* kKeyNoScreensaver = "cfg_noscr";
+static constexpr const char* kKeyLockOnSleep   = "cfg_lck_slp";
 
 void loadSettings() {
   int s = prefs.getInt(kKeyIdleSecs, 120);
@@ -31,6 +33,7 @@ void loadSettings() {
   if (s > 3600) s = 3600;
   s_idleSecs = s;
   s_noScreensaver = prefs.getBool(kKeyNoScreensaver, false);
+  s_lockOnSleep   = prefs.getBool(kKeyLockOnSleep,   false);
 }
 
 void setIdleTimeout(int secs) {
@@ -43,10 +46,16 @@ void setIdleTimeout(int secs) {
 int      idleTimeoutSecs() { return s_idleSecs; }
 uint32_t idleTimeoutMs()   { return (uint32_t)s_idleSecs * 1000UL; }
 bool     noScreensaver()   { return s_noScreensaver; }
+bool     lockOnSleep()     { return s_lockOnSleep; }
 
 void setNoScreensaver(bool val) {
   s_noScreensaver = val;
   prefs.putBool(kKeyNoScreensaver, val);
+}
+
+void setLockOnSleep(bool val) {
+  s_lockOnSleep = val;
+  prefs.putBool(kKeyLockOnSleep, val);
 }
 
 // Draw a padlock icon in the top-right corner so a user who has locked the
@@ -129,6 +138,8 @@ void enter() {
     drawSleepScreen();
     delay(600);
   }
+
+  if (s_lockOnSleep) Lock::engage();
 
   WiFi.softAPdisconnect(true);
   WiFi.disconnect(true, true);

--- a/Pala_One_2_1/src/ui/sleep.h
+++ b/Pala_One_2_1/src/ui/sleep.h
@@ -28,6 +28,11 @@ uint32_t idleTimeoutMs();     // for the main loop's sleep deadline check
 bool noScreensaver();
 void setNoScreensaver(bool val);
 
+// Lock-on-sleep mode. When true: Sleep::enter() engages the device lock
+// before entering deep sleep, so every sleep acts like a manual lock.
+bool lockOnSleep();
+void setLockOnSleep(bool val);
+
 // Enter deep sleep right now. Notifies the active screen, draws the sleep
 // image, releases peripherals, then `esp_deep_sleep_start`s.
 void enter();

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -11,6 +11,7 @@
 #include "src/ui/reader.h"                // g_bookview, findPageForOffset, renderCurrentPage
 #include "src/ui/reader_actions.h"        // ButtonAction + Gestures
 #include "src/ui/screens/reader_screen.h" // g_readerScreen — active-reader check
+#include "src/ui/lock.h"
 #include "src/ui/sleep.h"
 #include "src/web/chrome.h"
 
@@ -157,6 +158,13 @@ static void handleSettings() {
   out +=
     "><span>" D_WEB_NO_SCREENSAVER_LABEL "</span></label>"
     "<div class='hint'>" D_WEB_NO_SCREENSAVER_HINT "</div></div>"
+    "<div style='margin-top:10px'>"
+    "<label style='display:flex;align-items:center;gap:8px;font-weight:600;cursor:pointer'>"
+    "<input type='checkbox' name='lckslp' id='lckslp' style='width:auto'";
+  if (Sleep::lockOnSleep()) out += " checked";
+  out +=
+    "><span>" D_WEB_LOCK_ON_SLEEP_LABEL "</span></label>"
+    "<div class='hint'>" D_WEB_LOCK_ON_SLEEP_HINT "</div></div>"
     "<input type='hidden' name='noscr_form' value='1'>"
     "<div class='actions' style='margin-top:24px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button>"
     "<span class='muted'>" D_WEB_SETTINGS_APPLY_HINT "</span></div>"
@@ -265,6 +273,8 @@ static void handleSettingsPost() {
   if (server.hasArg("noscr_form")) {
     bool ns = server.hasArg("noscr");
     if (ns != Sleep::noScreensaver()) Sleep::setNoScreensaver(ns);
+    bool ls = server.hasArg("lckslp");
+    if (ls != Sleep::lockOnSleep()) Sleep::setLockOnSleep(ls);
   }
 
   // Header title — its own form card.


### PR DESCRIPTION
As sugested in #66 

- settings page: new checkbox "Lock on sleep" (form field lckslp)
- below "No-screensaver" toggle, same form card
- checked state read from Sleep::lockOnSleep(), persisted via Sleep::setLockOnSleep() on POST
- hint text: device auto-locks on sleep, long-press to unlock on wake
- new lang strings: D_WEB_LOCK_ON_SLEEP_LABEL, D_WEB_LOCK_ON_SLEEP_HINT (en + es_la)
- NVS key: cfg_lck_slp, default off

no other web routes touched. no styling/layout changes outside the new row.