### PR TITLE
fix: full refresh on unlock when waking from menu screen

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -298,8 +298,10 @@ void loop() {
         // Full refresh to clear screensaver ghosting on unlock.
         // forceNextRenderFull() overrides the reader's per-page fast-mode
         // decision so renderCurrentPage() uses fastmodeOff regardless of
-        // pageTurnsSinceFull. display.fastmodeOff() covers non-reader screens.
+        // pageTurnsSinceFull. forceNextMenuFrameFull() does the same for menu
+        // screens whose prepareMenuFrame() would otherwise override fastmodeOff.
         forceNextRenderFull();
+        forceNextMenuFrameFull();
         display.fastmodeOff();
         g_currentScreen->draw();
         return;


### PR DESCRIPTION
# fix: full refresh on unlock when waking from menu screen

## Problem

  When Auto Lock Screen is enabled and the device falls asleep from the main menu (or any other menu screen),
  unlocking does not clear the screensaver. The menu becomes interactive but the screensaver image remains visible on
  the display.
  
##  Root cause

  The unlock handler in loop() called forceNextRenderFull() and display.fastmodeOff() to ensure a clean full refresh
  after dismissing the screensaver. However, forceNextRenderFull() only affects the reader render path
  (renderCurrentPage()). For menu screens, the display mode is controlled by prepareMenuFrame() — which has its own
  independent one-shot flag (s_forceMenuFrameFull) and immediately overrides fastmodeOff with fastmodeOn when neither
  the flag nor the periodic counter is set.

  Result: the library (and all other menu screens) redrew in partial/fast mode, leaving the screensaver ghosted
  behind the menu content.

##  Fix

  Add forceNextMenuFrameFull() to the unlock handler alongside forceNextRenderFull(). This ensures prepareMenuFrame()
  uses full refresh on the next call, clearing screensaver ghosting regardless of which screen is active when the
  device unlocks.
  
  Affected screens

  All menu screens (library, list, apps, statistics, about, update, upload) when the device wakes from a
  lock-on-sleep deep sleep.

Closes #86 