### PR TITLE
Issue #147: Clamp filename length on upload

### DIFF
--- a/Pala_One_2_1/src/config.h
+++ b/Pala_One_2_1/src/config.h
@@ -57,6 +57,7 @@ static const int SCREEN_H = 122;
 
 static const uint8_t MAX_BOOKMARKS = 12;
 static const int MAX_BOOKS = 80;
+static const int MAX_FILE_PATH = 89;  // chars, relative path from app base
 static const int MAX_FOLDERS = 32;
 static const int MAX_FOLDER_PATH = 63;  // chars, excluding null
 static const int MAX_PAGES = 10000;

--- a/Pala_One_2_1/src/pure/paths.cpp
+++ b/Pala_One_2_1/src/pure/paths.cpp
@@ -81,8 +81,7 @@ String sanitizeFolderInput(const String& raw) {
 }
 
 String sanitizeUploadedFilename(String fname) {
-  int slash = fname.lastIndexOf('/');
-  if (slash >= 0) fname = fname.substring(slash + 1);
+  fname = lastPathComponent(fname);
 
   String clean;
   clean.reserve(fname.length());

--- a/Pala_One_2_1/src/pure/paths.cpp
+++ b/Pala_One_2_1/src/pure/paths.cpp
@@ -1,3 +1,4 @@
+#include "../config.h"
 #include "paths.h"
 
 String stripTxtExt(const String& s) {
@@ -102,6 +103,10 @@ String sanitizeUploadedFilename(String fname) {
   while (clean.startsWith(".")) clean.remove(0, 1);
   if (!clean.endsWith(".txt")) clean += ".txt";
   if (clean.length() == 0) clean = "book.txt";
+  if (clean.length() >= MAX_FILE_PATH) {
+    int ext = fname.lastIndexOf('.');
+    clean = clean.substring(0, min(ext, MAX_FILE_PATH - 4)) + ".txt";
+  }
   return clean;
 }
 

--- a/Pala_One_2_1/src/pure/paths.cpp
+++ b/Pala_One_2_1/src/pure/paths.cpp
@@ -101,8 +101,8 @@ String sanitizeUploadedFilename(String fname) {
 
   clean.replace("..", "");
   while (clean.startsWith(".")) clean.remove(0, 1);
-  if (!clean.endsWith(".txt")) clean += ".txt";
   if (clean.length() == 0) clean = "book.txt";
+  if (!clean.endsWith(".txt")) clean += ".txt";
   if (clean.length() >= MAX_FILE_PATH) {
     int ext = fname.lastIndexOf('.');
     clean = clean.substring(0, min(ext, MAX_FILE_PATH - 4)) + ".txt";

--- a/Pala_One_2_1/src/pure/paths.h
+++ b/Pala_One_2_1/src/pure/paths.h
@@ -36,7 +36,7 @@ String sanitizeFolderInput(const String& raw);
 
 // Sanitize a user-uploaded filename. Removes path components, restricts to a
 // safe byte set, kills repeated "..", ensures ".txt" suffix, falls back to
-// "book.txt" if empty.
+// "book.txt" if empty, ensures filename doesn't exceed max length.
 String sanitizeUploadedFilename(String fname);
 
 // Sibling of `sanitizeUploadedFilename` for app .bin uploads. Removes path

--- a/test/test_paths.cpp
+++ b/test/test_paths.cpp
@@ -76,6 +76,10 @@ TEST_CASE("sanitizeUploadedFilename") {
   CHECK(sanitizeUploadedFilename("weird!@#chars.txt") == "weird___chars.txt");
   // Numeric, punctuation in middle stays as filename
   CHECK(sanitizeUploadedFilename("a1-b2.txt") == "a1-b2.txt");
+  // Clamps to MAX_FILE_NAME
+  CHECK(sanitizeUploadedFilename("89_chars___________________________________________________________________________89.txt") == "89_chars___________________________________________________________________________89.txt");
+  CHECK(sanitizeUploadedFilename("90_chars____________________________________________________________________________90.txt") == "90_chars____________________________________________________________________________9.txt");
+  CHECK(sanitizeUploadedFilename("93_chars_______________________________________________________________________________93.txt") == "93_chars_____________________________________________________________________________.txt");
 }
 
 TEST_CASE("sanitizeUploadedAppFilename") {


### PR DESCRIPTION
#147 : This handles errors on file upload by forcing filenames to be below the 89 character threshold.