### PR TITLE
Allow WiFi settings to be managed from the Web UI.

### DIFF
--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -360,9 +360,10 @@
 #define D_WEB_WIFI_PASSWORD_LABEL     "Password"
 #define D_WEB_WIFI_SSID_PLACEHOLDER   "Network name"
 #define D_WEB_WIFI_PASSWORD_PLACEHOLDER "Password"
+#define D_WEB_WIFI_PASSWORD_SAVED_PLACEHOLDER "<saved>"
 #define D_WEB_WIFI_SHOW_PASSWORD      "Show password"
 #define D_WEB_WIFI_SAVE_BUTTON        "Save network"
-#define D_WEB_WIFI_HINT               "Stored on device. Leave the SSID blank to forget it."
+#define D_WEB_WIFI_HINT               "Stored on device. Leave the SSID blank to forget it. For security reasons, saved passwords will never be shown."
 
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Device"

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -370,7 +370,7 @@
 // Wi-Fi card (src/web/settings.cpp) — the saved network the upload screen
 // joins.
 #define D_WEB_WIFI_HEADING            "Wi-Fi"
-#define D_WEB_WIFI_INTRO              "The network the device joins for file upload."
+#define D_WEB_WIFI_INTRO              "The network the device joins for file upload. For security reasons, saved passwords will never be shown."
 #define D_WEB_WIFI_SSID_LABEL         "SSID"
 #define D_WEB_WIFI_PASSWORD_LABEL     "Password"
 #define D_WEB_WIFI_SSID_PLACEHOLDER   "Network name"
@@ -378,7 +378,7 @@
 #define D_WEB_WIFI_PASSWORD_SAVED_PLACEHOLDER "<saved>"
 #define D_WEB_WIFI_SHOW_PASSWORD      "Show password"
 #define D_WEB_WIFI_SAVE_BUTTON        "Save network"
-#define D_WEB_WIFI_HINT               "Stored on device. Leave the SSID blank to forget it. For security reasons, saved passwords will never be shown."
+#define D_WEB_WIFI_HINT               "Stored on device. Leave the SSID blank to forget it."
 
 // ----------------------------------------------------------------------------
 //  Upload (book + sleep image) routes (src/web/upload.cpp)

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -337,6 +337,18 @@
 #define D_WEB_BUTTONS_ACTION_MENU     "Open menu"
 #define D_WEB_BUTTONS_ACTION_ROTATE     "Flip screen orientation"
 
+// Wi-Fi card (src/web/settings.cpp) — the saved network the upload screen
+// joins.
+#define D_WEB_WIFI_HEADING            "Wi-Fi"
+#define D_WEB_WIFI_INTRO              "The network the device joins for file upload."
+#define D_WEB_WIFI_SSID_LABEL         "SSID"
+#define D_WEB_WIFI_PASSWORD_LABEL     "Password"
+#define D_WEB_WIFI_SSID_PLACEHOLDER   "Network name"
+#define D_WEB_WIFI_PASSWORD_PLACEHOLDER "Password"
+#define D_WEB_WIFI_SHOW_PASSWORD      "Show password"
+#define D_WEB_WIFI_SAVE_BUTTON        "Save network"
+#define D_WEB_WIFI_HINT               "Stored on device. Leave the SSID blank to forget it."
+
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Device"
 #define D_WEB_DEVICE_INTRO          "Personalize the device name shown on the library screen header."

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -357,7 +357,7 @@
 // Wi-Fi card (src/web/settings.cpp) — the saved network the upload screen
 // joins.
 #define D_WEB_WIFI_HEADING            "Wi-Fi"
-#define D_WEB_WIFI_INTRO              "La red a la que el dispositivo se une para subir archivos." // Translated by Claude
+#define D_WEB_WIFI_INTRO              "La red a la que el dispositivo se une para subir archivos. Por motivos de seguridad, las contraseñas guardadas nunca se mostrarán." // Translated by Claude
 #define D_WEB_WIFI_SSID_LABEL         "SSID"
 #define D_WEB_WIFI_PASSWORD_LABEL     "Contraseña" // Translated by Claude
 #define D_WEB_WIFI_SSID_PLACEHOLDER   "Nombre de la red" // Translated by Claude
@@ -365,7 +365,7 @@
 #define D_WEB_WIFI_PASSWORD_SAVED_PLACEHOLDER "<guardada>" // Translated by Claude
 #define D_WEB_WIFI_SHOW_PASSWORD      "Mostrar contraseña" // Translated by Claude
 #define D_WEB_WIFI_SAVE_BUTTON        "Guardar red" // Translated by Claude
-#define D_WEB_WIFI_HINT               "Se almacena en el dispositivo. Deja el SSID en blanco para olvidarla. Por motivos de seguridad, las contraseñas guardadas nunca se mostrarán." // Translated by Claude
+#define D_WEB_WIFI_HINT               "Se almacena en el dispositivo. Deja el SSID en blanco para olvidarla." // Translated by Claude
 
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Dispositivo"

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -354,9 +354,10 @@
 #define D_WEB_WIFI_PASSWORD_LABEL     "Contraseña" // Translated by Claude
 #define D_WEB_WIFI_SSID_PLACEHOLDER   "Nombre de la red" // Translated by Claude
 #define D_WEB_WIFI_PASSWORD_PLACEHOLDER "Contraseña" // Translated by Claude
+#define D_WEB_WIFI_PASSWORD_SAVED_PLACEHOLDER "<guardada>" // Translated by Claude
 #define D_WEB_WIFI_SHOW_PASSWORD      "Mostrar contraseña" // Translated by Claude
 #define D_WEB_WIFI_SAVE_BUTTON        "Guardar red" // Translated by Claude
-#define D_WEB_WIFI_HINT               "Almacenado en el dispositivo. Deja el SSID vacío para olvidarla." // Translated by Claude
+#define D_WEB_WIFI_HINT               "Se almacena en el dispositivo. Deja el SSID en blanco para olvidarla. Por motivos de seguridad, las contraseñas guardadas nunca se mostrarán." // Translated by Claude
 
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Dispositivo"

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -330,6 +330,18 @@
 #define D_WEB_BUTTONS_ACTION_LOCK     "Bloquear dispositivo"
 #define D_WEB_BUTTONS_ACTION_MENU     "Abrir menú"
 #define D_WEB_BUTTONS_ACTION_ROTATE  "Voltear orientación de la pantalla" // Translate by ChatGPT
+ 
+// Wi-Fi card (src/web/settings.cpp) — the saved network the upload screen
+// joins.
+#define D_WEB_WIFI_HEADING            "Wi-Fi"
+#define D_WEB_WIFI_INTRO              "La red a la que el dispositivo se une para subir archivos." // Translated by Claude
+#define D_WEB_WIFI_SSID_LABEL         "SSID"
+#define D_WEB_WIFI_PASSWORD_LABEL     "Contraseña" // Translated by Claude
+#define D_WEB_WIFI_SSID_PLACEHOLDER   "Nombre de la red" // Translated by Claude
+#define D_WEB_WIFI_PASSWORD_PLACEHOLDER "Contraseña" // Translated by Claude
+#define D_WEB_WIFI_SHOW_PASSWORD      "Mostrar contraseña" // Translated by Claude
+#define D_WEB_WIFI_SAVE_BUTTON        "Guardar red" // Translated by Claude
+#define D_WEB_WIFI_HINT               "Almacenado en el dispositivo. Deja el SSID vacío para olvidarla." // Translated by Claude
 
 // Device personalization card (src/web/settings.cpp).
 #define D_WEB_DEVICE_HEADING        "Dispositivo"

--- a/Pala_One_2_1/src/storage/wifi_creds.h
+++ b/Pala_One_2_1/src/storage/wifi_creds.h
@@ -3,8 +3,10 @@
 
 #include <Arduino.h>
 
-// Persisted home-network Wi-Fi credentials, written by the Improv Serial flow
-// and read by the upload screen when deciding STA vs SoftAP. Stored alongside
+// Persisted home-network Wi-Fi credentials, configurable in two ways:
+//  - The Web settings UI (web/settings.cpp)
+//  - written by the Improv Serial flow (hal/wifi_provisioning.cpp)
+// Read by the upload screen when deciding STA vs SoftAP. Stored alongside
 // the project's other settings in the shared "ereader" NVS namespace
 // (`prefs`), under per-module keys following the existing convention.
 namespace WifiCreds {

--- a/Pala_One_2_1/src/web/chrome.cpp
+++ b/Pala_One_2_1/src/web/chrome.cpp
@@ -69,8 +69,13 @@ static const char kStyleCss[] PROGMEM =
   ".status.idle{background:var(--pill-bg);color:var(--pill-fg)}"
   "button,.btn{display:inline-flex;align-items:center;justify-content:center;border:0;border-radius:10px;background:var(--btn-bg);color:var(--btn-fg);padding:10px 14px;font:600 14px system-ui,sans-serif;text-decoration:none;cursor:pointer}"
   ".btn.secondary{background:var(--btn-sec-bg);color:var(--btn-sec-fg);border:1px solid var(--btn-sec-bd)}"
-  "input[type=text],input[type=number],input[type=file],input[type=search],select,textarea{width:100%;box-sizing:border-box;border:1px solid var(--inp-bd);border-radius:10px;background:var(--inp-bg);color:var(--text);padding:10px;font:inherit}"
+  "input[type=file],input[type=number],input[type=password],input[type=search],input[type=text],select,textarea{width:100%;box-sizing:border-box;border:1px solid var(--inp-bd);border-radius:10px;background:var(--inp-bg);color:var(--text);padding:10px;font:inherit}"
   "input[type=checkbox],input[type=radio]{accent-color:var(--link)}"
+  ".pwwrap{position:relative}"
+  ".pwwrap input{padding-right:40px}"
+  ".pweye{position:absolute;right:4px;top:50%;transform:translateY(-50%);background:none;border:0;padding:6px;cursor:pointer;color:var(--muted);display:inline-flex}"
+  ".pweye .pwh{display:none}"
+  ".pweye.shown .pwh{display:inline}"
   ".theme-toggle{padding:8px 12px;font-size:13px;white-space:nowrap}"
   ".theme-toggle .tgd{display:none}"
   "html[data-theme=dark] .theme-toggle .tgl{display:none}"
@@ -98,6 +103,7 @@ static const char kStyleCss[] PROGMEM =
 // flash of the wrong palette. Reads localStorage.palaTheme first; falls back
 // to the build-time default above. Exposes window.palaToggleTheme() for the
 // button.
+// Also exposes PalaTogglePw to allow password fields to toggle between hidden and shown.
 static const char kThemeScript[] PROGMEM =
   "<script>(function(){"
   "var k='palaTheme',r=document.documentElement;"
@@ -105,6 +111,7 @@ static const char kThemeScript[] PROGMEM =
   "var v=null;try{v=localStorage.getItem(k)}catch(e){}"
   "S((v==='dark'||v==='light')?v:'" WEB_DEFAULT_THEME_JS "');"
   "window.palaToggleTheme=function(){S(r.dataset.theme==='dark'?'light':'dark')};"
+  "window.palaTogglePw=function(b){var i=b.parentNode.querySelector('input');var s=(i.type==='password');i.type=s?'text':'password';b.classList.toggle('shown',s);};"
   "})();</script>";
 
 static void handleStyleCss() {

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -348,12 +348,12 @@ static void handleSettingsPost() {
   // POST won't accidentally wipe the stored network via absent fields.
   // A blank SSID forgets the stored network.
   if (server.hasArg("wifi_form")) {
-    String ssid = server.hasArg("wifi_ssid") ? server.arg("wifi_ssid") : "";
+    String ssid = server.hasArg("wssid") ? server.arg("wssid") : "";
     ssid.trim();
     if (ssid.length() == 0) {
       WifiCreds::clear();
     } else {
-      WifiCreds::save(ssid, server.hasArg("wifi_pass") ? server.arg("wifi_pass") : "");
+      WifiCreds::save(ssid, server.hasArg("wpass") ? server.arg("wpass") : "");
     }
   }
 

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -208,7 +208,8 @@ static void handleSettings() {
     "<div><label for='wpass'>" D_WEB_WIFI_PASSWORD_LABEL "</label>"
     "<div class='pwwrap'>"
     "<input type='password' id='wpass' name='wpass' maxlength='64' placeholder='" D_WEB_WIFI_PASSWORD_PLACEHOLDER "' value='";
-  out += htmlAttrEscape(WifiCreds::pass().c_str());
+  // Never echo out the saved password verbatim for security reasons.
+  out += WifiCreds::pass().isEmpty() ? "" : D_WEB_WIFI_PASSWORD_SAVED_PLACEHOLDER;
   // Pasword area includes a crude SVG of an eye with a strike through that
   // acts as a button to allow it to be shown/hidden as appropriate.
   out +=
@@ -355,7 +356,12 @@ static void handleSettingsPost() {
     if (ssid.length() == 0) {
       WifiCreds::clear();
     } else {
-      WifiCreds::save(ssid, server.hasArg("wpass") ? server.arg("wpass") : "");
+      // If we get the saved password placeholder back, assume the user wants to keep that password as is.
+      String pass = server.hasArg("wpass") ? server.arg("wpass") : "";
+      if (pass == D_WEB_WIFI_PASSWORD_SAVED_PLACEHOLDER) {
+        pass = WifiCreds::pass();
+      }
+      WifiCreds::save(ssid, pass);
     }
   }
 

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -11,6 +11,7 @@
 #include "src/ui/reader.h"                // g_bookview, findPageForOffset, renderCurrentPage
 #include "src/ui/reader_actions.h"        // ButtonAction + Gestures
 #include "src/ui/screens/reader_screen.h" // g_readerScreen — active-reader check
+#include "src/storage/wifi_creds.h"
 #include "src/ui/lock.h"
 #include "src/ui/sleep.h"
 #include "src/web/chrome.h"
@@ -188,6 +189,39 @@ static void handleSettings() {
   out += "</div><div class='actions' style='margin-top:24px'><button type='submit'>" D_WEB_BUTTONS_SAVE "</button>";
   out += "<span class='muted'>" D_WEB_BUTTONS_LOCK_HINT "</span>";
   out += "</div></form></div>";
+ 
+  // Wi-Fi card — own form (wifi_form sentinel), posts back to the same
+  // /settings endpoint as the other cards. Edits the single stored network
+  // the upload screen joins.
+  out +=
+    "<div class='card'><h2>" D_WEB_WIFI_HEADING "</h2>"
+    "<p class='muted'>" D_WEB_WIFI_INTRO "</p>"
+    "<form method='POST' action='/settings' accept-charset='UTF-8' style='margin-top:12px'>"
+    "<div class='grid cols-2'>"
+    "<div><label for='wssid'>" D_WEB_WIFI_SSID_LABEL "</label>"
+    "<input type='text' id='wssid' name='wssid' maxlength='32' placeholder='" D_WEB_WIFI_SSID_PLACEHOLDER "' value='";
+  out += htmlAttrEscape(WifiCreds::ssid().c_str());
+  out +=
+    "'></div>"
+    "<div><label for='wpass'>" D_WEB_WIFI_PASSWORD_LABEL "</label>"
+    "<div class='pwwrap'>"
+    "<input type='password' id='wpass' name='wpass' maxlength='64' placeholder='" D_WEB_WIFI_PASSWORD_PLACEHOLDER "' value='";
+  out += htmlAttrEscape(WifiCreds::pass().c_str());
+  // Pasword area includes a crude SVG of an eye with a strike through that
+  // acts as a button to allow it to be shown/hidden as appropriate.
+  out +=
+    "'>"
+    "<button type='button' class='pweye' onclick='palaTogglePw(this)' aria-label='" D_WEB_WIFI_SHOW_PASSWORD "'>"
+    "<svg width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor'"
+    " stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>"
+    "<path d='M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z'/><circle cx='12' cy='12' r='3'/>"
+    "<line class='pwh' x1='3' y1='21' x2='21' y2='3'/></svg>"
+    "</button></div></div>"
+    "</div>"
+    "<input type='hidden' name='wifi_form' value='1'>"
+    "<div class='actions' style='margin-top:14px'><button type='submit'>" D_WEB_WIFI_SAVE_BUTTON "</button>"
+    "<span class='muted'>" D_WEB_WIFI_HINT "</span></div>"
+    "</form></div>";
 
   out += webPageEnd();
   server.send(200, "text/html; charset=utf-8", out);
@@ -308,6 +342,19 @@ static void handleSettingsPost() {
   }
   if (server.hasArg("btnCH")) {
     Gestures::setActionClickHold((ButtonAction)server.arg("btnCH").toInt());
+  }
+
+  // Wi-Fi — its own form, guarded by wifi_form sentinel, so a Reading/Device/Buttons
+  // POST won't accidentally wipe the stored network via absent fields.
+  // A blank SSID forgets the stored network.
+  if (server.hasArg("wifi_form")) {
+    String ssid = server.hasArg("wifi_ssid") ? server.arg("wifi_ssid") : "";
+    ssid.trim();
+    if (ssid.length() == 0) {
+      WifiCreds::clear();
+    } else {
+      WifiCreds::save(ssid, server.hasArg("wifi_pass") ? server.arg("wifi_pass") : "");
+    }
   }
 
   server.sendHeader("Location", "/settings");

--- a/README.md
+++ b/README.md
@@ -40,11 +40,25 @@ The board version is usually printed on the back of the PCB.
 
 Pick your board's revision in the build step below — either by uncommenting the matching `#define` at the top of `Pala_One_2_1/Pala_One_2_1.ino` (Arduino IDE), or by selecting the matching env (PlatformIO).
 
-## Wi-Fi provisioning (Improv)
+## Wi-Fi Setup
 
-Besides the SoftAP captive portal, the firmware supports **Improv Serial** Wi-Fi provisioning ([improv-wifi.com](https://www.improv-wifi.com)) over the USB-CDC port, using the [`jnthas/Improv-WiFi-Library`](https://github.com/jnthas/Improv-WiFi-Library). When the board is plugged into a computer, a browser can hand it Wi-Fi credentials directly — the [web installer](https://paullagier.github.io/pala-one-firmware/) does this right after flashing and then redirects to `connected.html`.
+Out of the box, the device supports a SoftAP captive portal that can be used to upload books and adjust settings. The device can also be configured to connect to a single WiFi network via one of
+two methods: Improv WiFi provisioning via USB; or, the Web UI.
+
+### Configuring using Improv
+
+The firmware supports **Improv Serial** Wi-Fi provisioning ([improv-wifi.com](https://www.improv-wifi.com)) over the USB-CDC port, using the [`jnthas/Improv-WiFi-Library`](https://github.com/jnthas/Improv-WiFi-Library). When the board is plugged into a computer, a browser can hand it Wi-Fi credentials directly — the [web installer](https://paullagier.github.io/pala-one-firmware/) does this right after flashing and then redirects to `connected.html`.
 
 Saved credentials let the device join your network in **Station mode** the next time it enters the web UI / upload mode; if none are saved (or the join fails) it falls back to the open SoftAP at `192.168.4.1`.
+
+### Configuring using Web UI
+
+On the `/settings` page of the device's Web UI, you can also find a "WiFi" section at the bottom. This will let you enter an SSID and password for the device to connect to. The next time you select "Upload"
+from the main menu, the device will try to connect to the configured WiFi network before falling back to the Soft AP mode (you can also force the fallback by pressing the button).
+
+Note: The `/settings` page will never show your actual WiFi password, it will simply indicate if one is saved or not.
+
+<img width="512" height="150" alt="WiFi Configuration Settings" src="[https://github.com/user-attachments/assets/e787ae2c-75d9-4ccd-8ce8-8093d3fb1b4d" />
 
 ## Customizing click behaviours
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ from the main menu, the device will try to connect to the configured WiFi networ
 
 Note: The `/settings` page will never show your actual WiFi password, it will simply indicate if one is saved or not.
 
-<img width="512" height="150" alt="WiFi Configuration Settings" src="[https://github.com/user-attachments/assets/e787ae2c-75d9-4ccd-8ce8-8093d3fb1b4d" />
-
 ## Customizing click behaviours
 
 Version 3.2 introduces a fully customizable action system. You can now bind *any* **action** (e.g. go-home, bookmark, sleep, ...) to any **gesture** (e.g. single click, double click, ...).


### PR DESCRIPTION
Adds a card at the end of the existing settings page that provides another path to setting/clearing wifi settings for the device than just USB provisioning. Very useful when you're on the road.

The password is hidden by default but can be shown by clicking on a small SVG button made to look like an eye. I could have used unicode characters to make life simpler, but they wouldn't have followed the light/dark theme and would look different depending on OS, so this felt like a better fit.

Closes #121.

<img width="875" height="291" alt="Screenshot 2026-07-07 231751" src="https://github.com/user-attachments/assets/b72f5979-66d9-469d-b78a-6365c2f8a091" />
<img width="866" height="283" alt="Screenshot 2026-07-07 231806" src="https://github.com/user-attachments/assets/68a23a37-a615-4659-b352-88e7384f3258" />
<img width="846" height="272" alt="Screenshot 2026-07-07 232450" src="https://github.com/user-attachments/assets/d39ae327-c9b1-4b34-bbaf-a798106d559b" />
<img width="843" height="272" alt="Screenshot 2026-07-07 232501" src="https://github.com/user-attachments/assets/3cd808ec-15a0-4a3e-9537-087ab7ad953d" />
