### PR TITLE
Accents on capital letters on the first line of a page are not shown

### DIFF
--- a/Pala_One_2_1/src/config.h
+++ b/Pala_One_2_1/src/config.h
@@ -109,7 +109,7 @@ static const int FULL_REFRESH_EVERY_N_PAGES = 100;
 static const int MENU_FULL_REFRESH_EVERY = 60;
 
 static const int MARGIN_X = 6;
-static const int TOP_PAD = 0;
+static const int TOP_PAD = 3;
 static const int BOT_PAD = 0;
 static const int STATUS_H = 8;
 


### PR DESCRIPTION
Fixes #101 by adding a 3 pixels top padding.

The primary reason for the text being clipped is due to how `getFontAscent` is implemented (https://github.com/olikraus/U8g2_for_Adafruit_GFX): 

> `int8_t u8g2_for_adafruit_gfx.getFontAscent(void)`: The height of the character 'A' in the current font.

This is used in `text.cpp` (`drawPageAt`) to calculate the offset of the first line of text from the top of the page

```cpp
int cursorY = TOP_PAD + m.ascent;
```
