### PR TITLE
Mark checkbox based on current flip setting.

### DIFF
--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -118,7 +118,9 @@ static void handleSettings() {
 
   // Toggle for setting the inversed screen orientation
   out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
-  out += "<input type='checkbox' name='flip_rot' value='1' style='width:auto'>";
+  out += "<input type='checkbox' name='flip_rot' value='1' style='width:auto'";
+  out += ScreenSettings::isScreenFlipped() ? " checked" : "";
+  out += ">";
   out += "<span>" D_WEB_FLIP_SCREEN "</span></label>";
   out += "<span class='muted' style='display:inline'>" D_WEB_SETTINGS_APPLY_HINT "</span>";
 


### PR DESCRIPTION
In the Web Settings UI correctly indicate if the screen flip is currently set by making the checkbox be checked.