### PR TITLE
Show progress of long page index rebuilds.

### DIFF
--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -109,6 +109,9 @@
 // ----------------------------------------------------------------------------
 #define D_READER_BOOK_EMPTY         "Book empty"
 #define D_READER_BACK_LIBRARY       "Back to library"
+#define D_READER_INDEXING_TITLE     "Preparing book..."
+#define D_READER_INDEXING_DETAIL    "Rebuilding page index"
+
 
 // ----------------------------------------------------------------------------
 //  App loader error overlay (src/ui/pala_api_impl.cpp paintLoadError)

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -109,6 +109,9 @@
 // ----------------------------------------------------------------------------
 #define D_READER_BOOK_EMPTY         "Libro vacío"
 #define D_READER_BACK_LIBRARY       "Volver a biblioteca"
+#define D_READER_INDEXING_TITLE     "Preparando libro..."
+#define D_READER_INDEXING_DETAIL    "Reconstruyendo índice de páginas"
+
 
 // ----------------------------------------------------------------------------
 //  App loader error overlay

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -168,10 +168,15 @@ static void ensureOffsetsUpTo(int targetPage) {
 // rebuilds.
 static const uint32_t kRebuildSplashDelayMs  = 500;
 // Controls how long between progress updates.
-// Screen updates take a while, so there's no point in updating constantly.
+// Screen updates take a while, so updating too frequently will actually increase
+// the time a rebuild can take substantially.
 static const uint32_t kRebuildSplashRedrawMs = 700;
 
 static void drawCacheRebuildProgress(int pct, bool firstFrame) {
+  const int barX = MARGIN_X;
+  const int barW = SCREEN_W - 2 * MARGIN_X;
+  const int barY = 74;
+  const int barH = 10;
   if (firstFrame) {
     prepareMenuFrame();
     Font::useBody();
@@ -188,10 +193,6 @@ static void drawCacheRebuildProgress(int pct, bool firstFrame) {
 
     gfx.drawRect(barX, barY, barW, barH, 1);
   }
-  const int barX = MARGIN_X;
-  const int barW = SCREEN_W - 2 * MARGIN_X;
-  const int barY = 74;
-  const int barH = 10;
   int fillW = ((barW - 4) * pct) / 100;
   if (fillW > 0) gfx.fillRect(barX + 2, barY + 2, fillW, barH - 4, 1);
 

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -181,8 +181,7 @@ static void drawCacheRebuildProgress(int pct, bool firstFrame) {
     prepareMenuFrame();
     Font::useBody();
     int ascent = u8g2.getFontAscent();
-    int lineH  = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 1;
-    int y = drawSectionHeader(D_READER_INDEXING_TITLE);
+    drawSectionHeader(D_READER_INDEXING_TITLE);
 
     // The detail message is expected to be a little longer.
     // Use toast font to give us more room for translations.

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -180,7 +180,6 @@ static void drawCacheRebuildProgress(int pct, bool firstFrame) {
   if (firstFrame) {
     prepareMenuFrame();
     Font::useBody();
-    int ascent = u8g2.getFontAscent();
     drawSectionHeader(D_READER_INDEXING_TITLE);
 
     // The detail message is expected to be a little longer.

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -163,13 +163,69 @@ static void ensureOffsetsUpTo(int targetPage) {
   }
 }
 
-int findPageForOffset(uint32_t targetOffset) {
+// Controls how long after we start rebuilding the page index to wait before
+// showing progress. This way we don't wast time doing screen updates for small
+// rebuilds.
+static const uint32_t kRebuildSplashDelayMs  = 500;
+// Controls how long between progress updates.
+// Screen updates take a while, so there's no point in updating constantly.
+static const uint32_t kRebuildSplashRedrawMs = 700;
+
+static void drawCacheRebuildProgress(int pct, bool firstFrame) {
+  if (firstFrame) {
+    prepareMenuFrame();
+    Font::useBody();
+    int ascent = u8g2.getFontAscent();
+    int lineH  = (ascent - u8g2.getFontDescent()) + Font::currentLineGap() + 1;
+    int y = drawSectionHeader(D_READER_INDEXING_TITLE);
+
+    // The detail message is expected to be a little longer.
+    // Use toast font to give us more room for translations.
+    Font::useToast();
+    int w = u8g2.getUTF8Width(D_READER_INDEXING_DETAIL);
+    u8g2.setCursor((SCREEN_W - w) / 2, 60);
+    u8g2.print(D_READER_INDEXING_DETAIL);
+
+    gfx.drawRect(barX, barY, barW, barH, 1);
+  }
+  const int barX = MARGIN_X;
+  const int barW = SCREEN_W - 2 * MARGIN_X;
+  const int barY = 74;
+  const int barH = 10;
+  int fillW = ((barW - 4) * pct) / 100;
+  if (fillW > 0) gfx.fillRect(barX + 2, barY + 2, fillW, barH - 4, 1);
+
+  display.update();
+}
+
+int findPageForOffset(uint32_t targetOffset, bool showProgress) {
+  uint32_t startMs = millis();
+  uint32_t lastDrawMs = 0;
+  int shownPct = -1;
+
   // Extend forward until the last known page starts at or past the target,
   // or we can't extend further.
   while (g_bookview.pages.count == 0
       || g_bookview.pages.offsets[g_bookview.pages.count - 1] < targetOffset) {
     if (!tryExtendPageTable()) break;
+    if (showProgress) {
+      uint32_t now = millis();
+      if (shownPct < 0 && now - startMs < kRebuildSplashDelayMs) continue;
+      if (shownPct >= 0 && now - lastDrawMs < kRebuildSplashRedrawMs) continue;
+	  int pct = (int)(((uint64_t)g_bookview.pages.offsets[g_bookview.pages.count - 1]
+                     * 100) / targetOffset);
+	  if (pct > 100) pct = 100;
+      if (pct <= shownPct) continue;
+
+      drawCacheRebuildProgress(pct, /*firstFrame=*/shownPct < 0);
+      shownPct = pct;
+      lastDrawMs = millis();
+    }
   }
+
+  // Progress bar can make for ugly ghosting.
+  if (shownPct >= 0) forceNextRenderFull();
+
   // The page containing `targetOffset` is the largest N with
   // offsets[N] <= targetOffset.
   for (int i = g_bookview.pages.count - 1; i >= 0; i--) {
@@ -210,7 +266,7 @@ bool openBookByIndex(int idx) {
   PreferencesStore kv(prefs);
   uint32_t savedOffset = loadSavedOffset(kv, g_bookview.book.key());
   if (savedOffset != kOffsetUnset) {
-    g_bookview.cursor.pageIndex = findPageForOffset(savedOffset);
+    g_bookview.cursor.pageIndex = findPageForOffset(savedOffset, /*showProgress=*/ true);
   } else {
     g_bookview.cursor.pageIndex = loadSavedPage(kv, g_bookview.book.key());
   }

--- a/Pala_One_2_1/src/ui/reader.h
+++ b/Pala_One_2_1/src/ui/reader.h
@@ -78,7 +78,10 @@ bool retreatPage();
 // active book forward as needed (so the page table grows up to the answer).
 // Used to resume from a saved byte offset and to navigate to a bookmark
 // whose offset is invariant under font/layout changes.
-int findPageForOffset(uint32_t targetOffset);
+// Setting showProgress to true will cause the device to show a fullscreen
+// progress interstitial if the index rebuild happens to take a long time
+// so that the user knows something is happening.
+int findPageForOffset(uint32_t targetOffset, bool showProgress=false);
 
 // Boot-time wake-resume. Checks if wake state asks us to resume reading and
 // if the book still exists. On success the reader is fully set up for an


### PR DESCRIPTION
Rebuilding the page index can take a while especially if you're deep into a book. At the moment this presents to the user as just a long freeze with no explanation.

This change adds a progress interstitial  when index rebuilds take longer than some threshold (currently 500ms). Progress is shown by a bar that fills as progress is made.

This will address issue #70 and is the beginning of adressing #118. It was also brough up during PR #116.

<img width="2200" height="1296" alt="20260706_233438" src="https://github.com/user-attachments/assets/5564921d-3209-4d28-b621-b8808be3a882" />
