### PR TITLE
Speed up line length computation

### DIFF
--- a/Pala_One_2_1/src/pure/paginator.cpp
+++ b/Pala_One_2_1/src/pure/paginator.cpp
@@ -71,8 +71,8 @@ uint32_t paginatePage(IReadStream& in,
     emit(line, lineLen);
     lineLen = 0;
     lineW = 0;
-	tailStart = 0;
-	tailW = 0;
+    tailStart = 0;
+    tailW = 0;
   };
 
   auto safeReturn = [&](uint32_t off) -> uint32_t {
@@ -155,15 +155,15 @@ uint32_t paginatePage(IReadStream& in,
       return startLineWithToken(measure(token));
     }
     // Only put the tail and the token into scratch to recompute width
-	// since the new token isn't going to be able to influence the layout
-	// of anything before that.
+    // since the new token isn't going to be able to influence the layout
+    // of anything before that.
     const size_t tailLen = lineLen - tailStart;
     memcpy(scratch, line + tailStart, tailLen);
     memcpy(scratch + tailLen, token, tokLen);
     scratch[tailLen + tokLen] = 0;
     const int combinedW = measure(scratch);
-	// lineW includes the width of the tail without the new token, so we
-	// need to subtract that here before adding the width of tail + token.
+    // lineW includes the width of the tail without the new token, so we
+    // need to subtract that here before adding the width of tail + token.
     const int candidateW = lineW - tailW + combinedW;
 
     if (candidateW > m.maxWidth) {
@@ -173,9 +173,9 @@ uint32_t paginatePage(IReadStream& in,
     }
 
     // The token fits entirely, perhaps having modified the tail
-	// width. Regardless, candidateW is the new width of the line.
-	// The tail only moves forward on whitespace so for the moment
-	// the start remains the same and the width becoems combinedW.
+    // width. Regardless, candidateW is the new width of the line.
+    // The tail only moves forward on whitespace so for the moment
+    // the start remains the same and the width becomes combinedW.
     memcpy(line + lineLen, token, tokLen);
     lineLen += tokLen;
     lineW = candidateW;
@@ -207,7 +207,7 @@ uint32_t paginatePage(IReadStream& in,
         // Same telescoping method as a token append: the trailing space's
         // marginal width is measure(tail + " ") - measure(tail), in case the space
         // modifies the tail's width. The space then starts a fresh one-byte trailing
-		// chunk.
+        // chunk.
         if (spaceW < 0) spaceW = measure(" ");
         const size_t tailLen = lineLen - tailStart;
         memcpy(scratch, line + tailStart, tailLen);

--- a/Pala_One_2_1/src/pure/paginator.cpp
+++ b/Pala_One_2_1/src/pure/paginator.cpp
@@ -19,8 +19,29 @@ uint32_t paginatePage(IReadStream& in,
   in.seek(startPos);
 
   int linesUsed = 0;
-  char line[kLineMax];      size_t lineLen = 0;
+  // This holds the content that has been incorporated into the current line.
+  char line[kLineMax];
+  // Indicates how many characters of line are part of the current line.
+  size_t lineLen = 0;
+  // This indicates the current calculated width of everything
+  // already added to the current line.
+  int lineW = 0;
+  // In order to avoid recomputing the width of the whole line
+  // every time we only recalculate based on the previously
+  // added tokens up to the last whitespace which we refer to as the tail.
+  // tailStart indicates where in the current line the tail beings.
+  size_t tailStart = 0;
+  // tailW indicates how wide the tail was at the time it was
+  // incorporated into the line. lineW already includes tailW
+  // which is why you'll see a lot of lineW - tailW in the token
+  // addition calculations.
+  int tailW = 0;
+  int spaceW = -1;
+  // This holds the accumulated token that should next be added to the current line.
   char token[kTokenMax] = {}; size_t tokLen  = 0;
+  // This is a scratch pad used to recalculate the length of the tail when the
+  // latest token is added to it to see if the new token will push the line over
+  // the line limit.
   char scratch[kScratchMax];
 
   uint32_t lineStartPos  = startPos;
@@ -49,6 +70,9 @@ uint32_t paginatePage(IReadStream& in,
     line[lineLen] = 0;
     emit(line, lineLen);
     lineLen = 0;
+    lineW = 0;
+	tailStart = 0;
+	tailW = 0;
   };
 
   auto safeReturn = [&](uint32_t off) -> uint32_t {
@@ -102,48 +126,60 @@ uint32_t paginatePage(IReadStream& in,
     return 0;
   };
 
+  // Start a fresh line with the token, hard-breaking it if it can't fit on
+  // a line by itself. tokenW is the computed width of the token being used.
+  auto startLineWithToken = [&](int tokenW) -> uint32_t {
+    if (tokenW > m.maxWidth) {
+      return hardBreakToken();
+    }
+    memcpy(line, token, tokLen);
+    lineLen = tokLen;
+    lineW = tailW = tokenW;
+    tailStart = 0;
+    lineStartPos = tokenStartPos;
+    tokLen = 0;
+    return 0;
+  };
+
   // Try to append the current token to the line. Flushes the line first if
   // the combined width would overflow; falls into hardBreakToken if even a
   // standalone token won't fit. Clears `tokLen` on success.
   auto appendTokenToLine = [&]() -> uint32_t {
     if (tokLen == 0) return 0;
 
-    if (lineLen == 0) {
-      trimLeading(token, tokLen);
-      if (tokLen == 0) return 0;
-      token[tokLen] = 0;
-      if (measure(token) > m.maxWidth) {
-        return hardBreakToken();
-      }
-      memcpy(line, token, tokLen);
-      lineLen = tokLen;
-      lineStartPos = tokenStartPos;
-      tokLen = 0;
-      return 0;
-    }
-
     trimLeading(token, tokLen);
     if (tokLen == 0) return 0;
+    token[tokLen] = 0;
 
-    memcpy(scratch, line, lineLen);
-    memcpy(scratch + lineLen, token, tokLen);
-    scratch[lineLen + tokLen] = 0;
+    if (lineLen == 0) {
+      return startLineWithToken(measure(token));
+    }
+    // Only put the tail and the token into scratch to recompute width
+	// since the new token isn't going to be able to influence the layout
+	// of anything before that.
+    const size_t tailLen = lineLen - tailStart;
+    memcpy(scratch, line + tailStart, tailLen);
+    memcpy(scratch + tailLen, token, tokLen);
+    scratch[tailLen + tokLen] = 0;
+    const int combinedW = measure(scratch);
+	// lineW includes the width of the tail without the new token, so we
+	// need to subtract that here before adding the width of tail + token.
+    const int candidateW = lineW - tailW + combinedW;
 
-    if (measure(scratch) > m.maxWidth) {
+    if (candidateW > m.maxWidth) {
       flushLine();
       if (linesUsed >= m.maxLines) return safeReturn(tokenStartPos);
-
-      token[tokLen] = 0;
-      if (measure(token) > m.maxWidth) {
-        return hardBreakToken();
-      }
-      memcpy(line, token, tokLen);
-      lineLen = tokLen;
-      lineStartPos = tokenStartPos;
-    } else {
-      memcpy(line + lineLen, token, tokLen);
-      lineLen += tokLen;
+      return startLineWithToken(measure(token));
     }
+
+    // The token fits entirely, perhaps having modified the tail
+	// width. Regardless, candidateW is the new width of the line.
+	// The tail only moves forward on whitespace so for the moment
+	// the start remains the same and the width becoems combinedW.
+    memcpy(line + lineLen, token, tokLen);
+    lineLen += tokLen;
+    lineW = candidateW;
+    tailW = combinedW;
     tokLen = 0;
     return 0;
   };
@@ -168,7 +204,19 @@ uint32_t paginatePage(IReadStream& in,
       uint32_t forcedNext = appendTokenToLine();
       if (forcedNext != 0) return forcedNext;
       if (lineLen > 0 && !lineEndsWithSpace() && lineLen < kLineMax - 1) {
+        // Same telescoping method as a token append: the trailing space's
+        // marginal width is measure(tail + " ") - measure(tail), in case the space
+        // modifies the tail's width. The space then starts a fresh one-byte trailing
+		// chunk.
+        if (spaceW < 0) spaceW = measure(" ");
+        const size_t tailLen = lineLen - tailStart;
+        memcpy(scratch, line + tailStart, tailLen);
+        scratch[tailLen] = ' ';
+        scratch[tailLen + 1] = 0;
+        lineW += measure(scratch) - tailW;
         line[lineLen++] = ' ';
+        tailStart = lineLen - 1;
+        tailW = spaceW;
       }
       continue;
     }


### PR DESCRIPTION
This change alters how we compute the total line length as part of pagination. In the old system, we would build up a scratch with every token and then call "measure" to determine the width of the whole scratch each time to see if it had to be a new line. This is enormously wasteful and gets worse as lines get longer.

We've instead switched it to only track the portion of the current line since the last whitespace (which should act as a width anchor) and recompute the width of just that mutable tail based on the influence of the new token.

This is layout identical to the existing approach and so doesn't require a page cache invalidation.

Some crude experiments show a performance improvement of ~30% on page cache rebuilds:
Book | 512b Buffer | Tail Width Tracking
-- | -- | --
DCC | 551 ms | 350 ms
long number | 3425 ms | 2215 ms

It's worth noting while that's a pretty good improvement, it's taken on the Heltec board with just 250 pixel width. Because the line scan redundancy gets worse with line length, this was slowing page turns to a crawl on larger devices. I swear on the LilyGo 4.7" at 960px wide, it would have been quicker to render on an Etch-a-Sketch sometimes.

It's worth noting that this code is actually still very over-engineered. The u8g2 fonts used by the Pala One do not have any kerning tables so there's actually no need to recompute any widths since they'll never change based on adjacent tokens. For now, however, I propose we push forward with this as is and we're future proofed against someone adding a font with kerning at a later date.

I had Claude make me a little harness to check that this paginates identially to the old code and it was found to be completely identical across the 192 test samples. As such, no modification of the magic number is needed: existing page caches should work fine.