### PR TITLE
streak: replace fixed 24 h buckets with a rolling window

### DIFF
--- a/Pala_One_2_1/src/pure/streak_log.cpp
+++ b/Pala_One_2_1/src/pure/streak_log.cpp
@@ -1,30 +1,84 @@
 #include "src/pure/streak_log.h"
 
-StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t today) {
-  StreakLogResult r{};
-  if (current.lastLoggedDay == today) {
-    r.changed = false;
-    r.next    = current;
-    return r;
-  }
+// Whole days in `secs`, rounded to nearest, floored at 2. Used only to size
+// the bitmap gap after a lapse, so the statistics grid shows roughly the right
+// number of blank cells. Written as divide-then-compare rather than
+// `(secs + halfDay) / day` so it cannot overflow on a nonsense timestamp.
+static uint32_t lapsedDays(uint32_t secs) {
+  uint32_t days = secs / STREAK_DAY_SECS;
+  if ((secs % STREAK_DAY_SECS) >= (STREAK_DAY_SECS / 2)) days += 1;
+  return (days < 2u) ? 2u : days;
+}
 
+StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t nowSec) {
   ReadingStreakFile s = current;
 
-  if (today > s.bitmapHead) {
-    uint32_t d = today - s.bitmapHead;
-    s.bitmap     = (d >= 32) ? 0u : (s.bitmap << d);
-    s.bitmapHead = today;
+  // ---- 1. First ever log -------------------------------------------------
+  if (s.lastLogSec == STREAK_SEC_UNSET) {
+    s.dayIndex      = 0;
+    s.bitmap        = 1u;
+    s.currentStreak = 1;
+    if (s.longestStreak < 1u) s.longestStreak = 1u;
+    s.totalSessions += 1;
+    s.lastLogSec     = nowSec;
+    s.lastReadSec    = nowSec;
+    return StreakLogResult{true, true, s};
   }
-  s.bitmap |= 1u;
 
-  bool cont = (s.lastLoggedDay != STREAK_DAY_UNSET)
-           && (today == s.lastLoggedDay + 1);
-  s.currentStreak  = cont ? (s.currentStreak + 1) : 1;
+  // ---- 2. RTC ran backwards ----------------------------------------------
+  // `lastReadSec >= lastLogSec` is an invariant of everything below, so one
+  // test covers both anchors. A power cycle restarts the counter, and elapsed
+  // time is then unknowable: re-anchor and leave the streak exactly as it was.
+  if (nowSec < s.lastReadSec) {
+    s.lastLogSec  = nowSec;
+    s.lastReadSec = nowSec;
+    return StreakLogResult{true, false, s};
+  }
+
+  const uint32_t sinceLog  = nowSec - s.lastLogSec;
+  const uint32_t sinceRead = nowSec - s.lastReadSec;
+
+  // ---- 3. Same reading day -----------------------------------------------
+  // Still counts as activity: moving lastReadSec pushes the break deadline
+  // out, so an evening spent picking the book up and putting it down keeps
+  // the streak alive without inflating it.
+  if (sinceLog < STREAK_SAME_DAY_SECS) {
+    s.lastReadSec = nowSec;
+    return StreakLogResult{s.lastReadSec != current.lastReadSec, false, s};
+  }
+
+  // ---- 4. A new streak day -----------------------------------------------
+  uint32_t step;
+  if (sinceRead <= STREAK_WINDOW_SECS) {
+    step             = 1u;
+    s.currentStreak += 1;
+  } else {
+    step            = lapsedDays(sinceRead);
+    s.currentStreak = 1;
+  }
+
+  s.dayIndex += step;
+  s.bitmap    = (step >= 32u) ? 0u : (s.bitmap << step);
+  s.bitmap   |= 1u;
+
   if (s.currentStreak > s.longestStreak) s.longestStreak = s.currentStreak;
-  s.lastLoggedDay  = today;
   s.totalSessions += 1;
+  s.lastLogSec     = nowSec;
+  s.lastReadSec    = nowSec;
 
-  r.changed = true;
-  r.next    = s;
-  return r;
+  return StreakLogResult{true, true, s};
+}
+
+ReadingStreakFile migrateStreakV1(const ReadingStreakFileV1& v1, uint32_t nowSec) {
+  ReadingStreakFile s{};
+  s.version       = STREAK_SCHEMA;
+  s.firstRtcSec   = v1.firstRtcSec;
+  s.lastLogSec    = nowSec;
+  s.lastReadSec   = nowSec;
+  s.dayIndex      = v1.bitmapHead;
+  s.currentStreak = v1.currentStreak;
+  s.longestStreak = v1.longestStreak;
+  s.totalSessions = v1.totalSessions;
+  s.bitmap        = v1.bitmap;
+  return s;
 }

--- a/Pala_One_2_1/src/pure/streak_log.h
+++ b/Pala_One_2_1/src/pure/streak_log.h
@@ -6,49 +6,120 @@
 // ============================================================================
 //  Reading-streak wire format + pure log-advance logic.
 //
-//  Lives in pure/ so the bitmap-shift + continuation rules are host-testable
-//  independent of LittleFS / RTC / Toast. The firmware side (reading_hooks.cpp)
-//  reads /apps/streak.dat into one of these structs, calls `applyStreakLog`
-//  to compute the next state, and writes it back. The same struct layout is
-//  shared with examples/reading_streak/app.c (schema-version gated).
+//  Lives in pure/ so the window + bitmap-shift rules are host-testable
+//  independent of LittleFS / RTC / Toast. The firmware side (statistics.cpp)
+//  reads the `cfg_streak` NVS blob into one of these structs, calls
+//  `applyStreakLog` to compute the next state, and writes it back. The same
+//  struct layout is shared with examples/reading_streak/app.c (schema-version
+//  gated).
+//
+//  --------------------------------------------------------------------------
+//  Why this is a rolling window and not a day index
+//  --------------------------------------------------------------------------
+//  The device has no wall clock. Schema v1 defined a "day" as
+//  `(rtcSeconds() - firstRtcSec) / 86400`, i.e. fixed 24 h buckets anchored to
+//  whenever the streak first initialised. That anchor is an arbitrary time of
+//  day, so the bucket boundary usually fell inside somebody's normal reading
+//  window: read at 23:00 on Monday and 01:00 on Wednesday and you had skipped
+//  a bucket, while reading at 21:00 and 23:00 on the same evening crossed one
+//  and counted twice. Users had to read at roughly the same hour every day to
+//  keep a streak alive.
+//
+//  v2 drops the fixed anchor. Two timestamps carry the state:
+//
+//    lastLogSec   RTC seconds when the streak last advanced. Nothing can
+//                 advance again until STREAK_SAME_DAY_SECS has passed, so a
+//                 second sitting on the same evening is a no-op rather than
+//                 a free extra day.
+//
+//    lastReadSec  RTC seconds of the most recent qualifying session, logged
+//                 or not. The streak breaks only when *this* is more than
+//                 STREAK_WINDOW_SECS old, so picking the book back up at any
+//                 point inside the window keeps it alive.
+//
+//  Neither threshold can be exactly right without a calendar: a gap of 30 h
+//  might be two late-night sessions in a row or one skipped day, and the
+//  device cannot tell. The defaults below deliberately err towards keeping a
+//  streak the reader earned rather than breaking one they did not.
+//
+//  A consequence worth knowing: because the floor is 18 h rather than 24 h, a
+//  reader who drifts steadily earlier can bank at most four days in three.
+//  That is the price of never punishing ordinary time-of-day jitter.
 // ============================================================================
 
-static const uint32_t STREAK_SCHEMA          = 1;
-static const uint32_t STREAK_DAY_SECS        = 86400u;
-static const uint32_t STREAK_DAY_UNSET       = 0xFFFFFFFFu;
-static const int      STREAK_PAGES_THRESHOLD = 5;     // pages today before we log
+static const uint32_t STREAK_SCHEMA          = 2;
+static const uint32_t STREAK_DAY_SECS        = 86400u;    // nominal day, for gap sizing
+static const uint32_t STREAK_SAME_DAY_SECS   = 64800u;    // 18 h — below this, same reading day
+static const uint32_t STREAK_WINDOW_SECS     = 129600u;   // 36 h — above this, the streak lapses
+static const uint32_t STREAK_SEC_UNSET       = 0xFFFFFFFFu;
+static const int      STREAK_PAGES_THRESHOLD = 5;         // page turns before a session counts
 
 struct ReadingStreakFile {
   uint32_t version;        // == STREAK_SCHEMA
   uint32_t firstRtcSec;    // rtcSeconds() at first ever write
-  uint32_t lastLoggedDay;  // day index, STREAK_DAY_UNSET = never
+  uint32_t lastLogSec;     // RTC seconds at the last advance, STREAK_SEC_UNSET = never
+  uint32_t lastReadSec;    // RTC seconds at the last qualifying session
+  uint32_t dayIndex;       // rolling day ordinal; doubles as the bitmap head
   uint32_t currentStreak;
   uint32_t longestStreak;
   uint32_t totalSessions;
-  uint32_t bitmapHead;     // day index of bit 0
-  uint32_t bitmap;         // bit i = "logged on day (head - i)"
+  uint32_t bitmap;         // bit i = "read on day (dayIndex - i)"
+};
+
+// Schema v1 on-disk shape. Retained only so `migrateStreakV1` can carry an
+// existing streak forward; nothing else should reference it.
+struct ReadingStreakFileV1 {
+  uint32_t version;        // == 1
+  uint32_t firstRtcSec;
+  uint32_t lastLoggedDay;
+  uint32_t currentStreak;
+  uint32_t longestStreak;
+  uint32_t totalSessions;
+  uint32_t bitmapHead;
+  uint32_t bitmap;
 };
 
 struct StreakLogResult {
-  bool                changed;  // false = same-day no-op
-  ReadingStreakFile   next;     // valid iff `changed`
+  bool              changed;  // `next` differs from `current`; caller may persist
+  bool              logged;   // a new streak day was recorded; caller toasts
+  ReadingStreakFile next;
 };
 
-// Advance the streak state for a session logged on `today`. Pure — same
-// `current` + `today` always yield the same result.
+// Advance the streak state for reading activity at `nowSec` (monotonic RTC
+// seconds). Pure — the same `current` + `nowSec` always yield the same result.
 //
-// Behaviour:
-//   - If `today == current.lastLoggedDay` → no-op ({false, current}).
-//   - Otherwise:
-//     - bitmap shifts left by `(today - bitmapHead)` (zeros if shift >= 32).
-//     - bit 0 set (today is logged).
-//     - currentStreak = (lastLoggedDay+1 == today) ? prev+1 : 1.
-//     - longestStreak = max(longestStreak, currentStreak).
-//     - totalSessions++.
-//     - lastLoggedDay = today.
+// Behaviour, in the order the cases are tested:
 //
-// `STREAK_DAY_UNSET` as `lastLoggedDay` means "never logged before" and
-// breaks continuation (the next log starts streak at 1, not 2).
-StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t today);
+//   1. lastLogSec == STREAK_SEC_UNSET  → first ever log. dayIndex 0, bitmap 1,
+//      currentStreak 1. {changed, logged}.
+//   2. nowSec < lastReadSec  → the RTC counter ran backwards, which on this
+//      hardware means a power cycle rather than time travel. Elapsed time is
+//      unknowable, so both anchors move to `nowSec` and the streak is left
+//      exactly as it was: not advanced, not broken. {changed, not logged}.
+//   3. nowSec - lastLogSec < STREAK_SAME_DAY_SECS  → same reading day. Only
+//      lastReadSec moves, which pushes the break deadline out. {changed iff
+//      lastReadSec actually moved, not logged}.
+//   4. Otherwise a new streak day is recorded:
+//        - continuing (nowSec - lastReadSec <= STREAK_WINDOW_SECS):
+//          currentStreak++, dayIndex += 1, bitmap shifts 1.
+//        - lapsed: currentStreak = 1, and dayIndex / the bitmap skip the whole
+//          gap (elapsed time rounded to whole days, at least 2) so the grid on
+//          the statistics screen shows the missed days as blanks.
+//      longestStreak = max(longestStreak, currentStreak), totalSessions++,
+//      both anchors move to `nowSec`. {changed, logged}.
+//
+// A shift of 32 or more clears the bitmap outright rather than relying on
+// `<<`, which is undefined at that width.
+StreakLogResult applyStreakLog(const ReadingStreakFile& current, uint32_t nowSec);
+
+// Convert a schema-v1 blob into a v2 one, preserving currentStreak,
+// longestStreak, totalSessions and the 30-day bitmap.
+//
+// The v1 day index counted 24 h buckets from `firstRtcSec`, which is not
+// comparable to a wall-clock-free rolling window, so both v2 anchors are set
+// to `nowSec`: the reader keeps the streak they earned and gets a full fresh
+// window from the moment they take the update. The session that triggers the
+// migration does not itself log a day; the next one, up to 36 h later, does.
+ReadingStreakFile migrateStreakV1(const ReadingStreakFileV1& v1, uint32_t nowSec);
 
 #endif  // PALA_PURE_STREAK_LOG_H

--- a/Pala_One_2_1/src/storage/statistics.cpp
+++ b/Pala_One_2_1/src/storage/statistics.cpp
@@ -15,22 +15,35 @@ extern "C" uint64_t esp_rtc_get_time_us(void);
 //  NVS:
 //    cfg_stats   blob — { uint32_t version; uint32_t firstRtcSec;
 //                         uint64_t pagesRead; uint64_t buttonPresses; }
-//    cfg_streak  blob — ReadingStreakFile (8 x uint32_t)
+//    cfg_streak  blob — ReadingStreakFile (9 x uint32_t, schema v2).
+//                       A 32-byte v1 blob left by an older firmware is
+//                       migrated in place on first read.
 //
 //  RTC RAM: working lifetime counters (survive deep sleep, zero flash writes
 //  during normal use). Re-seeded from cfg_stats on cold boot.
 //
-//  Plain RAM: streak threshold-gate cache (pagesToday + cachedLastDay) —
-//  reset on every cold boot, which restarts the 5-page threshold for the
-//  next session. Acceptable: page-turn count within one reading session is
-//  a small fraction of any realistic streak rule.
+//  Plain RAM: streak gate cache (pagesSinceCheck + lastTouchSec) — reset on
+//  every cold boot, which restarts the 5-page threshold for the next session.
+//  Acceptable: page-turn count within one reading session is a small fraction
+//  of any realistic streak rule.
+//
+//  Streak v2 tracks `lastReadSec` as well as `lastLogSec`, so unlike v1 it has
+//  something to persist on sessions that don't advance the streak. Two gates
+//  keep that off the flash: STREAK_PAGES_THRESHOLD page turns before we look
+//  at NVS at all, then STREAK_REFRESH_SECS before a bare lastReadSec refresh
+//  is worth a write. A logged day always writes through immediately.
 // ============================================================================
 
 static constexpr const char* kKeyStats  = "cfg_stats";
 static constexpr const char* kKeyStreak = "cfg_streak";
 
-static const uint32_t STATS_SCHEMA            = 1;
+static const uint32_t STATS_SCHEMA             = 1;
 static const uint32_t STATS_FLUSH_EVERY_EVENTS = 100;
+
+// Don't spend a flash write refreshing `lastReadSec` more often than this.
+// The value only matters within a single sitting — it is well under the 18 h
+// same-day floor, so it can never change which day a session lands on.
+static const uint32_t STREAK_REFRESH_SECS      = 900;  // 15 min
 
 struct StatsBlob {
   uint32_t version;
@@ -46,12 +59,12 @@ RTC_DATA_ATTR static uint32_t s_firstStatsRtcSec   = 0;
 RTC_DATA_ATTR static uint32_t s_eventsSinceFlush   = 0;
 RTC_DATA_ATTR static bool     s_rtcInitialised     = false;
 
-// Plain RAM streak threshold-gate cache. Reset on cold boot.
+// Plain RAM streak gate cache. Reset on cold boot.
 static struct {
-  int      pagesToday        = 0;
-  uint32_t cachedFirstRtcSec = 0;
-  uint32_t cachedLastDay     = STREAK_DAY_UNSET;
-  bool     bootstrapped      = false;
+  int      pagesSinceCheck = 0;
+  uint32_t lastTouchSec    = 0;      // RTC secs when we last consulted NVS
+  bool     touched         = false;  // lastTouchSec is meaningful
+  bool     bootstrapped    = false;
 } g_streakAuto;
 
 static uint32_t rtcSecondsNow() {
@@ -98,13 +111,31 @@ static inline void bumpEventsAndMaybeFlush() {
 //  Streak half
 // ---------------------------------------------------------------------------
 
-static bool readStreakBlob(ReadingStreakFile& out) {
-  size_t got = prefs.getBytes(kKeyStreak, &out, sizeof(out));
-  return got == sizeof(out) && out.version == STREAK_SCHEMA;
-}
-
 static void writeStreakBlob(const ReadingStreakFile& s) {
   prefs.putBytes(kKeyStreak, &s, sizeof(s));
+}
+
+// Read the streak blob, upgrading a schema-v1 one on the way through. The two
+// schemas are different sizes (32 vs 36 bytes), so the stored length tells us
+// which we're looking at without having to trust the version word first.
+static bool readStreakBlob(ReadingStreakFile& out) {
+  size_t len = prefs.getBytesLength(kKeyStreak);
+
+  if (len == sizeof(ReadingStreakFile)) {
+    size_t got = prefs.getBytes(kKeyStreak, &out, sizeof(out));
+    return got == sizeof(out) && out.version == STREAK_SCHEMA;
+  }
+
+  if (len == sizeof(ReadingStreakFileV1)) {
+    ReadingStreakFileV1 v1{};
+    size_t got = prefs.getBytes(kKeyStreak, &v1, sizeof(v1));
+    if (got != sizeof(v1) || v1.version != 1u) return false;
+    out = migrateStreakV1(v1, rtcSecondsNow());
+    writeStreakBlob(out);   // land the upgrade once, not on every read
+    return true;
+  }
+
+  return false;
 }
 
 // One-time initialise the streak NVS key + RAM cache. Called on first
@@ -114,42 +145,57 @@ static void bootstrapStreak() {
   if (!readStreakBlob(s)) {
     s.version       = STREAK_SCHEMA;
     s.firstRtcSec   = rtcSecondsNow();
-    s.lastLoggedDay = STREAK_DAY_UNSET;
+    s.lastLogSec    = STREAK_SEC_UNSET;
+    s.lastReadSec   = 0;
+    s.dayIndex      = 0;
     s.currentStreak = 0;
     s.longestStreak = 0;
     s.totalSessions = 0;
-    s.bitmapHead    = 0;
     s.bitmap        = 0;
     writeStreakBlob(s);
   }
-  g_streakAuto.cachedFirstRtcSec = s.firstRtcSec;
-  g_streakAuto.cachedLastDay     = s.lastLoggedDay;
-  g_streakAuto.bootstrapped      = true;
+  g_streakAuto.bootstrapped = true;
 }
 
-// Try to advance the streak based on today's RTC. Mirrors the threshold
-// gate from the original reading-streak feature: STREAK_PAGES_THRESHOLD
-// page turns on a new day before we commit. The actual continuation +
-// bitmap-shift rules are in src/pure/streak_log.cpp (host-tested).
+// Try to advance the streak from the current RTC reading. Keeps the threshold
+// gate from the original feature — STREAK_PAGES_THRESHOLD page turns before a
+// session counts as reading — and adds a time gate so a long sitting doesn't
+// re-read NVS every fifth page. The window rules themselves are in
+// src/pure/streak_log.cpp (host-tested).
 static void streakAutoLogOnPageTurn() {
   if (!g_streakAuto.bootstrapped) bootstrapStreak();
 
-  uint32_t now = rtcSecondsNow();
-  if (now < g_streakAuto.cachedFirstRtcSec) return;           // RTC ran backwards
-  uint32_t today = (now - g_streakAuto.cachedFirstRtcSec) / STREAK_DAY_SECS;
+  if (++g_streakAuto.pagesSinceCheck < STREAK_PAGES_THRESHOLD) return;
+  g_streakAuto.pagesSinceCheck = 0;
 
-  if (g_streakAuto.cachedLastDay == today) return;            // already logged today
-  if (++g_streakAuto.pagesToday < STREAK_PAGES_THRESHOLD) return;
+  uint32_t now = rtcSecondsNow();
+
+  // Nothing the pure logic decides can change faster than the refresh
+  // interval, so don't go back to NVS sooner than that. `now >= lastTouchSec`
+  // guards a backwards RTC: if the counter reset, fall through and let
+  // applyStreakLog re-anchor.
+  if (g_streakAuto.touched && now >= g_streakAuto.lastTouchSec &&
+      (now - g_streakAuto.lastTouchSec) < STREAK_REFRESH_SECS) {
+    return;
+  }
 
   ReadingStreakFile s;
   if (!readStreakBlob(s)) return;
 
-  StreakLogResult r = applyStreakLog(s, today);
+  g_streakAuto.lastTouchSec = now;
+  g_streakAuto.touched      = true;
+
+  StreakLogResult r = applyStreakLog(s, now);
   if (!r.changed) return;
 
+  // A bare lastReadSec refresh is worth a flash write only once per interval;
+  // a logged day, or a backwards-RTC re-anchor, always writes through.
+  const bool refreshDue = (r.next.lastReadSec < s.lastReadSec) ||
+                          (r.next.lastReadSec - s.lastReadSec) >= STREAK_REFRESH_SECS;
+  if (!r.logged && !refreshDue) return;
+
   writeStreakBlob(r.next);
-  g_streakAuto.cachedLastDay = today;
-  g_streakAuto.pagesToday    = 0;
+  if (!r.logged) return;
 
   char msg[48];
   snprintf(msg, sizeof(msg), D_TOAST_STREAK_DAY_FMT,
@@ -202,16 +248,16 @@ StatisticsSnapshot snapshot() {
     s.currentStreak     = str.currentStreak;
     s.longestStreak     = str.longestStreak;
     s.totalSessions     = str.totalSessions;
-    s.lastLoggedDay     = str.lastLoggedDay;
-    s.bitmapHead        = str.bitmapHead;
+    s.lastLogSec        = str.lastLogSec;
+    s.dayIndex          = str.dayIndex;
     s.bitmap            = str.bitmap;
   } else {
     s.firstStreakRtcSec = 0;
     s.currentStreak     = 0;
     s.longestStreak     = 0;
     s.totalSessions     = 0;
-    s.lastLoggedDay     = STREAK_DAY_UNSET;
-    s.bitmapHead        = 0;
+    s.lastLogSec        = STREAK_SEC_UNSET;
+    s.dayIndex          = 0;
     s.bitmap            = 0;
   }
   return s;

--- a/Pala_One_2_1/src/storage/statistics.h
+++ b/Pala_One_2_1/src/storage/statistics.h
@@ -15,11 +15,13 @@
 //       reloads from NVS into the RTC counters.
 //
 //    2. Reading streak (currentStreak, longestStreak, totalSessions,
-//       lastLoggedDay, bitmap). Persisted straight to NVS — log events
-//       are at most once per real day, so flash wear is a non-issue.
+//       lastLogSec, lastReadSec, dayIndex, bitmap). Persisted straight to
+//       NVS. A logged day happens at most once per rolling day; the
+//       lastReadSec refresh that keeps the window open is rate-limited to
+//       one write per STREAK_REFRESH_SECS, so flash wear stays a non-issue.
 //       The shape is `ReadingStreakFile` from src/pure/streak_log.h;
-//       the log-advance rules live in src/pure/streak_log.cpp and are
-//       host-tested.
+//       the window + log-advance rules live in src/pure/streak_log.cpp and
+//       are host-tested.
 //
 //  Both feed StatisticsScreen (src/ui/screens/statistics_screen) through
 //  one read-only snapshot accessor — the screen never touches state
@@ -37,9 +39,9 @@ struct StatisticsSnapshot {
   uint32_t currentStreak;
   uint32_t longestStreak;
   uint32_t totalSessions;
-  uint32_t lastLoggedDay;      // STREAK_DAY_UNSET if never logged
-  uint32_t bitmapHead;
-  uint32_t bitmap;             // bit i = "logged on day (bitmapHead - i)"
+  uint32_t lastLogSec;         // STREAK_SEC_UNSET if never logged
+  uint32_t dayIndex;           // rolling day ordinal; also the bitmap head
+  uint32_t bitmap;             // bit i = "read on day (dayIndex - i)"
 };
 
 namespace Statistics {
@@ -50,8 +52,10 @@ namespace Statistics {
 void loadOnBoot();
 
 // Page-turn hook — bumps the lifetime page counter and, after enough
-// page turns on a new day, advances the streak via applyStreakLog
-// from src/pure/streak_log.cpp. Toasts "Reading streak: day N" on a
+// page turns, offers the session to applyStreakLog from
+// src/pure/streak_log.cpp, which decides whether it opens a new streak
+// day, merely keeps the current one alive, or lands after a lapse.
+// Toasts "Reading streak: day N" on a
 // successful log. Call from advancePage() / retreatPage() in
 // src/ui/reader.cpp; bookmark-add doesn't go through those, so it
 // correctly stays uncounted.
@@ -64,7 +68,7 @@ void bumpButtons(uint32_t delta);
 
 // Force a flush of RTC-RAM lifetime counters to NVS. Called from
 // Sleep::enter so any in-flight deltas land before power-down. The
-// streak portion of the state is already in NVS (log events write
+// streak portion of the state is already in NVS (logged days write
 // straight through), so this only deals with pagesRead /
 // buttonPresses / firstStatsRtcSec.
 void flushToNvs();

--- a/Pala_One_2_1/src/ui/screens/statistics_screen.cpp
+++ b/Pala_One_2_1/src/ui/screens/statistics_screen.cpp
@@ -2,7 +2,7 @@
 
 #include "src/config.h"               // MARGIN_X, SCREEN_W, STATUS_H
 #include "src/hal/display.h"
-#include "src/pure/streak_log.h"      // STREAK_DAY_UNSET
+#include "src/pure/streak_log.h"      // ReadingStreakFile field semantics
 #include "src/storage/statistics.h"
 #include "src/ui/font.h"
 #include "src/ui/screens/library_screen.h"
@@ -50,9 +50,12 @@ void StatisticsScreen::draw() {
   u8g2.setCursor(MARGIN_X, y);
   u8g2.print(buf);
 
-  // Bottom row: 30-day bitmap. Each cell = 1 day. Right-most cell = today
-  // (bit 0). A filled rect means "logged that day"; an outlined rect means
-  // "not logged". Sits in the bottom strip above the statusbar reserve.
+  // Bottom row: 30-day bitmap. Each cell = 1 streak day (a rolling day, not a
+  // calendar one — see src/pure/streak_log.h). Right-most cell = the most
+  // recent logged day (bit 0). A filled rect means "read that day"; an
+  // outlined rect means "not read". A lapse advances the head by the whole
+  // gap, so missed days show up as blanks. Sits in the bottom strip above the
+  // statusbar reserve.
   static const int CELLS = 30;
   const int cellW = 6;
   const int cellH = 6;

--- a/test/README.md
+++ b/test/README.md
@@ -83,6 +83,7 @@ test/build/host_tests                 # Linux / macOS / MinGW
 | [`test_list_codec.cpp`](test_list_codec.cpp) | todo-list byte-blob encode/decode |
 | [`test_bookmarks_store.cpp`](test_bookmarks_store.cpp) | `loadBookmarks` / `saveBookmarks` against `MapKvStore` |
 | [`test_list_store.cpp`](test_list_store.cpp) | `loadList` / `saveList` against `MapKvStore` |
+| [`test_streak_log.cpp`](test_streak_log.cpp) | reading-streak rolling window, bitmap, v1 → v2 migration |
 
 ## Adding a new test
 

--- a/test/test_streak_log.cpp
+++ b/test/test_streak_log.cpp
@@ -1,102 +1,329 @@
 // Tests for src/pure/streak_log.cpp.
 //
 // applyStreakLog is the pure half of the reading-streak feature — given a
-// `ReadingStreakFile` (the on-disk wire format) and `today` (a day index),
-// it computes the next state. The bitmap-shift + continuation rules need
-// to match the in-app logic byte for byte so manual taps and the
-// firmware's auto-log produce identical numbers; these tests pin that.
+// `ReadingStreakFile` (the on-disk wire format) and the current monotonic RTC
+// second, it computes the next state. Schema v2 replaced v1's fixed 24 h
+// buckets with a rolling window, because the v1 buckets were anchored to an
+// arbitrary time of day and broke streaks for anyone who didn't read at the
+// same hour every day.
+//
+// The cases below pin both halves of that: the streak must survive ordinary
+// time-of-day jitter, and it must still refuse to count two sittings on one
+// evening as two days.
 
 #include "test_framework.h"
 #include "pure/streak_log.h"
+
+static const uint32_t H    = 3600u;      // one hour in seconds
+static const uint32_t BASE = 100000u;    // arbitrary non-zero RTC reading
 
 static ReadingStreakFile freshState() {
   ReadingStreakFile s{};
   s.version       = STREAK_SCHEMA;
   s.firstRtcSec   = 0;
-  s.lastLoggedDay = STREAK_DAY_UNSET;
+  s.lastLogSec    = STREAK_SEC_UNSET;
+  s.lastReadSec   = 0;
+  s.dayIndex      = 0;
   s.currentStreak = 0;
   s.longestStreak = 0;
   s.totalSessions = 0;
-  s.bitmapHead    = 0;
   s.bitmap        = 0;
   return s;
 }
 
+// ---------------------------------------------------------------------------
+//  Wire format
+// ---------------------------------------------------------------------------
+
+TEST_CASE("streak schema versions have distinct blob sizes") {
+  // statistics.cpp tells v1 and v2 blobs apart by their stored length before
+  // it trusts the version word, so these must never collide.
+  CHECK_EQ(sizeof(ReadingStreakFile),   (size_t)36);
+  CHECK_EQ(sizeof(ReadingStreakFileV1), (size_t)32);
+  CHECK_EQ(STREAK_SCHEMA, 2u);
+}
+
+// ---------------------------------------------------------------------------
+//  Basic advance
+// ---------------------------------------------------------------------------
+
 TEST_CASE("applyStreakLog starts streak at 1 on first ever log") {
   ReadingStreakFile s = freshState();
-  StreakLogResult r = applyStreakLog(s, 10);
+  StreakLogResult r = applyStreakLog(s, BASE);
   REQUIRE(r.changed);
+  CHECK(r.logged);
   CHECK_EQ(r.next.currentStreak, 1u);
   CHECK_EQ(r.next.longestStreak, 1u);
   CHECK_EQ(r.next.totalSessions, 1u);
-  CHECK_EQ(r.next.lastLoggedDay, 10u);
-  CHECK_EQ(r.next.bitmapHead, 10u);
+  CHECK_EQ(r.next.lastLogSec,  BASE);
+  CHECK_EQ(r.next.lastReadSec, BASE);
+  CHECK_EQ(r.next.dayIndex, 0u);
   CHECK_EQ(r.next.bitmap & 1u, 1u);
 }
 
 TEST_CASE("applyStreakLog continues streak on consecutive days") {
   ReadingStreakFile s = freshState();
-  s = applyStreakLog(s, 10).next;
-  s = applyStreakLog(s, 11).next;
-  s = applyStreakLog(s, 12).next;
+  s = applyStreakLog(s, BASE).next;
+  s = applyStreakLog(s, BASE + 24 * H).next;
+  s = applyStreakLog(s, BASE + 48 * H).next;
   CHECK_EQ(s.currentStreak, 3u);
   CHECK_EQ(s.longestStreak, 3u);
   CHECK_EQ(s.totalSessions, 3u);
-  CHECK_EQ(s.lastLoggedDay, 12u);
-}
-
-TEST_CASE("applyStreakLog resets streak after a gap but keeps longest") {
-  ReadingStreakFile s = freshState();
-  s = applyStreakLog(s, 10).next;
-  s = applyStreakLog(s, 11).next;
-  s = applyStreakLog(s, 12).next;   // streak 3, longest 3
-  s = applyStreakLog(s, 20).next;   // gap of 7 days -> reset to 1
-  CHECK_EQ(s.currentStreak, 1u);
-  CHECK_EQ(s.longestStreak, 3u);
-  CHECK_EQ(s.totalSessions, 4u);
-}
-
-TEST_CASE("applyStreakLog is a no-op when logging the same day twice") {
-  ReadingStreakFile s = freshState();
-  s = applyStreakLog(s, 10).next;
-  StreakLogResult r = applyStreakLog(s, 10);
-  CHECK(!r.changed);
-  CHECK_EQ(r.next.currentStreak, 1u);
-  CHECK_EQ(r.next.totalSessions, 1u);
-}
-
-TEST_CASE("applyStreakLog bitmap tracks the last 32 days") {
-  ReadingStreakFile s = freshState();
-  s = applyStreakLog(s, 100).next;
-  s = applyStreakLog(s, 101).next;  // bit 1
-  s = applyStreakLog(s, 103).next;  // bit 3 (gap of 1 day stays in window)
-  // Bitmap: today (bit 0) + bit 2 (day 101) + bit 3 (day 100... wait)
-  // After head=103: shifted by (103-100)=3 from prior head 100.
-  // bitmap before shift: 0b0110 (bits 0,1,2 from 100/101/102? actually
-  // we set bit0 each log). Let's just check the shape:
-  //   day 100 logged -> head=100, bitmap = ...0001
-  //   day 101 logged -> shift by 1 -> ...0010 then |1 -> ...0011, head=101
-  //   day 103 logged -> shift by 2 -> ...1100 then |1 -> ...1101, head=103
-  CHECK_EQ(s.bitmapHead, 103u);
-  CHECK_EQ(s.bitmap, 0b1101u);
-}
-
-TEST_CASE("applyStreakLog clears bitmap when shift >= 32") {
-  ReadingStreakFile s = freshState();
-  s = applyStreakLog(s, 100).next;
-  s = applyStreakLog(s, 101).next;
-  // Jump > 32 days. The bitmap shift of >=32 in a uint32_t is undefined in
-  // C++ if done with a raw `<<`; applyStreakLog clamps to 0 explicitly so
-  // the result is deterministic.
-  s = applyStreakLog(s, 200).next;
-  CHECK_EQ(s.bitmapHead, 200u);
-  CHECK_EQ(s.bitmap, 1u);  // only today's bit
+  CHECK_EQ(s.dayIndex, 2u);
 }
 
 TEST_CASE("applyStreakLog preserves firstRtcSec and version") {
   ReadingStreakFile s = freshState();
   s.firstRtcSec = 0x12345678;
-  StreakLogResult r = applyStreakLog(s, 5);
+  StreakLogResult r = applyStreakLog(s, BASE);
   CHECK_EQ(r.next.firstRtcSec, 0x12345678u);
   CHECK_EQ(r.next.version,     STREAK_SCHEMA);
+}
+
+TEST_CASE("applyStreakLog does not mutate its input and is deterministic") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+
+  const ReadingStreakFile before = s;
+  StreakLogResult a = applyStreakLog(s, BASE + 25 * H);
+  StreakLogResult b = applyStreakLog(s, BASE + 25 * H);
+
+  CHECK_EQ(s.currentStreak, before.currentStreak);
+  CHECK_EQ(s.lastLogSec,    before.lastLogSec);
+  CHECK_EQ(a.next.currentStreak, b.next.currentStreak);
+  CHECK_EQ(a.next.lastLogSec,    b.next.lastLogSec);
+  CHECK_EQ(a.next.bitmap,        b.next.bitmap);
+}
+
+// ---------------------------------------------------------------------------
+//  The reported problem: reading at a different hour each night
+// ---------------------------------------------------------------------------
+
+TEST_CASE("streak survives night-to-night jitter that v1 broke") {
+  // Mon 22:00, a nightcap at Tue 01:00, then Tue 23:00, Wed 19:00, Thu 23:00.
+  // Under v1's fixed buckets at least one of these fell on the wrong side of a
+  // boundary. Under v2 it is one unbroken five-day streak.
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE +  0 * H).next;   // Mon 22:00  -> day 1
+  s = applyStreakLog(s, BASE +  3 * H).next;   // Tue 01:00  -> same day
+  s = applyStreakLog(s, BASE + 25 * H).next;   // Tue 23:00  -> day 2
+  s = applyStreakLog(s, BASE + 45 * H).next;   // Wed 19:00  -> day 3
+  s = applyStreakLog(s, BASE + 73 * H).next;   // Thu 23:00  -> day 4
+  CHECK_EQ(s.currentStreak, 4u);
+  CHECK_EQ(s.totalSessions, 4u);
+}
+
+TEST_CASE("a 28 hour gap continues the streak") {
+  // The literal "24 h + 2 h grace" reading of the suggestion would break here.
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+  StreakLogResult r = applyStreakLog(s, BASE + 28 * H);
+  CHECK(r.logged);
+  CHECK_EQ(r.next.currentStreak, 2u);
+}
+
+TEST_CASE("a sitting that logs nothing still holds the window open") {
+  // Read Monday night, a short Tuesday sitting that is too soon to open a new
+  // day, then Wednesday evening. Measured from the last *logged* day that is
+  // 46 h and would lapse; measured from the last *read* it is 34 h and holds.
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;                    // day 1
+  StreakLogResult mid = applyStreakLog(s, BASE + 12 * H);
+  CHECK(mid.changed);            // lastReadSec moved
+  CHECK(!mid.logged);            // but no new day
+  s = mid.next;
+
+  StreakLogResult r = applyStreakLog(s, BASE + 46 * H);
+  CHECK(r.logged);
+  CHECK_EQ(r.next.currentStreak, 2u);
+}
+
+// ---------------------------------------------------------------------------
+//  Same reading day
+// ---------------------------------------------------------------------------
+
+TEST_CASE("reading twice in one evening counts once") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+  s = applyStreakLog(s, BASE + 6 * H).next;
+  s = applyStreakLog(s, BASE + 10 * H).next;
+  CHECK_EQ(s.currentStreak, 1u);
+  CHECK_EQ(s.totalSessions, 1u);
+  CHECK_EQ(s.dayIndex, 0u);
+  CHECK_EQ(s.lastReadSec, BASE + 10 * H);   // window still being pushed out
+}
+
+TEST_CASE("same-day re-read at the identical second is a no-op") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+  StreakLogResult r = applyStreakLog(s, BASE);
+  CHECK(!r.changed);
+  CHECK(!r.logged);
+  CHECK_EQ(r.next.currentStreak, 1u);
+  CHECK_EQ(r.next.totalSessions, 1u);
+}
+
+TEST_CASE("the same-day floor is exactly STREAK_SAME_DAY_SECS") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+
+  StreakLogResult just_under = applyStreakLog(s, BASE + STREAK_SAME_DAY_SECS - 1);
+  CHECK(!just_under.logged);
+
+  StreakLogResult exact = applyStreakLog(s, BASE + STREAK_SAME_DAY_SECS);
+  CHECK(exact.logged);
+  CHECK_EQ(exact.next.currentStreak, 2u);
+}
+
+// ---------------------------------------------------------------------------
+//  Lapsing
+// ---------------------------------------------------------------------------
+
+TEST_CASE("applyStreakLog resets streak after a lapse but keeps longest") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+  s = applyStreakLog(s, BASE + 24 * H).next;
+  s = applyStreakLog(s, BASE + 48 * H).next;   // streak 3, longest 3
+  s = applyStreakLog(s, BASE + 48 * H + 7 * 24 * H).next;
+  CHECK_EQ(s.currentStreak, 1u);
+  CHECK_EQ(s.longestStreak, 3u);
+  CHECK_EQ(s.totalSessions, 4u);
+}
+
+TEST_CASE("the break ceiling is exactly STREAK_WINDOW_SECS") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+
+  StreakLogResult exact = applyStreakLog(s, BASE + STREAK_WINDOW_SECS);
+  CHECK(exact.logged);
+  CHECK_EQ(exact.next.currentStreak, 2u);
+
+  StreakLogResult over = applyStreakLog(s, BASE + STREAK_WINDOW_SECS + 1);
+  CHECK(over.logged);
+  CHECK_EQ(over.next.currentStreak, 1u);
+}
+
+// ---------------------------------------------------------------------------
+//  Bitmap
+// ---------------------------------------------------------------------------
+
+TEST_CASE("bitmap records consecutive days as adjacent bits") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;             // dayIndex 0, bitmap ...0001
+  s = applyStreakLog(s, BASE + 24 * H).next;    // dayIndex 1, bitmap ...0011
+  s = applyStreakLog(s, BASE + 48 * H).next;    // dayIndex 2, bitmap ...0111
+  CHECK_EQ(s.dayIndex, 2u);
+  CHECK_EQ(s.bitmap, 0b111u);
+}
+
+TEST_CASE("a lapse leaves the missed days blank in the bitmap") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;             // dayIndex 0, bitmap ...0001
+  s = applyStreakLog(s, BASE + 24 * H).next;    // dayIndex 1, bitmap ...0011
+
+  // Three days later: the head jumps by 3, so two blank cells sit between the
+  // old run and today.
+  s = applyStreakLog(s, BASE + 24 * H + 72 * H).next;
+  CHECK_EQ(s.dayIndex, 4u);
+  CHECK_EQ(s.bitmap, 0b11001u);
+}
+
+TEST_CASE("lapse length rounds to the nearest whole day, floored at two") {
+  // 37 h is one and a half days, which rounds to 2 — the shortest a lapse can
+  // possibly be, since anything up to 36 h would have continued the streak.
+  ReadingStreakFile a = freshState();
+  a = applyStreakLog(a, BASE).next;
+  a = applyStreakLog(a, BASE + 37 * H).next;
+  CHECK_EQ(a.dayIndex, 2u);
+  CHECK_EQ(a.bitmap, 0b101u);
+
+  // 60 h rounds up to 3.
+  ReadingStreakFile b = freshState();
+  b = applyStreakLog(b, BASE).next;
+  b = applyStreakLog(b, BASE + 60 * H).next;
+  CHECK_EQ(b.dayIndex, 3u);
+  CHECK_EQ(b.bitmap, 0b1001u);
+}
+
+TEST_CASE("bitmap clears when the lapse is 32 days or more") {
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+  s = applyStreakLog(s, BASE + 24 * H).next;
+  // A shift of >= 32 on a uint32_t is undefined behaviour with a raw `<<`;
+  // applyStreakLog clamps to 0 so the result is deterministic.
+  s = applyStreakLog(s, BASE + 24 * H + 40 * 24 * H).next;
+  CHECK_EQ(s.dayIndex, 41u);
+  CHECK_EQ(s.bitmap, 1u);          // only today's bit
+  CHECK_EQ(s.currentStreak, 1u);
+}
+
+// ---------------------------------------------------------------------------
+//  Clock hazards
+// ---------------------------------------------------------------------------
+
+TEST_CASE("a backwards RTC re-anchors without breaking or advancing") {
+  // The RTC counter restarts at zero on a hard power cycle. Elapsed time is
+  // then unknowable, so the streak is left alone rather than reset. Under v1
+  // this case silently froze the streak forever.
+  ReadingStreakFile s = freshState();
+  s = applyStreakLog(s, BASE).next;
+  s = applyStreakLog(s, BASE + 24 * H).next;   // streak 2
+
+  StreakLogResult r = applyStreakLog(s, 5);    // counter went back to ~0
+  CHECK(r.changed);
+  CHECK(!r.logged);
+  CHECK_EQ(r.next.currentStreak, 2u);
+  CHECK_EQ(r.next.totalSessions, 2u);
+  CHECK_EQ(r.next.dayIndex,      1u);
+  CHECK_EQ(r.next.lastLogSec,    5u);
+  CHECK_EQ(r.next.lastReadSec,   5u);
+
+  // And the streak keeps going from the new anchor.
+  StreakLogResult n = applyStreakLog(r.next, 5 + 24 * H);
+  CHECK(n.logged);
+  CHECK_EQ(n.next.currentStreak, 3u);
+}
+
+// ---------------------------------------------------------------------------
+//  v1 -> v2 migration
+// ---------------------------------------------------------------------------
+
+TEST_CASE("migrateStreakV1 carries the streak across and re-anchors the clock") {
+  ReadingStreakFileV1 v1{};
+  v1.version       = 1;
+  v1.firstRtcSec   = 500;
+  v1.lastLoggedDay = 42;
+  v1.currentStreak = 7;
+  v1.longestStreak = 9;
+  v1.totalSessions = 30;
+  v1.bitmapHead    = 42;
+  v1.bitmap        = 0b1011u;
+
+  ReadingStreakFile s = migrateStreakV1(v1, BASE);
+  CHECK_EQ(s.version,       STREAK_SCHEMA);
+  CHECK_EQ(s.firstRtcSec,   500u);
+  CHECK_EQ(s.currentStreak, 7u);
+  CHECK_EQ(s.longestStreak, 9u);
+  CHECK_EQ(s.totalSessions, 30u);
+  CHECK_EQ(s.dayIndex,      42u);
+  CHECK_EQ(s.bitmap,        0b1011u);
+  CHECK_EQ(s.lastLogSec,    BASE);
+  CHECK_EQ(s.lastReadSec,   BASE);
+}
+
+TEST_CASE("a migrated reader continues rather than restarting") {
+  ReadingStreakFileV1 v1{};
+  v1.version       = 1;
+  v1.currentStreak = 7;
+  v1.longestStreak = 9;
+  v1.totalSessions = 30;
+  v1.bitmapHead    = 42;
+  v1.bitmap        = 0b1011u;
+
+  ReadingStreakFile s = migrateStreakV1(v1, BASE);
+  StreakLogResult r = applyStreakLog(s, BASE + 30 * H);
+  CHECK(r.logged);
+  CHECK_EQ(r.next.currentStreak, 8u);
+  CHECK_EQ(r.next.longestStreak, 9u);
+  CHECK_EQ(r.next.dayIndex,      43u);
 }


### PR DESCRIPTION
The reading streak measured a day as (rtcSeconds() - firstRtcSec) / 86400: fixed 24-hour buckets anchored to whenever the streak first initialised. That anchor is an arbitrary time of day, so the bucket boundary usually landed inside the reader's normal reading window. Reading an hour later than yesterday skipped a bucket and broke the streak, and two sittings on one evening could straddle a boundary and count as two days.

Schema v2 drops the anchor and tracks two timestamps instead:

  lastLogSec   when the streak last advanced. Nothing advances again
               until STREAK_SAME_DAY_SECS (18 h) has passed, so a second
               sitting the same evening is a no-op rather than a free day.

  lastReadSec  the most recent qualifying session, logged or not. The
               streak lapses only when this is older than
               STREAK_WINDOW_SECS (36 h), so picking the book back up at
               any point inside the window keeps it alive.

Without a wall clock no threshold is exact - a 30 h gap could be two late nights running or one skipped day, and the device cannot tell - so the ceiling deliberately errs towards keeping a streak the reader earned rather than breaking one they did not.

Two related problems fixed on the way past:

- A hard power cycle restarts the RTC counter at zero. The old `if (now < cachedFirstRtcSec) return;` then bailed out on every subsequent page turn and the streak never advanced again. v2 detects the backwards jump, re-anchors both timestamps and leaves the streak exactly as it was: not advanced, not broken.

- A lapse now advances the bitmap head by the whole gap (elapsed time rounded to whole days, floored at two), so missed days show as blank cells in the 30-day grid instead of the run closing up.

v1 blobs are 32 bytes and v2 blobs are 36, so readStreakBlob dispatches on the stored length before trusting the version word and migrates through the pure migrateStreakV1. Current streak, longest streak, total sessions and the grid all carry across; both anchors move to the moment of the upgrade, because the old day index is not comparable to a rolling window. Nobody loses a streak by updating.

v2 also has something to persist on sessions that do not advance the streak, which v1 did not. Two gates keep that off the flash: the existing five-page threshold before NVS is touched at all, then a 15-minute floor before a bare lastReadSec refresh is worth a write. A logged day always writes through immediately.

test_streak_log.cpp is rewritten against the new rules: 20 cases covering the reported jitter pattern, the same-day floor, the lapse ceiling, bitmap gap accounting, the backwards RTC and the v1 migration. Boundary tests assert against the constants rather than hard-coded hours, so retuning either threshold does not invalidate them.

Reported on Discord: streaks broke unless you read at roughly the same hour each day, and reading twice in one day did not behave either.