### PR TITLE
Fix uninitialized stack read in drawBatteryTopRight

### DIFF
--- a/Pala_One_2_1/src/hal/battery.cpp
+++ b/Pala_One_2_1/src/hal/battery.cpp
@@ -330,7 +330,7 @@ void drawBatteryTopRight(bool extended)
   int yIcon = 2;
 
   // Clear previous icons
-  gfx.fillRect(xIcon, yIcon, iconW + u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing, iconH, 0);
+  gfx.fillRect(xIcon, yIcon, iconW + (extended ? u8g2.getUTF8Width(extendedInfo) + icon_extendedInfo_spacing : 0), iconH, 0);
 
   drawBattery(xIcon, yIcon);
 


### PR DESCRIPTION
## Summary
`extendedInfo` is only populated by `snprintf` when `extended` is `true`, but the `fillRect` clear-rect width computation in `drawBatteryTopRight` read `u8g2.getUTF8Width(extendedInfo)` unconditionally — an uninitialized-buffer read on every call with `extended == false`, which is the common case (nearly every screen draw via `drawSectionHeader`).

The `xIcon` computation right above it already guards the same call behind `extended ? ... : 0`; this applies the same guard to the `fillRect` width.

Fixes #132

## Test plan
- [x] `pio check -e wireless-paper-v1_2-en --fail-on-defect low` passes
- [x] `pio run -e wireless-paper-v1_2-en` builds successfully