### PR TITLE
Buffer file reads to improve pagination performance

### DIFF
--- a/Pala_One_2_1/src/config.h
+++ b/Pala_One_2_1/src/config.h
@@ -110,6 +110,12 @@ static const float BAT_CHARGING_VOLTAGE = 4.2f;
 static const int FULL_REFRESH_EVERY_N_PAGES = 100;
 static const int MENU_FULL_REFRESH_EVERY = 60;
 
+// Buffer size for file read operations. Bigger is not necessarily
+// better as you might wind up just pulling in more data than you need
+// to fill a page. This was a value that worked well with both ASCII
+// unicode inputs.
+static const size_t FILE_STREAM_BUF_BYTES = 512;
+
 static const int MARGIN_X = 6;
 static const int TOP_PAD = 3;
 static const int BOT_PAD = 0;

--- a/Pala_One_2_1/src/hal/file_stream.h
+++ b/Pala_One_2_1/src/hal/file_stream.h
@@ -22,4 +22,64 @@ private:
   File& f_;
 };
 
+// Buffered variant of the FileReadStream that reads in FILE_STREAM_BUF_BYTES
+// at a time from the file and then hands them out one by one in calls to read.
+// This avoids traversing the whole stack up and down (twice, once to check available
+// and once to read) to the file system for each and every byte read.
+// IMPORTANT: The tradeoff here is that the position and seek are calls are handled
+// virtually within the buffer layer and wont necessarily be reflected on the underlying
+// file object. At the time of writing this is okay because all callsites perform an
+// explicit seek before starting to read, but care should be taken for new callsites.
+class BufferedFileReadStream : public IReadStream {
+public:
+  explicit BufferedFileReadStream(File& f)
+      : f_(f), size_((uint32_t)f.size()), pos_((uint32_t)f.position()) {
+    buf_ = (uint8_t*)malloc(kBufCap);
+  }
+  ~BufferedFileReadStream() override { free(buf_); }
+
+  int read() override {
+    if (pos_ >= size_) return -1;
+    if (!buf_) {
+      if (!f_.seek(pos_)) return -1;
+      int b = f_.read();
+      if (b >= 0) pos_++;
+      return b;
+    }
+    if (pos_ < winStart_ || pos_ >= winStart_ + winLen_) {
+      if (!fill(pos_)) return -1;
+    }
+    return buf_[pos_++ - winStart_];
+  }
+
+  bool seek(uint32_t pos) override {
+    if (pos > size_) return false;
+    pos_ = pos;
+    return true;
+  }
+
+  uint32_t position() override { return pos_; }
+  size_t size() override { return size_; }
+  bool available() override { return pos_ < size_; }
+
+private:
+  bool fill(uint32_t at) {
+    if (!f_.seek(at)) return false;
+    size_t n = f_.read(buf_, kBufCap);
+    if (n == 0) return false;
+    winStart_ = at;
+    winLen_ = (uint32_t)n;
+    return true;
+  }
+
+  static constexpr size_t kBufCap = FILE_STREAM_BUF_BYTES;
+
+  File&    f_;
+  uint8_t* buf_;
+  uint32_t size_;
+  uint32_t pos_;
+  uint32_t winStart_ = 0;
+  uint32_t winLen_ = 0;
+};
+
 #endif  // PALA_HAL_FILE_STREAM_H

--- a/Pala_One_2_1/src/ui/text.cpp
+++ b/Pala_One_2_1/src/ui/text.cpp
@@ -21,7 +21,7 @@ static int bodyMeasure(const char* s) {
 //  offset where the next page begins.
 // ============================================================================
 uint32_t drawPageAt(File& f, uint32_t startPos) {
-  FileReadStream stream(f);
+  BufferedFileReadStream stream(f);
   const LayoutMetrics& m = Font::bodyLayout();
   Font::useBody();
 
@@ -37,7 +37,7 @@ uint32_t drawPageAt(File& f, uint32_t startPos) {
 }
 
 uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
-  FileReadStream stream(f);
+  BufferedFileReadStream stream(f);
   const LayoutMetrics& m = Font::bodyLayout();
   Font::useBody();
 
@@ -54,7 +54,7 @@ uint32_t extractPageText(File& f, uint32_t startPos, String& out) {
 }
 
 uint32_t nextPageOffset(File& f, uint32_t startPos) {
-  FileReadStream stream(f);
+  BufferedFileReadStream stream(f);
   const LayoutMetrics& m = Font::bodyLayout();
   Font::useBody();
   return paginatePage(stream, startPos, m, bodyMeasure, nullptr);


### PR DESCRIPTION
At the moment, every byte read from file round trips twice down the entire file handling stack: once to check for next byte availability; and again to actually retrieve the next byte. Even though there are buffers at the bottom of that stack, it's still a substantial cost to pay on a per byte basis.

This change adds a small (512 byte configurable) buffer wrapping all file reads to reduce the number of stack walks we do.

In experiments, this improved individual page rendering time by 50-75% which was especially noticeable when rebuilding page caches. Here's some quick data for one experiment reconstructing the page caches for two books using different buffer sizes:

Book | Vanilla | 4K Buffer | 2K Buffer | 512b Buffer | 256b Buffer
-- | -- | -- | -- | -- | --
DCC | 4944 ms | 1978 ms | 414 ms | 342 ms | 323 ms
long number | 31546 ms | 11058 ms | 5269 ms | 4854 ms | 4871 ms

Note the 256b buffer showed only marginal improvements than 512b and in a separate test performed a little worse when fed unicode inputs (presumably due to going over the buffer size more often) so I went with 512b as the default. Should also mention that that experiment was conducted with the progress bar change in #119 in place. This means that some of the time saving comes from fewer screen updates and not just faster pagination. This is especially true of the first book where it managed to get it under the delay for showing the progress bar at all.

This should go some way to helping to alleviate #118.