### PR TITLE
Device screen strings are not hard coded anymore

### DIFF
--- a/Pala_One_2_1/src/config.h
+++ b/Pala_One_2_1/src/config.h
@@ -105,7 +105,7 @@ static const uint32_t TOAST_MS = 650;
 static const uint32_t UPLOAD_AUTO_EXIT_MS = 15UL * 60UL * 1000UL;
 static const uint32_t BAT_CACHE_MS = 180000; // 3 min — battery changes slowly
 static const uint32_t BAT_CHARGING_CHECK_MS = 2000;
-static const float BAT_CHARGING_VOLTAGE = 4.2f;
+static const float BAT_CHARGING_VOLTAGE = 4.09f;
 
 static const int FULL_REFRESH_EVERY_N_PAGES = 100;
 static const int MENU_FULL_REFRESH_EVERY = 60;

--- a/Pala_One_2_1/src/hal/battery.cpp
+++ b/Pala_One_2_1/src/hal/battery.cpp
@@ -260,21 +260,28 @@ void drawBolt(int battX, int battY, int battH, int spacing)
   }
 }
 
-void drawBatteryTopRight()
+void drawBatteryTopRight(bool extended)
 {
   updateBatteryCached(false);
-
+  Font::useUiSmall();
   int pct = s_battery.valid ? s_battery.pctShown : 0;
   if (pct < 0)
     pct = 0;
   if (pct > 100)
     pct = 100;
 
+  char extendedInfo[11];
+  int icon_extendedInfo_spacing = 5;
+  if (extended) {
+    snprintf(extendedInfo, sizeof(extendedInfo), "%d%%/%.2fV", pct, readBatteryVoltageRaw());
+  }
   const int iconW = 18;
   const int iconH = 9;
-  int xIcon = SCREEN_W - MARGIN_X - iconW - 2;
+  int xIcon = SCREEN_W - MARGIN_X - iconW - 2 - (extended ? u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing : 0);
   int yIcon = 2;
 
+  // Clear previous icons
+  gfx.fillRect(xIcon, yIcon, iconW + u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing, iconH, 0);
   drawBatteryOutline(xIcon, yIcon, iconW, iconH);
   int displayedCharge = 0;
 
@@ -304,7 +311,12 @@ void drawBatteryTopRight()
     drawChargingFill(xIcon, yIcon, iconH, iconW);
   }
 
+  if (extended) {
+    u8g2.setCursor(xIcon + iconW + icon_extendedInfo_spacing, yIcon + iconH - 1);
+    u8g2.print(extendedInfo);
+  }
 }
+
 
 // void drawBatteryTopRight()
 // {

--- a/Pala_One_2_1/src/hal/battery.h
+++ b/Pala_One_2_1/src/hal/battery.h
@@ -7,7 +7,7 @@
 #if HAS_BATTERY
 void adcSetupOnce();
 void updateBatteryCached(bool force = false);
-void drawBatteryTopRight();
+void drawBatteryTopRight(bool extended = false);
 bool batteryChargingChanged();
 #endif
 

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -16,11 +16,26 @@
 //  About screen (src/ui/screens/about_screen.cpp)
 // ----------------------------------------------------------------------------
 #define D_ABOUT_HEADER              "Device"
-#define D_ABOUT_FIRMWARE_PREFIX     "Firmware "
-#define D_ABOUT_GESTURE_NEXT        "1x next / down"
-#define D_ABOUT_GESTURE_OPEN        "2x open / select"
-#define D_ABOUT_GESTURE_HOME        "3x home"
-#define D_ABOUT_GESTURE_BOOKMARK    "Hold bookmark"
+#define D_ABOUT_FIRMWARE_PREFIX     "Firmware"
+#define D_ABOUT_GESTURE_CLICK       "click"
+#define D_ABOUT_GESTURE_CLICK_2     "click x 2"
+#define D_ABOUT_GESTURE_CLICK_3     "click x 3"
+#define D_ABOUT_GESTURE_CLICK_HOLD  "click + hold"
+#define D_ABOUT_GESTURE_HOLD        "hold"
+#define D_ABOUT_GESTURE_LONG_HOLD   "long hold"
+#define D_ABOUT_GESTURE_SEPARATOR   ": "
+
+// ----------------------------------------------------------------------------
+// Action names  (src/ui/reader_actions.cpp)
+// ----------------------------------------------------------------------------
+#define D_ACTION_NONE_LABEL     "None"
+#define D_ACTION_NEXT_LABEL     "Next"
+#define D_ACTION_OPEN_LABEL     "Open/Select"
+#define D_ACTION_BOOKMARK_LABEL "Bookmark"
+#define D_ACTION_HOME_LABEL     "Home"
+#define D_ACTION_LOCK_LABEL     "Lock"
+#define D_ACTION_MENU_LABEL     "Menu"
+#define D_ACTION_ROTATE_LABEL   "Flip screen"
 
 // ----------------------------------------------------------------------------
 //  Library screen — section title + system menu entries

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -20,12 +20,27 @@
 // ----------------------------------------------------------------------------
 //  About screen
 // ----------------------------------------------------------------------------
-#define D_ABOUT_HEADER              "Dispositivo"
-#define D_ABOUT_FIRMWARE_PREFIX     "Firmware "
-#define D_ABOUT_GESTURE_NEXT        "1x siguiente / abajo"
-#define D_ABOUT_GESTURE_OPEN        "2x abrir / elegir"
-#define D_ABOUT_GESTURE_HOME        "3x inicio"
-#define D_ABOUT_GESTURE_BOOKMARK    "Mantener: marcapáginas"
+#define D_ABOUT_HEADER              "Dispositivo" // AI translation
+#define D_ABOUT_FIRMWARE_PREFIX     "Firmware" // AI translation
+#define D_ABOUT_GESTURE_CLICK       "clic" // AI translation
+#define D_ABOUT_GESTURE_CLICK_2     "clic x 2" // AI translation
+#define D_ABOUT_GESTURE_CLICK_3     "clic x 3" // AI translation
+#define D_ABOUT_GESTURE_CLICK_HOLD  "clic + mantener" // AI translation
+#define D_ABOUT_GESTURE_HOLD        "mantener" // AI translation
+#define D_ABOUT_GESTURE_LONG_HOLD   "mantener mucho" // AI translation
+#define D_ABOUT_GESTURE_SEPARATOR   ": "
+
+// ----------------------------------------------------------------------------
+// Action names  (src/ui/reader_actions.cpp)
+// ----------------------------------------------------------------------------
+#define D_ACTION_NONE_LABEL     "Ninguna" // AI translation
+#define D_ACTION_NEXT_LABEL     "Siguiente" // AI translation
+#define D_ACTION_OPEN_LABEL     "Abrir/Seleccionar" // AI translation
+#define D_ACTION_BOOKMARK_LABEL "Marcador" // AI translation
+#define D_ACTION_HOME_LABEL     "Inicio" // AI translation
+#define D_ACTION_LOCK_LABEL     "Bloquear" // AI translation
+#define D_ACTION_MENU_LABEL     "Menú" // AI translation
+#define D_ACTION_ROTATE_LABEL   "Girar pantalla" // AI translation
 
 // ----------------------------------------------------------------------------
 //  Library menu entries

--- a/Pala_One_2_1/src/ui/reader_actions.h
+++ b/Pala_One_2_1/src/ui/reader_actions.h
@@ -28,6 +28,8 @@ enum ButtonAction {
   ACTION_ROTATE   = 4,
 };
 
+
+
 namespace Gestures {
 
 // NVS load on boot — call once from setup() after `prefs.begin`.

--- a/Pala_One_2_1/src/ui/screens/about_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/about_screen.cpp
@@ -5,6 +5,7 @@
 #include "src/ui/screens/library_screen.h"
 #include "src/ui/widgets.h"
 #include "src/ui/reader_actions.h"
+#include "src/hal/battery.h"
 
 void AboutScreen::onEnter() {
   draw();
@@ -33,7 +34,8 @@ void AboutScreen::draw() {
   Font::useUiSmall();
   int ascent = u8g2.getFontAscent();
   int lineH = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 3;
-  int y = drawSectionHeader(D_ABOUT_HEADER);
+  int y = drawSectionHeader(D_ABOUT_HEADER, false);
+  drawBatteryTopRight(true);
   const int rowNumber = 7;
   String rows[rowNumber][2] = {
       {D_ABOUT_FIRMWARE_PREFIX, FW_VERSION},

--- a/Pala_One_2_1/src/ui/screens/about_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/about_screen.cpp
@@ -4,33 +4,84 @@
 #include "src/ui/font.h"
 #include "src/ui/screens/library_screen.h"
 #include "src/ui/widgets.h"
+#include "src/ui/reader_actions.h"
 
 void AboutScreen::onEnter() {
   draw();
 }
 
+static String actionLabel(ButtonAction action) {
+  switch (action) {
+    case ACTION_BOOKMARK:
+      return D_ACTION_BOOKMARK_LABEL;
+    case ACTION_LOCK:
+      return D_ACTION_LOCK_LABEL;
+    case ACTION_MENU:
+      return D_ACTION_MENU_LABEL;
+    case ACTION_ROTATE:
+      return D_ACTION_ROTATE_LABEL;
+    case ACTION_NONE:
+    default:
+      return D_ACTION_NONE_LABEL;
+    }
+}
+
+
+
 void AboutScreen::draw() {
   prepareMenuFrame();
-  Font::useBody();
+  Font::useUiSmall();
   int ascent = u8g2.getFontAscent();
-  int lineH = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 1;
+  int lineH = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 3;
   int y = drawSectionHeader(D_ABOUT_HEADER);
-
-  String rows[5] = {
-    D_ABOUT_FIRMWARE_PREFIX FW_VERSION,
-    D_ABOUT_GESTURE_NEXT,
-    D_ABOUT_GESTURE_OPEN,
-    D_ABOUT_GESTURE_HOME,
-    D_ABOUT_GESTURE_BOOKMARK
+  const int rowNumber = 7;
+  String rows[rowNumber][2] = {
+      {D_ABOUT_FIRMWARE_PREFIX, FW_VERSION},
+      {D_ABOUT_GESTURE_CLICK, D_ACTION_NEXT_LABEL},
+      {D_ABOUT_GESTURE_CLICK_2, D_ACTION_OPEN_LABEL},
+      {D_ABOUT_GESTURE_CLICK_3, D_ACTION_HOME_LABEL},
+      {D_ABOUT_GESTURE_HOLD, actionLabel(Gestures::actionLong())},
+      {D_ABOUT_GESTURE_LONG_HOLD, actionLabel(Gestures::actionExtraLong())},
+      {D_ABOUT_GESTURE_CLICK_HOLD, actionLabel(Gestures::actionClickHold())},
   };
 
-  for (int i = 0; i < 5; i++) {
-    if (i == 0) Font::useBold();
-    else        Font::useBody();
-    u8g2.setCursor(MARGIN_X, y);
-    u8g2.print(rows[i].c_str());
-    y += lineH;
+  // Left padding to align all the action labels
+  int leftPad = MARGIN_X;
+
+  for (int i = 0; i < rowNumber; i++) {
+    Font::useBold();
+    int leftStrWidth = MARGIN_X;
+    
+    leftStrWidth += u8g2.getUTF8Width(rows[i][0].c_str());
+    leftStrWidth += u8g2.getUTF8Width(D_ABOUT_GESTURE_SEPARATOR);
+    if (leftStrWidth > leftPad) {
+      leftPad = leftStrWidth;
+    }
   }
+
+    for (int i = 0; i < rowNumber; i++)
+    {
+      // if (i == 0) Font::useBold();
+      // else        Font::useBody();
+      int x = MARGIN_X;
+      u8g2.setCursor(x, y);
+      Font::useBold();
+      u8g2.print(rows[i][0].c_str());
+      x += u8g2.getUTF8Width(rows[i][0].c_str()) + 1;
+      u8g2.setCursor(x, y);
+      u8g2.print(D_ABOUT_GESTURE_SEPARATOR);
+      x += u8g2.getUTF8Width(D_ABOUT_GESTURE_SEPARATOR) + 1;
+      Font::useBody();
+      if (i == 0) {
+        u8g2.setCursor(x, y);
+      }
+      else {
+        u8g2.setCursor(leftPad, y);
+      }
+      u8g2.print(rows[i][1].c_str());
+
+      y += lineH;
+    }
 
   display.update();
 }

--- a/Pala_One_2_1/src/ui/widgets.cpp
+++ b/Pala_One_2_1/src/ui/widgets.cpp
@@ -55,7 +55,7 @@ void drawCenter(const char* a, const char* b) {
   display.update();
 }
 
-int drawSectionHeader(const char* title) {
+int drawSectionHeader(const char* title, bool drawBattery) {
   Font::useBold();
   int ascent = u8g2.getFontAscent();
   int yTitle = UI_HEADER_TOP + ascent - 2;
@@ -64,7 +64,9 @@ int drawSectionHeader(const char* title) {
   u8g2.print(title);
 
 #if HAS_BATTERY
-  drawBatteryTopRight();
+  if (drawBattery){
+    drawBatteryTopRight();
+  }
 #endif
 
   int lineY = yTitle + 4;

--- a/Pala_One_2_1/src/ui/widgets.h
+++ b/Pala_One_2_1/src/ui/widgets.h
@@ -9,7 +9,7 @@
 // ============================================================================
 //  Shared drawing helpers used by multiple screens
 // ============================================================================
-int drawSectionHeader(const char* title);
+int drawSectionHeader(const char* title, bool drawBattery = true);
 
 // Full-screen single- or two-line centered message. Always full-refreshes
 // (no fastmode), so use it sparingly — for hard errors or status notices


### PR DESCRIPTION
This PR adds starts introducing a separation between gesture (e.g. click, double click, ...) and action (e.g. bookmark, home, ...) and removes the hard coded strings that were previously displayed in the device screen, addressing #107 and starting to tackle #108.

<img width="1600" height="1119" alt="image" src="https://github.com/user-attachments/assets/db541c15-8b6b-410f-a391-83ec7df6350c" />
