### PR TITLE
Fix C-style pointer cast in file buffer

### DIFF
--- a/Pala_One_2_1/src/hal/file_stream.h
+++ b/Pala_One_2_1/src/hal/file_stream.h
@@ -33,8 +33,8 @@ private:
 class BufferedFileReadStream : public IReadStream {
 public:
   explicit BufferedFileReadStream(File& f)
-      : f_(f), size_((uint32_t)f.size()), pos_((uint32_t)f.position()) {
-    buf_ = (uint8_t*)malloc(kBufCap);
+      : f_(f), size_(static_cast<uint32_t>(f.size())), pos_(static_cast<uint32_t>(f.position())) {
+    buf_ = static_cast<uint8_t*>(malloc(kBufCap));
   }
   ~BufferedFileReadStream() override { free(buf_); }
 


### PR DESCRIPTION
Change the C-style casts in file_stream.h when creating the buffer to be C++ style static_casts instead to keep the linter happy.

We could also have made the variable an explicit array, but this way, if the malloc fails, we gracefully fall back to unbuffered reads.