### PR TITLE
Add support for flipping screen orientation

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -111,6 +111,7 @@
 #include "src/ui/text.h"
 #include "src/ui/toast.h"
 #include "src/web/web.h"
+#include "src/ui/screen_settings.h"
 
 // ============================================================================
 //  Screen instances + current-screen pointer
@@ -198,6 +199,8 @@ void setup() {
   Statusbar::loadSettings();
   Gestures::loadSettings();
   HeaderTitle::loadSettings();
+  ScreenSettings::loadSettings();
+
   // Sleep::loadSettings() and Lock::loadSettings() already ran earlier in
   // setup() so both flags were available for the boot-clear gate above —
   // don't reload them here.

--- a/Pala_One_2_1/src/hal/display.h
+++ b/Pala_One_2_1/src/hal/display.h
@@ -6,6 +6,7 @@
 
 #include "src/config.h"
 #include "src/state.h"
+#include "src/ui/screen_settings.h"
 
 // ============================================================================
 //  Display adapter — wraps the Heltec EInk display so Adafruit_GFX can draw
@@ -21,7 +22,13 @@ public:
     uint16_t c = color ? BLACK : WHITE;
     int16_t xx = (SCREEN_W - 1) - x;
     int16_t yy = (SCREEN_H - 1) - y;
-    disp.drawPixel(xx, yy, c);
+    if (!ScreenSettings::isScreenFlipped())
+    {
+      disp.drawPixel(xx, yy, c);
+    }
+    else {
+      disp.drawPixel(x, y, c);
+    }
   }
 
 private:

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -335,6 +335,7 @@
 #define D_WEB_BUTTONS_ACTION_BOOKMARK "Bookmark page"
 #define D_WEB_BUTTONS_ACTION_LOCK     "Lock device"
 #define D_WEB_BUTTONS_ACTION_MENU     "Open menu"
+#define D_WEB_BUTTONS_ACTION_ROTATE     "Flip screen orientation"
 
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Device"
@@ -342,6 +343,7 @@
 #define D_WEB_HEADER_TITLE_LABEL    "Header title"
 #define D_WEB_HEADER_TITLE_HINT     "Shown at the top of the library screen. Leave empty for no title."
 #define D_WEB_HEADER_TITLE_RESET    "Reset to default"
+#define D_WEB_FLIP_SCREEN           "Flip screen orientation"
 
 // ----------------------------------------------------------------------------
 //  Upload (book + sleep image) routes (src/web/upload.cpp)

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -329,6 +329,7 @@
 #define D_WEB_BUTTONS_ACTION_BOOKMARK "Marcar página"
 #define D_WEB_BUTTONS_ACTION_LOCK     "Bloquear dispositivo"
 #define D_WEB_BUTTONS_ACTION_MENU     "Abrir menú"
+#define D_WEB_BUTTONS_ACTION_ROTATE  "Voltear orientación de la pantalla" // Translate by ChatGPT
 
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Dispositivo"
@@ -336,7 +337,7 @@
 #define D_WEB_HEADER_TITLE_LABEL    "Título del encabezado"
 #define D_WEB_HEADER_TITLE_HINT     "Se muestra arriba de la pantalla de biblioteca. Deja vacío para ocultarlo."
 #define D_WEB_HEADER_TITLE_RESET    "Restaurar predeterminado"
-
+#define D_WEB_FLIP_SCREEN           "Voltear orientación de la pantalla" // Translate by ChatGPT
 // ----------------------------------------------------------------------------
 //  Upload routes
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/ui/reader_actions.cpp
+++ b/Pala_One_2_1/src/ui/reader_actions.cpp
@@ -17,7 +17,7 @@ static ButtonAction s_extraLong = ACTION_LOCK;
 static ButtonAction s_clickHold = ACTION_MENU;
 
 static ButtonAction clamp(int v) {
-  if (v < ACTION_NONE || v > ACTION_MENU) return ACTION_NONE;
+  if (v < ACTION_NONE || v > ACTION_ROTATE) return ACTION_NONE;
   return (ButtonAction)v;
 }
 

--- a/Pala_One_2_1/src/ui/reader_actions.h
+++ b/Pala_One_2_1/src/ui/reader_actions.h
@@ -25,6 +25,7 @@ enum ButtonAction {
   ACTION_BOOKMARK = 1,
   ACTION_LOCK     = 2,
   ACTION_MENU     = 3,
+  ACTION_ROTATE   = 4,
 };
 
 namespace Gestures {

--- a/Pala_One_2_1/src/ui/screen_settings.cpp
+++ b/Pala_One_2_1/src/ui/screen_settings.cpp
@@ -1,0 +1,27 @@
+#include "src/ui/screen_settings.h"
+#include "src/state.h"
+#include "src/ui/toast.h"
+
+namespace ScreenSettings {
+    static bool s_screenFlipped = false;
+    static constexpr const char *kKeyScreenFlipped = "cfg_scr_flip";
+
+    void loadSettings() {
+        s_screenFlipped = prefs.getBool(kKeyScreenFlipped, false);
+    }
+
+    void toggleScreenRotation() {
+        s_screenFlipped = !s_screenFlipped;
+        Toast::show("Flipped");
+        prefs.putBool(kKeyScreenFlipped, s_screenFlipped);
+    }
+    
+    bool isScreenFlipped() {
+        return s_screenFlipped;
+    }
+
+    void setScreenRotation(bool inverted) {
+        s_screenFlipped = inverted;
+        prefs.putBool(kKeyScreenFlipped, s_screenFlipped);
+    }
+}

--- a/Pala_One_2_1/src/ui/screen_settings.h
+++ b/Pala_One_2_1/src/ui/screen_settings.h
@@ -1,0 +1,13 @@
+#ifndef PALA_UI_SCREEN_ROTATION_H
+#define PALA_UI_SCREEN_ROTATION_H
+
+namespace ScreenSettings
+{
+
+    void loadSettings();
+    void toggleScreenRotation();
+    bool isScreenFlipped();
+    void setScreenRotation(bool);
+}
+
+#endif

--- a/Pala_One_2_1/src/ui/screens/reader_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/reader_screen.cpp
@@ -10,6 +10,8 @@
 #include "src/ui/sleep.h"                    // Sleep::enter on ACTION_LOCK
 #include "src/ui/text.h"
 #include "src/ui/toast.h"                    // Toast::show for bookmark-saved feedback
+#include "src/config.h"
+#include "src/ui/screen_settings.h"
 
 // Carry out one of the bindable reader actions. No-op for ACTION_NONE.
 // Lives at the screen layer because the actions are reader-context things
@@ -33,6 +35,9 @@ static void performReaderAction(ButtonAction action) {
       break;
     case ACTION_MENU:
       ReaderMenu::open();
+      break;
+    case ACTION_ROTATE:
+      ScreenSettings::toggleScreenRotation();
       break;
     case ACTION_NONE:
     default:

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -14,6 +14,7 @@
 #include "src/ui/lock.h"
 #include "src/ui/sleep.h"
 #include "src/web/chrome.h"
+#include "src/ui/screen_settings.h"
 
 // ----------------------------------------------------------------------------
 //  HTML escaping for user-supplied text rendered in attributes
@@ -62,6 +63,7 @@ static void appendActionSelect(String& out, const char* nameId, const char* labe
   appendActionOption(out, ACTION_BOOKMARK, D_WEB_BUTTONS_ACTION_BOOKMARK, current);
   appendActionOption(out, ACTION_LOCK,     D_WEB_BUTTONS_ACTION_LOCK,     current);
   appendActionOption(out, ACTION_MENU,     D_WEB_BUTTONS_ACTION_MENU,     current);
+  appendActionOption(out, ACTION_ROTATE,   D_WEB_BUTTONS_ACTION_ROTATE,   current);
   out += "</select></div>";
 }
 
@@ -113,6 +115,13 @@ static void handleSettings() {
   out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
   out += "<input type='checkbox' name='hdr_rst' value='1' style='width:auto'>";
   out += "<span>" D_WEB_HEADER_TITLE_RESET "</span></label>";
+
+  // Toggle for setting the inversed screen orientation
+  out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
+  out += "<input type='checkbox' name='flip_rot' value='1' style='width:auto'>";
+  out += "<span>" D_WEB_FLIP_SCREEN "</span></label>";
+  out += "<span class='muted' style='display:inline'>" D_WEB_SETTINGS_APPLY_HINT "</span>";
+
   out += "<div class='actions' style='margin-top:14px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button></div>";
   out += "</form></div>";
 
@@ -275,6 +284,16 @@ static void handleSettingsPost() {
       String hdr = server.arg("hdr");
       hdr.trim();
       HeaderTitle::set(hdr.c_str());
+    }
+  }
+  if (server.hasArg("hdr")) {
+    if (server.hasArg("flip_rot"))
+    {
+      ScreenSettings::setScreenRotation(true);
+    }
+    else
+    {
+      ScreenSettings::setScreenRotation(false);
     }
   }
 


### PR DESCRIPTION
Added support for flipping screen orientation both in webUI and as an action which can be mapped to one of the device's clicks.

Motivation:
1. Support for different case designs
2. I would like to be able to flip the device while reading so that I can hold it in a different way to avoid fatigue