### PR TITLE
Add an option to support half height paragraph breaks.

### DIFF
--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -456,6 +456,8 @@
 #define D_WEB_FONT_FAMILY_HINT      "OpenDyslexic uses heavier letter shapes designed for easier scanning."
 #define D_WEB_BIONIC_LABEL          "Bionic reading"
 #define D_WEB_BIONIC_HINT           "Bolds the leading characters of each word to help your eyes anchor."
+#define D_WEB_PARA_GAP_LABEL        "Compact paragraph gaps"
+#define D_WEB_PARA_GAP_HINT         "If enabled, paragraph breaks will be reduced to half normal height allowing more lines of text to fit on a single page."
 #define D_WEB_SETTINGS_APPLY_HINT   "Changes apply to the next page render."
 
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -447,6 +447,8 @@
 #define D_WEB_FONT_FAMILY_HINT      "OpenDyslexic usa formas de letra más gruesas diseñadas para una lectura más fácil."
 #define D_WEB_BIONIC_LABEL          "Lectura biónica"
 #define D_WEB_BIONIC_HINT           "Resalta en negrita las primeras letras de cada palabra para anclar la mirada."
+#define D_WEB_PARA_GAP_LABEL        "Espacios de párrafo compactos"
+#define D_WEB_PARA_GAP_HINT         "Si está activado, los saltos de párrafo se reducirán a la mitad de su altura normal, permitiendo que quepan más líneas de texto en una sola página."
 #define D_WEB_SETTINGS_APPLY_HINT   "Los cambios se aplican en la próxima página renderizada."
 
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/pure/paginator.cpp
+++ b/Pala_One_2_1/src/pure/paginator.cpp
@@ -18,7 +18,16 @@ uint32_t paginatePage(IReadStream& in,
                       const LineCallback& onLine) {
   in.seek(startPos);
 
-  int linesUsed = 0;
+  // Vertical layout is tracked in PIXELS (usedH), not whole-line counts, so a
+  // blank line between paragraphs can consume a fractional gap (e.g. a
+  // half-height paragraph break) instead of a full empty line. budgetH is the
+  // usable text height; a full text line costs m.lineH, a paragraph gap costs
+  // gapH. The page-fill test (pageFull) is identical in the draw and measure
+  // passes (both advance usedH the same way), so page offsets stay
+  // deterministic for back-nav and the on-disk offset cache.
+  const int budgetH = m.maxLines * m.lineH;
+  const int gapH    = (m.paragraphGapH > 0) ? m.paragraphGapH : m.lineH;
+  int usedH = 0;
   char line[kLineMax];      size_t lineLen = 0;
   char token[kTokenMax] = {}; size_t tokLen  = 0;
   char scratch[kScratchMax];
@@ -40,9 +49,13 @@ uint32_t paginatePage(IReadStream& in,
   };
 
   auto emit = [&](const char* buf, size_t len) {
-    linesUsed++;
+    usedH += m.lineH;
     if (onLine) onLine(buf, len);
   };
+
+  // True once there's no room left for another full text line calculated
+  // according to pixel budgets.
+  auto pageFull = [&]() -> bool { return usedH + m.lineH > budgetH; };
 
   auto flushLine = [&]() {
     trimTrailing(line, lineLen);
@@ -92,7 +105,7 @@ uint32_t paginatePage(IReadStream& in,
       emit(token, fitLen);
       token[fitLen] = saved;
 
-      if (linesUsed >= m.maxLines)
+      if (pageFull())
         return safeReturn(tokenStartPos + (uint32_t)fitLen);
 
       memmove(token, token + fitLen, tokLen - fitLen);
@@ -131,7 +144,7 @@ uint32_t paginatePage(IReadStream& in,
 
     if (measure(scratch) > m.maxWidth) {
       flushLine();
-      if (linesUsed >= m.maxLines) return safeReturn(tokenStartPos);
+      if (pageFull()) return safeReturn(tokenStartPos);
 
       token[tokLen] = 0;
       if (measure(token) > m.maxWidth) {
@@ -148,7 +161,7 @@ uint32_t paginatePage(IReadStream& in,
     return 0;
   };
 
-  while (in.available() && linesUsed < m.maxLines) {
+  while (in.available() && !pageFull()) {
     uint32_t charPos = in.position();
     int rb = in.read();
     if (rb < 0) break;
@@ -158,8 +171,17 @@ uint32_t paginatePage(IReadStream& in,
     if (c == '\n') {
       uint32_t forcedNext = appendTokenToLine();
       if (forcedNext != 0) return forcedNext;
-      flushLine();
-      if (linesUsed >= m.maxLines) return safeReturn(in.position());
+      // Empty line = paragraph break. Height can be full or half line depending on settings.
+      if (lineLen == 0) {
+        // If we're at the top of the page, just skip it.
+        if (usedH > 0) {
+          usedH += gapH;
+          if (onLine) onLine(nullptr, 0);
+        }
+      } else {
+        flushLine();
+      }
+      if (pageFull()) return safeReturn(in.position());
       lineStartPos = in.position();
       continue;
     }
@@ -192,7 +214,7 @@ uint32_t paginatePage(IReadStream& in,
   uint32_t forcedNext = appendTokenToLine();
   if (forcedNext != 0) return forcedNext;
 
-  if (linesUsed < m.maxLines && lineLen > 0) {
+  if (!pageFull() && lineLen > 0) {
     flushLine();
   }
 

--- a/Pala_One_2_1/src/pure/paginator.cpp
+++ b/Pala_One_2_1/src/pure/paginator.cpp
@@ -212,7 +212,7 @@ uint32_t paginatePage(IReadStream& in,
         // If we're at the top of the page, just skip it.
         if (usedH > 0) {
           usedH += gapH;
-          if (onLine) onLine(nullptr, 0);
+          if (onLine) onLine("", 0);
         }
       } else {
         flushLine();

--- a/Pala_One_2_1/src/pure/paginator.h
+++ b/Pala_One_2_1/src/pure/paginator.h
@@ -13,6 +13,8 @@ struct LayoutMetrics {
   int lineH = 0;
   int maxWidth = 0;
   int maxLines = 1;
+  // Height to be used for a paragraph gap. Either lineH or lineH/2.
+  int paragraphGapH = 0;
 };
 
 // Measure the rendered width (in pixels) of a UTF-8 string under the layout's

--- a/Pala_One_2_1/src/storage/page_cache.cpp
+++ b/Pala_One_2_1/src/storage/page_cache.cpp
@@ -43,12 +43,12 @@ static constexpr size_t kHeaderBytes =
 // statusbarReserve in pixels (currently 0/1/STATUS_H) gets to stretch out in the top byte.
 // Bits 20-23 are currently spare.
 static uint32_t encodeLayoutVersion(const PageCacheLayout& layout) {
-  return ((uint32_t)(layout.bodySize         & 0x0F))
-       | ((uint32_t)(layout.lineGap          & 0x0F) << 8)
+  return ((uint32_t)(layout.bodySize         & 0xFF))
+       | ((uint32_t)(layout.lineGap          & 0xFF) << 8)
        | ((uint32_t)(layout.family           & 0x03) << 16)
        | ((uint32_t)(layout.bionic           & 0x01) << 18)
        | ((uint32_t)(layout.halfGaps         & 0x01) << 19)
-       | ((uint32_t)(layout.statusbarReserve & 0x0F) << 24);
+       | ((uint32_t)(layout.statusbarReserve & 0xFF) << 24);
 }
 
 static String pageCachePathForBook(const String& path) {

--- a/Pala_One_2_1/src/storage/page_cache.cpp
+++ b/Pala_One_2_1/src/storage/page_cache.cpp
@@ -47,7 +47,7 @@ static uint32_t encodeLayoutVersion(const PageCacheLayout& layout) {
        | ((uint32_t)(layout.lineGap          & 0x0F) << 8)
        | ((uint32_t)(layout.family           & 0x03) << 16)
        | ((uint32_t)(layout.bionic           & 0x01) << 18)
-       | ((uint32_t)(layout.bionic           & 0x01) << 19)
+       | ((uint32_t)(layout.halfGaps         & 0x01) << 19)
        | ((uint32_t)(layout.statusbarReserve & 0x0F) << 24);
 }
 

--- a/Pala_One_2_1/src/storage/page_cache.cpp
+++ b/Pala_One_2_1/src/storage/page_cache.cpp
@@ -21,12 +21,14 @@
 //                 must rebuild when Statusbar::setMode toggles between
 //                 Full / Minimal / Hidden because each has a different
 //                 reserve height and therefore a different maxLines
+//    0x50434F4A — added the half-height-paragraph-gaps flag; toggling it
+//                 changes how a blank line fills the page, shifting offsets
 //
 //  Old files fail the magic check, get ignored, then overwritten on the next
 //  save. No migration code needed.
 // ============================================================================
 
-static constexpr uint32_t kPageCacheMagic = 0x50434F49UL;
+static constexpr uint32_t kPageCacheMagic = 0x50434F4AUL;
 
 static constexpr size_t kHeaderBytes =
     sizeof(uint32_t)   // magic
@@ -35,16 +37,18 @@ static constexpr size_t kHeaderBytes =
   + sizeof(uint16_t);  // count
 
 // Compact encoding of "what layout were the offsets in this file computed
-// under?" — every field tucks into one byte (bodySize ∈ {8,10,12,14},
-// lineGap ∈ [0,4], family ∈ {0,1}, bionic ∈ {0,1}, statusbarReserve in
-// pixels — currently 0/1/STATUS_H). family + bionic share the third byte
-// (4 bits each) to leave room for statusbarReserve in the top byte.
+// under?" — bodySize ∈ {8,10,12,14} and lineGap ∈ [0,4] get a byte each.
+// Third byte really packs in the small fields: family ∈ {0,1} gets 2 bits to allow for
+// growth; and, bionic ∈ {0,1} and halfGaps ∈ {0,1} get a bit each.
+// statusbarReserve in pixels (currently 0/1/STATUS_H) gets to stretch out in the top byte.
+// Bits 20-23 are currently spare.
 static uint32_t encodeLayoutVersion(const PageCacheLayout& layout) {
-  return ((uint32_t)(layout.bodySize         & 0xFF))
-       | ((uint32_t)(layout.lineGap          & 0xFF) << 8)
-       | ((uint32_t)(layout.family           & 0x0F) << 16)
-       | ((uint32_t)(layout.bionic           & 0x0F) << 20)
-       | ((uint32_t)(layout.statusbarReserve & 0xFF) << 24);
+  return ((uint32_t)(layout.bodySize         & 0x0F))
+       | ((uint32_t)(layout.lineGap          & 0x0F) << 8)
+       | ((uint32_t)(layout.family           & 0x03) << 16)
+       | ((uint32_t)(layout.bionic           & 0x01) << 18)
+       | ((uint32_t)(layout.bionic           & 0x01) << 19)
+       | ((uint32_t)(layout.statusbarReserve & 0x0F) << 24);
 }
 
 static String pageCachePathForBook(const String& path) {

--- a/Pala_One_2_1/src/storage/page_cache.h
+++ b/Pala_One_2_1/src/storage/page_cache.h
@@ -40,6 +40,7 @@ struct PageCacheLayout {
   int     lineGap;           // [0, 4]
   uint8_t family;            // matches Font::Family numeric value (0 = Helv, 1 = Dys)
   uint8_t bionic;            // 0 / 1
+  uint8_t halfGaps;          // 0 / 1 - half-height paragraph gaps
   uint8_t statusbarReserve;  // pixels reserved at the bottom; from Statusbar::reserveH()
 };
 

--- a/Pala_One_2_1/src/ui/font.cpp
+++ b/Pala_One_2_1/src/ui/font.cpp
@@ -35,6 +35,7 @@ static int    s_size    = 10;
 static int    s_lineGap = 0;
 static Family s_family  = Family::Helvetica;
 static bool   s_bionic  = false;
+static bool   s_halfGaps = false;
 
 // Layout-metrics cache. Invalid after the mutators below; recomputed on the
 // next bodyLayout() call.
@@ -46,6 +47,7 @@ static constexpr const char* kKeyBodySize   = "cfg_font";
 static constexpr const char* kKeyLineGap    = "cfg_lgap";
 static constexpr const char* kKeyFamily     = "cfg_font_fam";
 static constexpr const char* kKeyBionic     = "cfg_bionic";
+static constexpr const char* kKeyHalfGaps   = "cfg_hgap";
 
 // Pick the (regular, bold) pair for a given size + family. Centralized so
 // applyBodySize and applyFamily share one switch. Returns true if `sz` was
@@ -111,6 +113,7 @@ const LayoutMetrics& bodyLayout() {
     s_layout.ascent  = u8g2.getFontAscent();
     s_layout.descent = u8g2.getFontDescent();
     s_layout.lineH   = (s_layout.ascent - s_layout.descent) + s_lineGap;
+    s_layout.paragraphGapH = s_halfGaps ? (s_layout.lineH / 2) : s_layout.lineH;
 
     s_layout.maxWidth = SCREEN_W - (MARGIN_X * 2);
 
@@ -130,6 +133,7 @@ void loadSettings() {
   applyBodySize(prefs.getInt(kKeyBodySize, 10));
   applyLineGap(prefs.getInt(kKeyLineGap, 0));
   s_bionic = (prefs.getInt(kKeyBionic, 0) != 0);
+  s_halfGaps = (prefs.getInt(kKeyHalfGaps, 0) != 0);
 }
 
 void setBodySize(int sz) {
@@ -156,10 +160,20 @@ void setBionic(bool on) {
   prefs.putInt(kKeyBionic, on ? 1 : 0);
 }
 
+void setHalfParagraphGaps(bool on) {
+  if (s_halfGaps == on) return;
+  s_halfGaps = on;
+  // Changing paragraph height changes page layout so drop the
+  // cached metrics and invalidate caches.
+  s_layoutValid = false;
+  prefs.putInt(kKeyHalfGaps, on ? 1 : 0);
+}
+
 int    currentBodySize() { return s_size; }
 int    currentLineGap()  { return s_lineGap; }
 Family currentFamily()   { return s_family; }
 bool   bionicEnabled()   { return s_bionic; }
+bool   halfParagraphGapsEnabled() { return s_halfGaps; }
 
 PageCacheLayout layoutForCache() {
   // Statusbar reserve goes into the cache stamp too — toggling between
@@ -171,6 +185,7 @@ PageCacheLayout layoutForCache() {
     /*lineGap         =*/s_lineGap,
     /*family          =*/(uint8_t)s_family,
     /*bionic          =*/(uint8_t)(s_bionic ? 1 : 0),
+    /*halfGaps        =*/(uint8_t)(s_halfGaps ? 1 : 0),
     /*statusbarReserve=*/(uint8_t)Statusbar::reserveH(),
   };
 }

--- a/Pala_One_2_1/src/ui/font.h
+++ b/Pala_One_2_1/src/ui/font.h
@@ -72,6 +72,7 @@ void setBodySize(int sz);
 void setLineGap(int gap);
 void setFamily(Family fam);
 void setBionic(bool on);
+void setHalfParagraphGaps(bool on);
 
 // Current applied values. Page-cache stamping passes everything through
 // `layoutForCache()`; these direct accessors exist for places that need
@@ -80,6 +81,7 @@ int    currentBodySize();
 int    currentLineGap();
 Family currentFamily();
 bool   bionicEnabled();
+bool   halfParagraphGapsEnabled();
 
 // One-shot snapshot of every layout-affecting setting, packed for stamping
 // the on-disk page cache. Centralizing this here means call sites in

--- a/Pala_One_2_1/src/ui/text.cpp
+++ b/Pala_One_2_1/src/ui/text.cpp
@@ -27,6 +27,8 @@ uint32_t drawPageAt(File& f, uint32_t startPos) {
 
   int cursorY = TOP_PAD + m.ascent;
   auto onLine = [&](const char* buf, size_t /*len*/) {
+    // nullptr indicates a paragraph break. Advance by gap height.
+    if (buf == nullptr) { cursorY += m.paragraphGapH; return; }
     // drawBionicLine sets the active u8g2 font back to Body before returning,
     // so the next line measurement (via bodyMeasure) is consistent.
     Font::drawBionicLine(MARGIN_X, cursorY, buf);
@@ -42,6 +44,8 @@ uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
   Font::useBody();
 
   auto onLine = [&](const char* buf, size_t len) {
+    // nullptr indicates paragraph break.
+    if (buf == nullptr) { out.concat('\n'); return; }
     // Trim leading whitespace (paginator already trims trailing).
     const char* start = buf;
     size_t remaining = len;

--- a/Pala_One_2_1/src/ui/text.cpp
+++ b/Pala_One_2_1/src/ui/text.cpp
@@ -26,9 +26,9 @@ uint32_t drawPageAt(File& f, uint32_t startPos) {
   Font::useBody();
 
   int cursorY = TOP_PAD + m.ascent;
-  auto onLine = [&](const char* buf, size_t /*len*/) {
-    // nullptr indicates a paragraph break. Advance by gap height.
-    if (buf == nullptr) { cursorY += m.paragraphGapH; return; }
+  auto onLine = [&](const char* buf, size_t len) {
+    // len 0 indicates a paragraph gap. Advance by gap height.
+    if (len == 0) { cursorY += m.paragraphGapH; return; }
     // drawBionicLine sets the active u8g2 font back to Body before returning,
     // so the next line measurement (via bodyMeasure) is consistent.
     Font::drawBionicLine(MARGIN_X, cursorY, buf);
@@ -44,8 +44,8 @@ uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
   Font::useBody();
 
   auto onLine = [&](const char* buf, size_t len) {
-    // nullptr indicates paragraph break.
-    if (buf == nullptr) { out.concat('\n'); return; }
+    // len 0 indicates paragraph break.
+    if (len == 0) { out.concat('\n'); return; }
     // Trim leading whitespace (paginator already trims trailing).
     const char* start = buf;
     size_t remaining = len;

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -95,6 +95,8 @@ static void handleSettings() {
 
   bool curBionic   = Font::bionicEnabled();
   String bChecked  = curBionic ? " checked" : "";
+  bool curHalfGaps = Font::halfParagraphGapsEnabled();
+  String hgChecked = curHalfGaps ? " checked" : "";
 
   String out = webPageStart(
     D_WEB_SETTINGS_TITLE,
@@ -157,6 +159,9 @@ static void handleSettings() {
     "<div class='full' style='grid-column:1/-1'><label style='display:flex;gap:10px;align-items:center;font-weight:600'>"
     "<input type='checkbox' name='bionic' value='1'"; out += bChecked; out += "><span>" D_WEB_BIONIC_LABEL "</span></label>"
     "<div class='hint'>" D_WEB_BIONIC_HINT "</div></div>"
+    "<div class='full' style='grid-column:1/-1'><label style='display:flex;gap:10px;align-items:center;font-weight:600'>"
+    "<input type='checkbox' name='hgap' value='1'"; out += hgChecked; out += "><span>" D_WEB_PARA_GAP_LABEL "</span></label>"
+    "<div class='hint'>" D_WEB_PARA_GAP_HINT "</div></div>"
     "</div>"
     "<div style='margin-top:14px'>"
     "<label style='display:flex;align-items:center;gap:8px;font-weight:600;cursor:pointer'>"
@@ -222,6 +227,11 @@ static bool applySettingsForm() {
   bool wantBionic = server.hasArg("bionic");
   if (wantBionic != Font::bionicEnabled()) {
     Font::setBionic(wantBionic);
+    layoutChanged = true;
+  }
+  bool wantHalfGaps = server.hasArg("hgap");
+  if (wantHalfGaps != Font::halfParagraphGapsEnabled()) {
+    Font::setHalfParagraphGaps(wantHalfGaps);
     layoutChanged = true;
   }
   return layoutChanged;

--- a/test/test_paginator.cpp
+++ b/test/test_paginator.cpp
@@ -104,3 +104,43 @@ TEST_CASE("paginator handles UTF-8 multibyte characters without splitting them")
   REQUIRE(lines.size() == 1u);
   CHECK_EQ(lines[0], String("café"));
 }
+
+TEST_CASE("height based line budgeting works as expected") {
+  auto lines = linesOf("One\nTwo\nThree\nFour\nFive\nSix\nSeven\nEight\n", m(50, 5));
+  CHECK_EQ(lines.size(), 5u);
+  CHECK_EQ(lines[0], String("One"));
+  CHECK_EQ(lines[1], String("Two"));
+  CHECK_EQ(lines[2], String("Three"));
+  CHECK_EQ(lines[3], String("Four"));
+  CHECK_EQ(lines[4], String("Five"));
+}
+
+TEST_CASE("changing paragraph height allows more lines") {
+  auto lm = m(50, 10);
+  auto lines = linesOf("One\n\nTwo\n\nThree\n\nFour\n\nFive\n\nSix\n\nSeven\n\nEight\n", lm);
+  CHECK_EQ(lines.size(), 10u);
+  CHECK_EQ(lines[0], String("One"));
+  CHECK_EQ(lines[2], String("Two"));
+  CHECK_EQ(lines[4], String("Three"));
+  CHECK_EQ(lines[6], String("Four"));
+  CHECK_EQ(lines[8], String("Five"));
+  
+  lm.paragraphGapH = lm.lineH / 2;
+  lines = linesOf("One\n\nTwo\n\nThree\n\nFour\n\nFive\n\nSix\n\nSeven\n\nEight\n", lm);
+  CHECK_EQ(lines.size(), 13u);
+  CHECK_EQ(lines[0], String("One"));
+  CHECK_EQ(lines[2], String("Two"));
+  CHECK_EQ(lines[4], String("Three"));
+  CHECK_EQ(lines[6], String("Four"));
+  CHECK_EQ(lines[8], String("Five"));
+  CHECK_EQ(lines[10], String("Six"));
+  CHECK_EQ(lines[12], String("Seven"));
+}
+
+TEST_CASE("skip empty lines at start of page") {
+  auto lines = linesOf("\n\nOne\nTwo\nThree\nFour\nFive\nSix\nSeven\nEight\n", m(50, 3));
+  CHECK_EQ(lines.size(), 3u);
+  CHECK_EQ(lines[0], String("One"));
+  CHECK_EQ(lines[1], String("Two"));
+  CHECK_EQ(lines[2], String("Three"));
+}


### PR DESCRIPTION
Currently a lot of screen real estate is given over to paragraph breaks. This change adds an option for paragraph breaks to only span half a line instead of a full line. This means we can get more lines of useful text on the screen while still making paragraphs clear.

This required changing the screen layout calculation to rely on a pixel budget rather than just counting lines.  Changing the setting also invalidates the on disk page cache.

Other than that, the implementation mostly followed the same paths as the similar "bionic reading" feature.

NOTE: I do not speak Spanish and I used automated translation tools for the UI text.