### PR TITLE
Only show low battery with full status bar

### DIFF
--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -276,21 +276,12 @@ bool openBookByIndex(int idx) {
 }
 
 static void drawStatusBar(uint32_t startOffset) {
-  // If the battery is low, we show a full status bar regardless of preference
-  // with a warning icon.
-  bool showBatteryWarning = false;
-#if HAS_BATTERY
-  // Battery status usually isn't updated mid-session, so poll it here to see if we're low.
-  // Entries are valid for BAT_CACHE_MS so this won't be too burdonsome.
-  updateBatteryBackground();
-  showBatteryWarning = batteryLow();
-#endif
-  if (!showBatteryWarning && Statusbar::mode() == Statusbar::Hidden) return;
+  if (Statusbar::mode() == Statusbar::Hidden) return;
 
   size_t total = g_bookview.book.size();
   if (total == 0) total = 1;
 
-  if (!showBatteryWarning && Statusbar::mode() == Statusbar::Minimal) {
+  if (Statusbar::mode() == Statusbar::Minimal) {
     int w = SCREEN_W - 2 * MARGIN_X;
     int filled = (int)((startOffset * (uint32_t)w) / (uint32_t)total);
     if (filled < 0) filled = 0;
@@ -313,10 +304,17 @@ static void drawStatusBar(uint32_t startOffset) {
   if (SHOW_PROGRESS_BAR) {
     const int padR = SHOW_PAGE_NUMBER ? (pageTextW + 8) : 0;
     int x0 = MARGIN_X;
-	if (showBatteryWarning) {
-	  drawBatteryBottomLeft();
-	  x0 += 24;
-	}
+    bool showBatteryWarning = false;
+#if HAS_BATTERY
+    // Battery status usually isn't updated mid-session, so poll it here to see if we're low.
+    // Entries are valid for BAT_CACHE_MS so this won't be too burdonsome.
+    updateBatteryBackground();
+    showBatteryWarning = batteryLow();
+#endif
+    if (showBatteryWarning) {
+      drawBatteryBottomLeft();
+      x0 += 24;
+    }
     int w = (SCREEN_W - MARGIN_X - x0) - padR;
     if (w < 40) w = 40;
     int yTop = SCREEN_H - 7;


### PR DESCRIPTION
Only show the low battery indicator if the user already has full status bar selected.

Attempting to force the full status bar when low battery is detected doesn't work as intended and results in text being written over the top of the status bar at certain font sizes. See #143 for more details.

I could also adjust the drawable area passed to the paginator but that would risk triggering a variant of #117.

For now, let's just restrict this feature to full status bar and I'll work on a more general solution separately.