### PR TITLE
Time Statistics Addition

### DIFF
--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -47,6 +47,16 @@
 #define D_STATS_LIFETIME_PAGES_FMT     "Pages turned: %llu"
 #define D_STATS_LIFETIME_PRESSES_FMT   "Button presses: %llu"
 
+// Reading-time page (page 2 of the statistics screen). %s is a duration
+// formatted by the screen (e.g. "1h 23m" or "45m").
+#define D_STATS_TIME_HEADING           "Reading time"
+#define D_STATS_TIME_TODAY_FMT         "Today: %s"
+#define D_STATS_TIME_WEEK_FMT          "Week:  %s"
+#define D_STATS_TIME_MONTH_FMT         "Month: %s"
+#define D_STATS_TIME_YEAR_FMT          "Year:  %s"
+#define D_STATS_TIME_AVG_FMT           "Avg/day: %s"
+#define D_STATS_BACK_HINT              "Click to go back"
+
 // ----------------------------------------------------------------------------
 //  List screen (src/ui/screens/list_screen.cpp)
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -55,7 +55,6 @@
 #define D_STATS_TIME_MONTH_FMT         "Month: %s"
 #define D_STATS_TIME_YEAR_FMT          "Year:  %s"
 #define D_STATS_TIME_AVG_FMT           "Avg/day: %s"
-#define D_STATS_BACK_HINT              "Click to go back"
 
 // ----------------------------------------------------------------------------
 //  List screen (src/ui/screens/list_screen.cpp)

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -48,6 +48,16 @@
 #define D_STATS_LIFETIME_PAGES_FMT     "Páginas leídas: %llu"
 #define D_STATS_LIFETIME_PRESSES_FMT   "Pulsaciones: %llu"
 
+// Reading-time page (page 2 of the statistics screen). %s is a duration
+// formatted by the screen (e.g. "1h 23m" or "45m").
+#define D_STATS_TIME_HEADING           "Tiempo de lectura"
+#define D_STATS_TIME_TODAY_FMT         "Hoy:    %s"
+#define D_STATS_TIME_WEEK_FMT          "Semana: %s"
+#define D_STATS_TIME_MONTH_FMT         "Mes:    %s"
+#define D_STATS_TIME_YEAR_FMT          "Año:    %s"
+#define D_STATS_TIME_AVG_FMT           "Prom/día: %s"
+#define D_STATS_BACK_HINT              "Clic para volver"
+
 // ----------------------------------------------------------------------------
 //  List screen
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -56,7 +56,6 @@
 #define D_STATS_TIME_MONTH_FMT         "Mes:    %s"
 #define D_STATS_TIME_YEAR_FMT          "Año:    %s"
 #define D_STATS_TIME_AVG_FMT           "Prom/día: %s"
-#define D_STATS_BACK_HINT              "Clic para volver"
 
 // ----------------------------------------------------------------------------
 //  List screen

--- a/Pala_One_2_1/src/pure/reading_time_log.cpp
+++ b/Pala_One_2_1/src/pure/reading_time_log.cpp
@@ -1,0 +1,39 @@
+#include "src/pure/reading_time_log.h"
+
+ReadingTimeFile applyReadingTime(const ReadingTimeFile& cur, uint32_t day, uint32_t seconds) {
+  ReadingTimeFile f = cur;
+  if (seconds == 0) return f;
+
+  uint32_t week  = day / RTIME_DAYS_PER_WEEK;
+  uint32_t month = day / RTIME_DAYS_PER_MONTH;
+  uint32_t year  = day / RTIME_DAYS_PER_YEAR;
+
+  // Roll over any bucket that has moved on since its last write.
+  if (f.dayIndex   != day)   { f.dayIndex   = day;   f.daySeconds   = 0; }
+  if (f.weekIndex  != week)  { f.weekIndex  = week;  f.weekSeconds  = 0; }
+  if (f.monthIndex != month) { f.monthIndex = month; f.monthSeconds = 0; }
+  if (f.yearIndex  != year)  { f.yearIndex  = year;  f.yearSeconds  = 0; }
+
+  f.daySeconds   += seconds;
+  f.weekSeconds  += seconds;
+  f.monthSeconds += seconds;
+  f.yearSeconds  += seconds;
+  f.totalSeconds += seconds;
+  return f;
+}
+
+ReadingTimeView viewReadingTime(const ReadingTimeFile& f, uint32_t curDay) {
+  ReadingTimeView v{};
+  v.total = f.totalSeconds;
+  v.today = (f.dayIndex   == curDay)                        ? f.daySeconds   : 0;
+  v.week  = (f.weekIndex  == curDay / RTIME_DAYS_PER_WEEK)  ? f.weekSeconds  : 0;
+  v.month = (f.monthIndex == curDay / RTIME_DAYS_PER_MONTH) ? f.monthSeconds : 0;
+  v.year  = (f.yearIndex  == curDay / RTIME_DAYS_PER_YEAR)  ? f.yearSeconds  : 0;
+
+  // curDay is 0-based, so the epoch day counts as 1 elapsed day.
+  uint32_t daysElapsed  = curDay + 1;
+  uint32_t weeksElapsed = curDay / RTIME_DAYS_PER_WEEK + 1;
+  v.avgPerDay  = (uint32_t)(f.totalSeconds / daysElapsed);
+  v.avgPerWeek = (uint32_t)(f.totalSeconds / weeksElapsed);
+  return v;
+}

--- a/Pala_One_2_1/src/pure/reading_time_log.h
+++ b/Pala_One_2_1/src/pure/reading_time_log.h
@@ -1,0 +1,66 @@
+#ifndef PALA_PURE_READING_TIME_LOG_H
+#define PALA_PURE_READING_TIME_LOG_H
+
+#include "src/pure/arduino_compat.h"  // uint32_t, uint64_t
+
+// ============================================================================
+//  Reading-time wire format + pure bucket-advance / view logic.
+//
+//  Mirrors the streak_log split: the day/week/month/year roll-over rules live
+//  here so they're host-testable without RTC, NVS, or the display. The
+//  firmware side (storage/statistics.cpp) keeps one of these structs in RTC
+//  RAM, feeds it capped per-page reading deltas via `applyReadingTime`, and
+//  flushes it to NVS on the same safety-net schedule as the lifetime counters.
+//
+//  "day" is a day index = (rtcSeconds - firstRtcSec) / 86400, identical to the
+//  reading-streak day index. Week/month/year are coarse fixed-length buckets
+//  derived from it (day/7, day/30, day/365) — not real calendar boundaries,
+//  matching the firmware's RTC-relative time model (no wall clock).
+// ============================================================================
+
+static const uint32_t RTIME_SCHEMA         = 1;
+static const uint32_t RTIME_DAYS_PER_WEEK   = 7;
+static const uint32_t RTIME_DAYS_PER_MONTH  = 30;
+static const uint32_t RTIME_DAYS_PER_YEAR   = 365;
+
+// Max seconds credited to a single page-turn gap. Longer gaps are treated as
+// "put the book down" (idle / overnight / first turn after deep-sleep wake)
+// and dropped entirely rather than clamped, so reading time never counts idle.
+static const uint32_t RTIME_GAP_CAP_SECS = 300;  // 5 min/page ceiling
+
+struct ReadingTimeFile {
+  uint32_t version;       // == RTIME_SCHEMA
+  uint32_t firstRtcSec;   // rtcSeconds() at first init — day-index epoch
+  uint64_t totalSeconds;  // lifetime reading seconds
+
+  uint32_t dayIndex;      uint32_t daySeconds;
+  uint32_t weekIndex;     uint32_t weekSeconds;
+  uint32_t monthIndex;    uint32_t monthSeconds;
+  uint32_t yearIndex;     uint32_t yearSeconds;
+};
+
+// Add `seconds` of reading logged on day index `day`. Pure — same inputs
+// always yield the same result. Each bucket whose index changed is reset to 0
+// before the add, so a stored bucket only ever holds the *current*
+// day/week/month/year total. `totalSeconds` always accumulates. `seconds == 0`
+// is a no-op (returns `cur` unchanged). version / firstRtcSec are preserved.
+ReadingTimeFile applyReadingTime(const ReadingTimeFile& cur, uint32_t day, uint32_t seconds);
+
+// Snapshot for display, given the *current* day index `curDay` (derived from
+// "now", not from the last logged day). A bucket whose stored index != the
+// current index reads as 0 — e.g. nothing read yet today, or the stored
+// daySeconds belongs to a day that has since rolled over. Averages divide the
+// lifetime total by elapsed buckets since the epoch (curDay+1 days, etc.), so
+// they answer "how much do you read per day/week on average".
+struct ReadingTimeView {
+  uint64_t total;
+  uint32_t today;
+  uint32_t week;
+  uint32_t month;
+  uint32_t year;
+  uint32_t avgPerDay;
+  uint32_t avgPerWeek;
+};
+ReadingTimeView viewReadingTime(const ReadingTimeFile& f, uint32_t curDay);
+
+#endif  // PALA_PURE_READING_TIME_LOG_H

--- a/Pala_One_2_1/src/storage/statistics.cpp
+++ b/Pala_One_2_1/src/storage/statistics.cpp
@@ -1,8 +1,9 @@
 #include "src/storage/statistics.h"
 
-#include "src/pure/streak_log.h"  // ReadingStreakFile + applyStreakLog
-#include "src/state.h"            // prefs
-#include "src/ui/toast.h"         // Toast::show
+#include "src/pure/streak_log.h"        // ReadingStreakFile + applyStreakLog
+#include "src/pure/reading_time_log.h"  // ReadingTimeFile + applyReadingTime
+#include "src/state.h"                  // prefs
+#include "src/ui/toast.h"               // Toast::show
 
 // esp_rtc_get_time_us lives in a chip-specific header; forward-declaring it
 // keeps this file building across chip variants. Same pattern as
@@ -16,9 +17,13 @@ extern "C" uint64_t esp_rtc_get_time_us(void);
 //    cfg_stats   blob — { uint32_t version; uint32_t firstRtcSec;
 //                         uint64_t pagesRead; uint64_t buttonPresses; }
 //    cfg_streak  blob — ReadingStreakFile (8 x uint32_t)
+//    cfg_rtime   blob — ReadingTimeFile (reading-time buckets + total)
 //
-//  RTC RAM: working lifetime counters (survive deep sleep, zero flash writes
-//  during normal use). Re-seeded from cfg_stats on cold boot.
+//  RTC RAM: working lifetime counters + reading-time buckets (survive deep
+//  sleep, zero flash writes during normal use). Re-seeded from cfg_stats /
+//  cfg_rtime on cold boot. Reading time is bucketed per page turn into RTC RAM
+//  and flushed on the same safety-net schedule as the lifetime counters, so
+//  frequent page turns never hit flash.
 //
 //  Plain RAM: streak threshold-gate cache (pagesToday + cachedLastDay) —
 //  reset on every cold boot, which restarts the 5-page threshold for the
@@ -28,6 +33,7 @@ extern "C" uint64_t esp_rtc_get_time_us(void);
 
 static constexpr const char* kKeyStats  = "cfg_stats";
 static constexpr const char* kKeyStreak = "cfg_streak";
+static constexpr const char* kKeyRtime  = "cfg_rtime";
 
 static const uint32_t STATS_SCHEMA            = 1;
 static const uint32_t STATS_FLUSH_EVERY_EVENTS = 100;
@@ -46,6 +52,14 @@ RTC_DATA_ATTR static uint32_t s_firstStatsRtcSec   = 0;
 RTC_DATA_ATTR static uint32_t s_eventsSinceFlush   = 0;
 RTC_DATA_ATTR static bool     s_rtcInitialised     = false;
 
+// RTC-RAM reading-time accumulator. Working copy of the cfg_rtime blob; the
+// pure bucket rules live in pure/reading_time_log.cpp. s_lastReadMarkRtcSec is
+// the RTC second of the previous reading mark — the gap to "now" on the next
+// page turn is the time spent on the page just read. Both survive deep sleep
+// (a stale overnight mark is dropped by the RTIME_GAP_CAP_SECS guard).
+RTC_DATA_ATTR static ReadingTimeFile s_rtime            = {};
+RTC_DATA_ATTR static uint32_t        s_lastReadMarkRtcSec = 0;
+
 // Plain RAM streak threshold-gate cache. Reset on cold boot.
 static struct {
   int      pagesToday        = 0;
@@ -62,13 +76,21 @@ static uint32_t rtcSecondsNow() {
 //  Stats half
 // ---------------------------------------------------------------------------
 
-static void writeStatsBlob() {
+static void writeRtimeBlob() {
+  prefs.putBytes(kKeyRtime, &s_rtime, sizeof(s_rtime));
+}
+
+// Flush both RTC-RAM blobs (lifetime counters + reading-time buckets) to NVS
+// and reset the safety-net counter. They share one flush cadence because both
+// are bumped by the same page-turn / button events.
+static void flushAll() {
   StatsBlob b;
   b.version       = STATS_SCHEMA;
   b.firstRtcSec   = s_firstStatsRtcSec;
   b.pagesRead     = s_pagesRead;
   b.buttonPresses = s_buttonPresses;
   prefs.putBytes(kKeyStats, &b, sizeof(b));
+  writeRtimeBlob();
   s_eventsSinceFlush = 0;
 }
 
@@ -86,12 +108,49 @@ static void loadStatsFromNvs() {
     s_buttonPresses   = 0;
     s_firstStatsRtcSec = rtcSecondsNow();
   }
+
+  ReadingTimeFile rf{};
+  size_t gotR = prefs.getBytes(kKeyRtime, &rf, sizeof(rf));
+  if (gotR == sizeof(rf) && rf.version == RTIME_SCHEMA) {
+    s_rtime = rf;
+  } else {
+    s_rtime             = ReadingTimeFile{};
+    s_rtime.version     = RTIME_SCHEMA;
+    s_rtime.firstRtcSec = rtcSecondsNow();
+  }
+  // Cold boot starts a fresh reading session — no mark carries over.
+  s_lastReadMarkRtcSec = 0;
+
   s_eventsSinceFlush = 0;
   s_rtcInitialised   = true;
 }
 
+// Day index for "now", matching the streak day index. Clamps to 0 if the RTC
+// ran backwards (e.g. firstRtcSec persisted across a power loss that reset the
+// RTC timer) so we never underflow the unsigned subtraction.
+static uint32_t rtimeDayNow() {
+  uint32_t now = rtcSecondsNow();
+  if (now < s_rtime.firstRtcSec) return 0;
+  return (now - s_rtime.firstRtcSec) / STREAK_DAY_SECS;
+}
+
+// Credit the time spent on the page just turned away from. The gap from the
+// previous mark to now is real reading time; gaps over the cap are idle / a
+// post-wake first turn and are dropped. Buckets live in RTC RAM — persistence
+// rides the shared flush cadence, so this stays flash-free.
+static void accrueReadingTimeOnPageTurn() {
+  uint32_t now = rtcSecondsNow();
+  if (s_lastReadMarkRtcSec != 0 && now >= s_lastReadMarkRtcSec) {
+    uint32_t delta = now - s_lastReadMarkRtcSec;
+    if (delta > 0 && delta <= RTIME_GAP_CAP_SECS) {
+      s_rtime = applyReadingTime(s_rtime, rtimeDayNow(), delta);
+    }
+  }
+  s_lastReadMarkRtcSec = now;
+}
+
 static inline void bumpEventsAndMaybeFlush() {
-  if (++s_eventsSinceFlush >= STATS_FLUSH_EVERY_EVENTS) writeStatsBlob();
+  if (++s_eventsSinceFlush >= STATS_FLUSH_EVERY_EVENTS) flushAll();
 }
 
 // ---------------------------------------------------------------------------
@@ -168,6 +227,7 @@ void loadOnBoot() {
 
 void onReaderPageTurn() {
   loadStatsFromNvs();  // safety in case setup() didn't call us
+  accrueReadingTimeOnPageTurn();
   s_pagesRead++;
   bumpEventsAndMaybeFlush();
   streakAutoLogOnPageTurn();
@@ -182,7 +242,7 @@ void bumpButtons(uint32_t delta) {
 
 void flushToNvs() {
   if (!s_rtcInitialised) return;
-  writeStatsBlob();
+  flushAll();
 }
 
 StatisticsSnapshot snapshot() {
@@ -211,6 +271,15 @@ StatisticsSnapshot snapshot() {
     s.bitmapHead        = 0;
     s.bitmap            = 0;
   }
+
+  ReadingTimeView v = viewReadingTime(s_rtime, rtimeDayNow());
+  s.totalReadSecs      = v.total;
+  s.todayReadSecs      = v.today;
+  s.weekReadSecs       = v.week;
+  s.monthReadSecs      = v.month;
+  s.yearReadSecs       = v.year;
+  s.avgPerDayReadSecs  = v.avgPerDay;
+  s.avgPerWeekReadSecs = v.avgPerWeek;
   return s;
 }
 

--- a/Pala_One_2_1/src/storage/statistics.h
+++ b/Pala_One_2_1/src/storage/statistics.h
@@ -40,6 +40,17 @@ struct StatisticsSnapshot {
   uint32_t lastLoggedDay;      // STREAK_DAY_UNSET if never logged
   uint32_t bitmapHead;
   uint32_t bitmap;             // bit i = "logged on day (bitmapHead - i)"
+
+  // Reading time (seconds). today/week/month/year are the current buckets
+  // (0 once the bucket rolls over with no fresh reading); avg* divide the
+  // lifetime total by elapsed days/weeks since tracking began.
+  uint64_t totalReadSecs;
+  uint32_t todayReadSecs;
+  uint32_t weekReadSecs;
+  uint32_t monthReadSecs;
+  uint32_t yearReadSecs;
+  uint32_t avgPerDayReadSecs;
+  uint32_t avgPerWeekReadSecs;
 };
 
 namespace Statistics {

--- a/Pala_One_2_1/src/ui/screens/statistics_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/statistics_screen.cpp
@@ -92,8 +92,9 @@ void StatisticsScreen::drawStreakPage(const StatisticsSnapshot& s) {
 void StatisticsScreen::drawTimePage(const StatisticsSnapshot& s) {
   prepareMenuFrame();
   Font::useBody();
-  int ascent = u8g2.getFontAscent();
-  int lineH  = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 1;
+  // Compact, fixed row spacing — independent of the reader's line-gap setting
+  // so the five rows plus the footer hint always fit and never overlap.
+  int lineH  = (u8g2.getFontAscent() - u8g2.getFontDescent()) + 2;
   int y = drawSectionHeader(D_STATS_TIME_HEADING);
 
   char dur[24];
@@ -119,22 +120,21 @@ void StatisticsScreen::drawTimePage(const StatisticsSnapshot& s) {
   }
   Font::useBody();
 
-  // Footer hint — page 1 has no bitmap, so the bottom strip is free. Centered
-  // above the statusbar reserve so the single-button "click returns" is
-  // discoverable.
-  int hintW = u8g2.getUTF8Width(D_STATS_BACK_HINT);
-  u8g2.setCursor((SCREEN_W - hintW) / 2, SCREEN_H - STATUS_H - 2);
-  u8g2.print(D_STATS_BACK_HINT);
-
   display.update();
 }
 
 void StatisticsScreen::onButton(const ButtonEvent& e) {
-  if (!e.any()) return;
-  if (page_ + 1 < STATS_PAGE_COUNT) {
-    page_++;
-    draw();
-  } else {
-    nextScreen = &g_libraryScreen;
+  switch (e.kind) {
+    case ButtonEvent::Short:
+      // One click cycles back and forth through the stats pages.
+      page_ = (page_ + 1) % STATS_PAGE_COUNT;
+      draw();
+      break;
+    case ButtonEvent::Double:
+      // Two clicks exit to the library.
+      nextScreen = &g_libraryScreen;
+      break;
+    default:
+      break;  // ignore long / triple / hold gestures
   }
 }

--- a/Pala_One_2_1/src/ui/screens/statistics_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/statistics_screen.cpp
@@ -8,13 +8,31 @@
 #include "src/ui/screens/library_screen.h"
 #include "src/ui/widgets.h"
 
+static const int STATS_PAGE_COUNT = 2;
+
+// Format a duration in seconds as a compact "Hh Mm" (or just "Mm" under an
+// hour). Seconds are dropped — page-granularity reading time doesn't need
+// them, and the e-ink rows are narrow.
+static void fmtDuration(char* out, size_t n, uint64_t secs) {
+  uint64_t mins = secs / 60;
+  uint64_t hours = mins / 60;
+  unsigned m = (unsigned)(mins % 60);
+  if (hours > 0) snprintf(out, n, "%lluh %um", (unsigned long long)hours, m);
+  else           snprintf(out, n, "%um", m);
+}
+
 void StatisticsScreen::onEnter() {
+  page_ = 0;
   draw();
 }
 
 void StatisticsScreen::draw() {
   StatisticsSnapshot s = Statistics::snapshot();
+  if (page_ == 0) drawStreakPage(s);
+  else            drawTimePage(s);
+}
 
+void StatisticsScreen::drawStreakPage(const StatisticsSnapshot& s) {
   prepareMenuFrame();
   Font::useBody();
   int ascent = u8g2.getFontAscent();
@@ -71,6 +89,52 @@ void StatisticsScreen::draw() {
   display.update();
 }
 
+void StatisticsScreen::drawTimePage(const StatisticsSnapshot& s) {
+  prepareMenuFrame();
+  Font::useBody();
+  int ascent = u8g2.getFontAscent();
+  int lineH  = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 1;
+  int y = drawSectionHeader(D_STATS_TIME_HEADING);
+
+  char dur[24];
+  char buf[64];
+
+  struct Row { const char* fmt; uint64_t secs; bool bold; };
+  const Row rows[] = {
+    { D_STATS_TIME_TODAY_FMT, s.todayReadSecs,     true  },
+    { D_STATS_TIME_WEEK_FMT,  s.weekReadSecs,      false },
+    { D_STATS_TIME_MONTH_FMT, s.monthReadSecs,     false },
+    { D_STATS_TIME_YEAR_FMT,  s.yearReadSecs,      false },
+    { D_STATS_TIME_AVG_FMT,   s.avgPerDayReadSecs, false },
+  };
+
+  for (const Row& r : rows) {
+    fmtDuration(dur, sizeof(dur), r.secs);
+    snprintf(buf, sizeof(buf), r.fmt, dur);
+    if (r.bold) Font::useBold();
+    else        Font::useBody();
+    u8g2.setCursor(MARGIN_X, y);
+    u8g2.print(buf);
+    y += lineH;
+  }
+  Font::useBody();
+
+  // Footer hint — page 1 has no bitmap, so the bottom strip is free. Centered
+  // above the statusbar reserve so the single-button "click returns" is
+  // discoverable.
+  int hintW = u8g2.getUTF8Width(D_STATS_BACK_HINT);
+  u8g2.setCursor((SCREEN_W - hintW) / 2, SCREEN_H - STATUS_H - 2);
+  u8g2.print(D_STATS_BACK_HINT);
+
+  display.update();
+}
+
 void StatisticsScreen::onButton(const ButtonEvent& e) {
-  if (e.any()) nextScreen = &g_libraryScreen;
+  if (!e.any()) return;
+  if (page_ + 1 < STATS_PAGE_COUNT) {
+    page_++;
+    draw();
+  } else {
+    nextScreen = &g_libraryScreen;
+  }
 }

--- a/Pala_One_2_1/src/ui/screens/statistics_screen.h
+++ b/Pala_One_2_1/src/ui/screens/statistics_screen.h
@@ -3,15 +3,25 @@
 
 #include "src/ui/screen.h"
 
-// Read-only dashboard showing the current reading streak, longest streak,
-// total sessions, and lifetime page-turn / button-press counters. Snapshot
-// at onEnter — values don't update mid-screen. Any button click returns to
-// the library.
+struct StatisticsSnapshot;  // src/storage/statistics.h
+
+// Read-only dashboard across two pages:
+//   page 0 — reading streak, longest streak, total sessions, lifetime
+//            page-turn / button-press counters, 30-day bitmap.
+//   page 1 — today / week / month / year reading time + average per day.
+// Snapshot is taken per draw. With the device's single button, a click
+// advances to the next page; a click on the last page returns to the library.
 class StatisticsScreen : public Screen {
 public:
   void onEnter() override;
   void onButton(const ButtonEvent& e) override;
   void draw() override;
+
+private:
+  void drawStreakPage(const StatisticsSnapshot& s);
+  void drawTimePage(const StatisticsSnapshot& s);
+
+  int page_ = 0;
 };
 
 extern StatisticsScreen g_statsScreen;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SUT_SRC
   ${FW_SRC}/pure/app_header.cpp
   ${FW_SRC}/pure/hold_gesture.cpp
   ${FW_SRC}/pure/streak_log.cpp
+  ${FW_SRC}/pure/reading_time_log.cpp
   ${FW_SRC}/storage/book_metadata.cpp
   ${FW_SRC}/storage/list_items.cpp
 )
@@ -44,6 +45,7 @@ set(TEST_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/test_app_header.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_hold_gesture.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_streak_log.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_reading_time_log.cpp
 )
 
 add_executable(host_tests ${SUT_SRC} ${TEST_SRC})

--- a/test/test_reading_time_log.cpp
+++ b/test/test_reading_time_log.cpp
@@ -1,0 +1,122 @@
+// Tests for src/pure/reading_time_log.cpp.
+//
+// applyReadingTime / viewReadingTime are the pure half of the reading-time
+// feature — given a `ReadingTimeFile` (the on-disk wire format), a day index,
+// and a per-page reading delta, they bucket the time into day/week/month/year
+// and lifetime totals. The firmware (storage/statistics.cpp) keeps one of
+// these structs in RTC RAM; these tests pin the roll-over + averaging rules so
+// the displayed numbers stay correct as buckets advance.
+
+#include "test_framework.h"
+#include "pure/reading_time_log.h"
+
+static ReadingTimeFile freshState() {
+  ReadingTimeFile f{};
+  f.version     = RTIME_SCHEMA;
+  f.firstRtcSec = 0;
+  return f;
+}
+
+TEST_CASE("applyReadingTime accumulates into every bucket on first log") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, /*day=*/0, /*seconds=*/60);
+  CHECK_EQ(f.totalSeconds, 60u);
+  CHECK_EQ(f.daySeconds,   60u);
+  CHECK_EQ(f.weekSeconds,  60u);
+  CHECK_EQ(f.monthSeconds, 60u);
+  CHECK_EQ(f.yearSeconds,  60u);
+}
+
+TEST_CASE("applyReadingTime is a no-op for zero seconds") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, 3, 120);
+  ReadingTimeFile g = applyReadingTime(f, 3, 0);
+  CHECK_EQ(g.totalSeconds, f.totalSeconds);
+  CHECK_EQ(g.daySeconds,   f.daySeconds);
+}
+
+TEST_CASE("applyReadingTime sums multiple logs on the same day") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, 5, 100);
+  f = applyReadingTime(f, 5, 50);
+  CHECK_EQ(f.daySeconds,   150u);
+  CHECK_EQ(f.totalSeconds, 150u);
+}
+
+TEST_CASE("applyReadingTime resets the day bucket but keeps the week within a week") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, 0, 100);   // week 0
+  f = applyReadingTime(f, 1, 40);    // next day, still week 0
+  CHECK_EQ(f.daySeconds,   40u);     // day bucket rolled over
+  CHECK_EQ(f.weekSeconds,  140u);    // week bucket kept accumulating
+  CHECK_EQ(f.monthSeconds, 140u);
+  CHECK_EQ(f.totalSeconds, 140u);
+}
+
+TEST_CASE("applyReadingTime rolls the week bucket on a new week") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, 0, 100);   // day 0, week 0
+  f = applyReadingTime(f, 7, 30);    // day 7, week 1
+  CHECK_EQ(f.weekSeconds,  30u);     // week bucket reset
+  CHECK_EQ(f.monthSeconds, 130u);    // still month 0
+  CHECK_EQ(f.totalSeconds, 130u);
+}
+
+TEST_CASE("applyReadingTime rolls month and year buckets at their boundaries") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, 0, 100);
+  f = applyReadingTime(f, 30, 40);   // month 1, year 0
+  CHECK_EQ(f.monthSeconds, 40u);
+  CHECK_EQ(f.yearSeconds,  140u);
+  f = applyReadingTime(f, 365, 10);  // year 1
+  CHECK_EQ(f.yearSeconds,  10u);
+  CHECK_EQ(f.totalSeconds, 150u);
+}
+
+TEST_CASE("applyReadingTime preserves version and firstRtcSec") {
+  ReadingTimeFile f = freshState();
+  f.firstRtcSec = 0x0BADF00D;
+  f = applyReadingTime(f, 2, 10);
+  CHECK_EQ(f.version,     RTIME_SCHEMA);
+  CHECK_EQ(f.firstRtcSec, 0x0BADF00Du);
+}
+
+TEST_CASE("viewReadingTime shows current buckets and zeros stale ones") {
+  ReadingTimeFile f = freshState();
+  f = applyReadingTime(f, 10, 600);  // day 10, week 1, month 0, year 0
+
+  // Viewed on the same day: all buckets live.
+  ReadingTimeView v = viewReadingTime(f, 10);
+  CHECK_EQ(v.today, 600u);
+  CHECK_EQ(v.week,  600u);
+  CHECK_EQ(v.month, 600u);
+  CHECK_EQ(v.year,  600u);
+  CHECK_EQ((unsigned)v.total, 600u);
+
+  // Viewed the next day (day 11, same week): today resets, week persists.
+  ReadingTimeView v2 = viewReadingTime(f, 11);
+  CHECK_EQ(v2.today, 0u);
+  CHECK_EQ(v2.week,  600u);
+
+  // Viewed a week later (day 17, week 2): week resets too, month persists.
+  ReadingTimeView v3 = viewReadingTime(f, 17);
+  CHECK_EQ(v3.today, 0u);
+  CHECK_EQ(v3.week,  0u);
+  CHECK_EQ(v3.month, 600u);
+}
+
+TEST_CASE("viewReadingTime averages lifetime total over elapsed buckets") {
+  ReadingTimeFile f = freshState();
+  // 700s total spread so the view sees it as lifetime total.
+  f = applyReadingTime(f, 0, 700);
+  // On day 6 (7 elapsed days, 1 elapsed week): avg/day = 100, avg/week = 700.
+  ReadingTimeView v = viewReadingTime(f, 6);
+  CHECK_EQ((unsigned)v.total, 700u);
+  CHECK_EQ(v.avgPerDay,  100u);
+  CHECK_EQ(v.avgPerWeek, 700u);
+
+  // On day 13 (14 elapsed days, 2 elapsed weeks): avg/day = 50, avg/week = 350.
+  ReadingTimeView v2 = viewReadingTime(f, 13);
+  CHECK_EQ(v2.avgPerDay,  50u);
+  CHECK_EQ(v2.avgPerWeek, 350u);
+}


### PR DESCRIPTION
## Reading-time statistics

in response to #79 

Adds reading-time tracking to the statistics screen.

- Today / week / month / year reading time + average per day, on a new second stats page.
- Time accrues from the gap between page turns; gaps over 5 min are treated as idle and dropped. State lives in RTC RAM and flushes to NVS on the existing safety-net + sleep path, so frequent page turns add no flash wear. New `cfg_rtime` blob; buckets use the streak day-index model.

**UI / controls**
- Statistics screen is now two pages: streak/lifetime (1) and reading time (2).
- One click cycles pages; double-click exits to the library.

**Tests**
- Pure bucket logic in `pure/reading_time_log.{h,cpp}`, host-tested (`test_reading_time_log.cpp`).
- Strings mirrored across `en.h` + `es_la.h`; full firmware build (`wireless-paper-v1_2-en`) passes.