### PR TITLE
Add toggle for battery indicator

### DIFF
--- a/Pala_One_2_1/Pala_One_2_1.ino
+++ b/Pala_One_2_1/Pala_One_2_1.ino
@@ -134,9 +134,10 @@ Screen* g_currentScreen = &g_libraryScreen;
 
 #if HAS_BATTERY
 static bool batteryIndicatorVisible() {
+  if (g_currentScreen == &g_aboutScreen) return true;
+  if (!ScreenSettings::batteryIndicatorsEnabled()) return false;
   return g_currentScreen == &g_libraryScreen
       || g_currentScreen == &g_uploadScreen
-      || g_currentScreen == &g_aboutScreen
       || g_currentScreen == &g_updateScreen
       || g_currentScreen == &g_appsScreen
       || g_currentScreen == &g_listScreen

--- a/Pala_One_2_1/src/hal/battery.cpp
+++ b/Pala_One_2_1/src/hal/battery.cpp
@@ -285,22 +285,26 @@ void drawBattery(int xIcon, int yIcon)
   drawBatteryOutline(xIcon, yIcon, iconW, iconH);
   int displayedCharge = 0;
 
-  if (pct > 75)
+  if (batteryLow())
+  {
+    displayedCharge = 0;
+    drawExclamation(xIcon, yIcon, iconH, 2);
+  }
+  else if (pct > 75)
   {
     displayedCharge = 100;
   }
-  else if (pct > 50)
+  else if (pct > 40)
   {
     displayedCharge = 50;
   }
-  else if (pct > 25)
+  else if (pct > 15)
   {
     displayedCharge = 25;
   }
   else
   {
     displayedCharge = 0;
-    drawExclamation(xIcon, yIcon, iconH, 2);
   }
 
   if (!s_battery.charging) {

--- a/Pala_One_2_1/src/hal/battery.cpp
+++ b/Pala_One_2_1/src/hal/battery.cpp
@@ -2,6 +2,7 @@
 
 #include "src/hal/display.h" // u8g2 + gfx for the battery icon
 #include "src/ui/font.h"     // role-based font switch (UiSmall for the % text)
+#include "src/ui/screen_settings.h"
 
 #if HAS_BATTERY
 
@@ -347,6 +348,9 @@ void drawBatteryTopRight(bool extended)
 
 void drawBatteryBottomLeft()
 {
+  if (!ScreenSettings::batteryIndicatorsEnabled()) {
+    return;
+  }
 	drawBattery(/*xIcon=*/MARGIN_X + 2, /*yIcon=*/SCREEN_H - iconH);
 }
 

--- a/Pala_One_2_1/src/lang/en.h
+++ b/Pala_One_2_1/src/lang/en.h
@@ -412,6 +412,8 @@
 #define D_WEB_HEADER_TITLE_HINT     "Shown at the top of the library screen. Leave empty for no title."
 #define D_WEB_HEADER_TITLE_RESET    "Reset to default"
 #define D_WEB_FLIP_SCREEN           "Flip screen orientation"
+#define D_WEB_BATTERY_INDICATORS_LABEL "Hide battery indicators"
+#define D_WEB_BATTERY_INDICATORS_HINT "When checked, battery status is visible on the " D_ABOUT_HEADER " screen only."
 
 // Wi-Fi card (src/web/settings.cpp) — the saved network the upload screen
 // joins.

--- a/Pala_One_2_1/src/lang/es_la.h
+++ b/Pala_One_2_1/src/lang/es_la.h
@@ -413,6 +413,8 @@
 #define D_WEB_HEADER_TITLE_HINT     "Se muestra arriba de la pantalla de biblioteca. Deja vacío para ocultarlo."
 #define D_WEB_HEADER_TITLE_RESET    "Restaurar predeterminado"
 #define D_WEB_FLIP_SCREEN           "Voltear orientación de la pantalla" // Translate by ChatGPT
+#define D_WEB_BATTERY_INDICATORS_LABEL "Ocultar indicadores de batería"
+#define D_WEB_BATTERY_INDICATORS_HINT "Cuando se selecciona, el estado de la batería solo es visible en la pantalla " D_ABOUT_HEADER "."
 // ----------------------------------------------------------------------------
 //  Upload routes
 // ----------------------------------------------------------------------------

--- a/Pala_One_2_1/src/ui/reader.cpp
+++ b/Pala_One_2_1/src/ui/reader.cpp
@@ -10,6 +10,7 @@
 #include "src/storage/statistics.h"         // Statistics::onReaderPageTurn
 
 #include "src/ui/font.h"                    // layoutForCache for cache stamping
+#include "src/ui/screen_settings.h"          // battery indicator toggle
 #include "src/ui/screens/library_screen.h"  // navigateToLibraryRoot — fallback on error
 #include "src/ui/statusbar.h"               // Statusbar::mode for the per-mode statusbar render
 #include "src/ui/text.h"
@@ -306,10 +307,12 @@ static void drawStatusBar(uint32_t startOffset) {
     int x0 = MARGIN_X;
     bool showBatteryWarning = false;
 #if HAS_BATTERY
-    // Battery status usually isn't updated mid-session, so poll it here to see if we're low.
-    // Entries are valid for BAT_CACHE_MS so this won't be too burdonsome.
-    updateBatteryBackground();
-    showBatteryWarning = batteryLow();
+    if (ScreenSettings::batteryIndicatorsEnabled()) {
+      // Battery status usually isn't updated mid-session, so poll it here to see if we're low.
+      // Entries are valid for BAT_CACHE_MS so this won't be too burdonsome.
+      updateBatteryBackground();
+      showBatteryWarning = batteryLow();
+    }
 #endif
     if (showBatteryWarning) {
       drawBatteryBottomLeft();

--- a/Pala_One_2_1/src/ui/screen_settings.cpp
+++ b/Pala_One_2_1/src/ui/screen_settings.cpp
@@ -4,10 +4,13 @@
 
 namespace ScreenSettings {
     static bool s_screenFlipped = false;
+    static bool s_batteryIndicatorsEnabled = true;
     static constexpr const char *kKeyScreenFlipped = "cfg_scr_flip";
+    static constexpr const char *kKeyBatteryIndicators = "cfg_batt_ind";
 
     void loadSettings() {
         s_screenFlipped = prefs.getBool(kKeyScreenFlipped, false);
+        s_batteryIndicatorsEnabled = prefs.getBool(kKeyBatteryIndicators, true);
     }
 
     void toggleScreenRotation() {
@@ -23,5 +26,14 @@ namespace ScreenSettings {
     void setScreenRotation(bool inverted) {
         s_screenFlipped = inverted;
         prefs.putBool(kKeyScreenFlipped, s_screenFlipped);
+    }
+
+    bool batteryIndicatorsEnabled() {
+        return s_batteryIndicatorsEnabled;
+    }
+
+    void setBatteryIndicatorsEnabled(bool enabled) {
+        s_batteryIndicatorsEnabled = enabled;
+        prefs.putBool(kKeyBatteryIndicators, enabled);
     }
 }

--- a/Pala_One_2_1/src/ui/screen_settings.h
+++ b/Pala_One_2_1/src/ui/screen_settings.h
@@ -8,6 +8,8 @@ namespace ScreenSettings
     void toggleScreenRotation();
     bool isScreenFlipped();
     void setScreenRotation(bool);
+    bool batteryIndicatorsEnabled();
+    void setBatteryIndicatorsEnabled(bool enabled);
 }
 
 #endif

--- a/Pala_One_2_1/src/ui/widgets.cpp
+++ b/Pala_One_2_1/src/ui/widgets.cpp
@@ -3,6 +3,7 @@
 #include "src/hal/battery.h"
 #include "src/hal/display.h"
 #include "src/ui/font.h"
+#include "src/ui/screen_settings.h"
 
 static const int UI_HEADER_TOP = 6;
 static const int UI_HEADER_GAP = 6;
@@ -64,7 +65,7 @@ int drawSectionHeader(const char* title, bool drawBattery) {
   u8g2.print(title);
 
 #if HAS_BATTERY
-  if (drawBattery){
+  if (drawBattery && ScreenSettings::batteryIndicatorsEnabled()) {
     drawBatteryTopRight();
   }
 #endif

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -255,12 +255,7 @@ static void handleSettings() {
   out += ScreenSettings::isScreenFlipped() ? " checked" : "";
   out += ">";
   out += "<span>" D_WEB_FLIP_SCREEN "</span></label>";
-  out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
-  out += "<input type='checkbox' name='batt_ind' value='1' style='width:auto'";
-  out += !ScreenSettings::batteryIndicatorsEnabled() ? " checked" : "";
-  out += ">";
-  out += "<span>" D_WEB_BATTERY_INDICATORS_LABEL "</span></label>";
-  out += "<div class='hint'>" D_WEB_BATTERY_INDICATORS_HINT "</div>";
+
   out += "<span class='muted' style='display:inline'>" D_WEB_SETTINGS_APPLY_HINT "</span>";
 
   out += "<div class='actions' style='margin-top:14px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button></div>";
@@ -277,6 +272,13 @@ static void handleSettings() {
   out += "><span>" D_WEB_ICON_SLEEP_LABEL "</span></label>";
   out += "<div class='hint'>" D_WEB_ICON_SLEEP_HINT "</div>";
   out += "<input type='hidden' name='icons_form' value='1'>";
+  
+  out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
+  out += "<input type='checkbox' name='batt_ind' value='1' style='width:auto'";
+  out += !ScreenSettings::batteryIndicatorsEnabled() ? " checked" : "";
+  out += ">";
+  out += "<span>" D_WEB_BATTERY_INDICATORS_LABEL "</span></label>";
+  out += "<div class='hint'>" D_WEB_BATTERY_INDICATORS_HINT "</div>";
   out += "<div class='actions' style='margin-top:14px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button></div>";
   out += "</form></div>";
 
@@ -609,6 +611,7 @@ static void handleSettingsPost() {
   if (server.hasArg("icons_form")) {
     bool si = server.hasArg("ico_sleep");
     if (si != Icons::sleepIconEnabled()) Icons::setSleepIconEnabled(si);
+    ScreenSettings::setBatteryIndicatorsEnabled(!server.hasArg("batt_ind"));
   }
 
   // Header title — its own form card.
@@ -630,7 +633,6 @@ static void handleSettingsPost() {
     {
       ScreenSettings::setScreenRotation(false);
     }
-    ScreenSettings::setBatteryIndicatorsEnabled(!server.hasArg("batt_ind"));
   }
 
   handleLibraryMenuOrderPost();

--- a/Pala_One_2_1/src/web/settings.cpp
+++ b/Pala_One_2_1/src/web/settings.cpp
@@ -233,6 +233,12 @@ static void handleSettings() {
   out += ScreenSettings::isScreenFlipped() ? " checked" : "";
   out += ">";
   out += "<span>" D_WEB_FLIP_SCREEN "</span></label>";
+  out += "<label style='display:flex;gap:8px;align-items:center;margin-top:10px;cursor:pointer'>";
+  out += "<input type='checkbox' name='batt_ind' value='1' style='width:auto'";
+  out += !ScreenSettings::batteryIndicatorsEnabled() ? " checked" : "";
+  out += ">";
+  out += "<span>" D_WEB_BATTERY_INDICATORS_LABEL "</span></label>";
+  out += "<div class='hint'>" D_WEB_BATTERY_INDICATORS_HINT "</div>";
   out += "<span class='muted' style='display:inline'>" D_WEB_SETTINGS_APPLY_HINT "</span>";
 
   out += "<div class='actions' style='margin-top:14px'><button type='submit'>" D_WEB_SAVE_SETTINGS_BUTTON "</button></div>";
@@ -509,6 +515,7 @@ static void handleSettingsPost() {
     {
       ScreenSettings::setScreenRotation(false);
     }
+    ScreenSettings::setBatteryIndicatorsEnabled(!server.hasArg("batt_ind"));
   }
 
   handleLibraryMenuOrderPost();


### PR DESCRIPTION
This PR adds a toggle in the webUI to disable the battery indicators in all screens except for the Device menu. 
I felt the need for this feature since my battery indicator is completely unreliable (oscillating between low battery warning and 75% charge multiple times a day).