### PR TITLE
Add low battery warning when reading.

### DIFF
--- a/Pala_One_2_1/src/hal/battery.cpp
+++ b/Pala_One_2_1/src/hal/battery.cpp
@@ -124,8 +124,16 @@ static int batteryPercentFromOCV(float v)
   return 0;
 }
 
-void updateBatteryCached(bool force)
+void updateBatteryBackground()
 {
+  uint32_t now = millis();
+  bool needFull = (now - s_battery.lastMs) >= BAT_CACHE_MS;
+  if (needFull) {
+    updateBatteryCached(/*force=*/true);
+  }
+}
+
+void updateBatteryCached(bool force) {
   uint32_t now = millis();
   bool needFull = force || (now - s_battery.lastMs) >= BAT_CACHE_MS;
   bool chargingCheckDue = force || (now - s_battery.lastChargingCheckMs) >= BAT_CHARGING_CHECK_MS;
@@ -260,7 +268,10 @@ void drawBolt(int battX, int battY, int battH, int spacing)
   }
 }
 
-void drawBatteryTopRight(bool extended)
+const int iconW = 18;
+const int iconH = 9;
+
+void drawBattery(int xIcon, int yIcon)
 {
   updateBatteryCached(false);
   Font::useUiSmall();
@@ -270,18 +281,6 @@ void drawBatteryTopRight(bool extended)
   if (pct > 100)
     pct = 100;
 
-  char extendedInfo[11];
-  int icon_extendedInfo_spacing = 5;
-  if (extended) {
-    snprintf(extendedInfo, sizeof(extendedInfo), "%d%%/%.2fV", pct, readBatteryVoltageRaw());
-  }
-  const int iconW = 18;
-  const int iconH = 9;
-  int xIcon = SCREEN_W - MARGIN_X - iconW - 2 - (extended ? u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing : 0);
-  int yIcon = 2;
-
-  // Clear previous icons
-  gfx.fillRect(xIcon, yIcon, iconW + u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing, iconH, 0);
   drawBatteryOutline(xIcon, yIcon, iconW, iconH);
   int displayedCharge = 0;
 
@@ -310,13 +309,43 @@ void drawBatteryTopRight(bool extended)
     drawBolt(xIcon, yIcon, iconH, 2);
     drawChargingFill(xIcon, yIcon, iconH, iconW);
   }
+}
+
+void drawBatteryTopRight(bool extended) {
+  updateBatteryCached(false);
+  int pct = s_battery.valid ? s_battery.pctShown : 0;
+  if (pct < 0)
+    pct = 0;
+  if (pct > 100)
+    pct = 100;
+
+  char extendedInfo[11];
+  int icon_extendedInfo_spacing = 5;
+  if (extended) {
+    snprintf(extendedInfo, sizeof(extendedInfo), "%d%%/%.2fV", pct, readBatteryVoltageRaw());
+  }
+  int xIcon = SCREEN_W - MARGIN_X - iconW - 2 - (extended ? u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing : 0);
+  int yIcon = 2;
+
+  // Clear previous icons
+  gfx.fillRect(xIcon, yIcon, iconW + u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing, iconH, 0);
+
+  drawBattery(xIcon, yIcon);
 
   if (extended) {
+    Font::useUiSmall();
     u8g2.setCursor(xIcon + iconW + icon_extendedInfo_spacing, yIcon + iconH - 1);
     u8g2.print(extendedInfo);
   }
 }
 
+void drawBatteryBottomLeft() {
+	drawBattery(/*xIcon=*/MARGIN_X + 2, /*yIcon=*/SCREEN_H - iconH);
+}
+
+bool batteryLow() {
+  return s_battery.valid && s_battery.low;
+}
 
 // void drawBatteryTopRight()
 // {

--- a/Pala_One_2_1/src/hal/battery.cpp
+++ b/Pala_One_2_1/src/hal/battery.cpp
@@ -133,7 +133,8 @@ void updateBatteryBackground()
   }
 }
 
-void updateBatteryCached(bool force) {
+void updateBatteryCached(bool force)
+{
   uint32_t now = millis();
   bool needFull = force || (now - s_battery.lastMs) >= BAT_CACHE_MS;
   bool chargingCheckDue = force || (now - s_battery.lastChargingCheckMs) >= BAT_CHARGING_CHECK_MS;
@@ -311,7 +312,8 @@ void drawBattery(int xIcon, int yIcon)
   }
 }
 
-void drawBatteryTopRight(bool extended) {
+void drawBatteryTopRight(bool extended)
+{
   updateBatteryCached(false);
   int pct = s_battery.valid ? s_battery.pctShown : 0;
   if (pct < 0)
@@ -339,11 +341,13 @@ void drawBatteryTopRight(bool extended) {
   }
 }
 
-void drawBatteryBottomLeft() {
+void drawBatteryBottomLeft()
+{
 	drawBattery(/*xIcon=*/MARGIN_X + 2, /*yIcon=*/SCREEN_H - iconH);
 }
 
-bool batteryLow() {
+bool batteryLow()
+{
   return s_battery.valid && s_battery.low;
 }
 

--- a/Pala_One_2_1/src/hal/battery.h
+++ b/Pala_One_2_1/src/hal/battery.h
@@ -7,8 +7,24 @@
 #if HAS_BATTERY
 void adcSetupOnce();
 void updateBatteryCached(bool force = false);
+
+/*
+ * This is a more conservative version of updateBatteryCached that is
+ * used when checking battery status in the background. It doesn't allow
+ * bypassing the cache and will only check charging status if it would
+ * be doing a full update anyway.
+ */
+void updateBatteryBackground();
+
 void drawBatteryTopRight(bool extended = false);
+void drawBatteryBottomLeft();
 bool batteryChargingChanged();
+
+/*
+ * True iff the most recent reading is valid and below the low-battery
+ * threshold.
+ */
+bool batteryLow();
 #endif
 
 #endif  // PALA_HAL_BATTERY_H

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -1,5 +1,6 @@
 #include "src/ui/reader.h"
 
+#include "src/hal/battery.h" // for low battery warning.
 #include "src/hal/display.h"
 #include "src/pure/hashing.h"
 #include "src/storage/book_metadata.h"
@@ -220,12 +221,21 @@ bool openBookByIndex(int idx) {
 }
 
 static void drawStatusBar(uint32_t startOffset) {
-  if (Statusbar::mode() == Statusbar::Hidden) return;
+  // If the battery is low, we show a full status bar regardless of preference
+  // with a warning icon.
+  bool showBatteryWarning = false;
+#if HAS_BATTERY
+  // Battery status usually isn't updated mid-session, so poll it here to see if we're low.
+  // Entries are valid for BAT_CACHE_MS so this won't be too burdonsome.
+  updateBatteryBackground();
+  showBatteryWarning = batteryLow();
+#endif
+  if (!showBatteryWarning && Statusbar::mode() == Statusbar::Hidden) return;
 
   size_t total = g_bookview.book.size();
   if (total == 0) total = 1;
 
-  if (Statusbar::mode() == Statusbar::Minimal) {
+  if (!showBatteryWarning && Statusbar::mode() == Statusbar::Minimal) {
     int w = SCREEN_W - 2 * MARGIN_X;
     int filled = (int)((startOffset * (uint32_t)w) / (uint32_t)total);
     if (filled < 0) filled = 0;
@@ -247,10 +257,13 @@ static void drawStatusBar(uint32_t startOffset) {
 
   if (SHOW_PROGRESS_BAR) {
     const int padR = SHOW_PAGE_NUMBER ? (pageTextW + 8) : 0;
-    int w = (SCREEN_W - 2 * MARGIN_X) - padR;
-    if (w < 40) w = 40;
-
     int x0 = MARGIN_X;
+	if (showBatteryWarning) {
+	  drawBatteryBottomLeft();
+	  x0 += 24;
+	}
+    int w = (SCREEN_W - MARGIN_X - x0) - padR;
+    if (w < 40) w = 40;
     int yTop = SCREEN_H - 7;
     int barH = 4;
     int filled = (int)((startOffset * (uint32_t)w) / (uint32_t)total);


### PR DESCRIPTION
This change draws the battery icon in the status bar at the bottom left of the reading page if the battery is detected as being low.

This will override any selected status bar preference to ensure the warning is seen.