### PR TITLE
Add Version Fix

### DIFF
--- a/.github/workflows/deploy-installer.yml
+++ b/.github/workflows/deploy-installer.yml
@@ -87,7 +87,9 @@ jobs:
             # workflow_dispatch republish without a tag — label by sha.
             VERSION="manual-${GITHUB_SHA::7}"
           else
-            VERSION="dev-${GITHUB_SHA::7}"
+            # Match build_info.py: both the manifest and the firmware derive
+            # their version from `git describe` so the OTA equality check works.
+            VERSION=$(git describe --tags --always)
           fi
 
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
  Fix: OTA always reporting update available on dev builds
  
  The dev channel manifest version was set to dev-<sha> in CI, while the
  firmware's FW_VERSION is derived from git describe (e.g.
  v2.1-169-gabcdef1). The simple string equality check in OTA::checkAvailable
  always saw them as different, so an update was perpetually reported.
  
  Fix: use git describe --tags --always in the workflow to generate the
  manifest version, matching exactly what build_info.py bakes into the
  firmware.
